### PR TITLE
#5 Create Base Layout and Navigation

### DIFF
--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -1,0 +1,7 @@
+export default function ApplicationsPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">Applications</h1>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,8 @@ import { Inter } from 'next/font/google';
 
 import { cn } from '@/lib/utils';
 
-import { ThemeProvider } from '@/components/providers/theme-provider';
+import { MainLayout } from '@/components/layouts/main-layout';
+import { Providers } from '@/components/providers';
 
 import './globals.css';
 
@@ -20,14 +21,9 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn('w-full font-sans antialiased', inter.variable)}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          {children}
-        </ThemeProvider>
+        <Providers>
+          <MainLayout>{children}</MainLayout>
+        </Providers>
       </body>
     </html>
   );

--- a/app/positions/page.tsx
+++ b/app/positions/page.tsx
@@ -1,0 +1,7 @@
+export default function PositionsPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">Positions</h1>
+    </div>
+  );
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,7 @@
+export default function UsersPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
+    </div>
+  );
+}

--- a/components/layouts/main-layout.tsx
+++ b/components/layouts/main-layout.tsx
@@ -1,0 +1,16 @@
+import { Sidebar } from '@/components/layouts/sidebar';
+
+interface MainLayoutProps {
+  children: React.ReactNode;
+}
+
+export function MainLayout({ children }: MainLayoutProps) {
+  return (
+    <div className="flex h-screen w-full overflow-hidden">
+      <Sidebar />
+      <main className="flex flex-1 flex-col overflow-y-auto">
+        <div className="flex-1 p-6">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/components/layouts/main-layout.tsx
+++ b/components/layouts/main-layout.tsx
@@ -1,3 +1,4 @@
+import { MobileNav } from '@/components/layouts/mobile-nav';
 import { Sidebar } from '@/components/layouts/sidebar';
 
 interface MainLayoutProps {
@@ -8,9 +9,12 @@ export function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="flex h-screen w-full overflow-hidden">
       <Sidebar />
-      <main className="flex flex-1 flex-col overflow-y-auto">
-        <div className="flex-1 p-6">{children}</div>
-      </main>
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <MobileNav />
+        <main className="flex flex-1 flex-col overflow-y-auto">
+          <div className="flex-1 p-6">{children}</div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -46,7 +46,7 @@ export function MobileNav() {
             <Menu className="size-5" />
           </Button>
           <SheetContent side="left">
-            <SheetHeader className="border-sidebar-border border-b pb-4">
+            <SheetHeader className="border-sidebar-border flex h-14 items-center border-b px-4">
               <SheetTitle>
                 <Link
                   href="/"

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -9,12 +9,7 @@ import { BriefcaseBusiness, FileText, Menu, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 import { Button } from '@/components/ui/button';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 
 const navItems = [
   { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
@@ -46,8 +41,8 @@ export function MobileNav() {
             <Menu className="size-5" />
           </Button>
           <SheetContent side="left">
-            <SheetHeader className="border-sidebar-border flex h-14 items-center border-b px-4">
-              <SheetTitle>
+            <div className="border-sidebar-border flex h-14 items-center border-b px-4">
+              <SheetTitle asChild>
                 <Link
                   href="/"
                   className="flex items-center gap-2"
@@ -63,7 +58,7 @@ export function MobileNav() {
                   </span>
                 </Link>
               </SheetTitle>
-            </SheetHeader>
+            </div>
 
             <nav className="flex flex-col gap-1 p-2">
               {navItems.map(({ href, label, icon: Icon }) => {

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+
+import { BriefcaseBusiness, FileText, Menu, Users } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+
+const navItems = [
+  { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
+  { href: '/applications', label: 'Applications', icon: FileText },
+  { href: '/users', label: 'Users', icon: Users },
+];
+
+export function MobileNav() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="bg-sidebar border-sidebar-border flex h-14 items-center border-b px-4 md:hidden">
+      <Link href="/" className="flex items-center gap-2">
+        <div className="bg-primary flex size-8 items-center justify-center rounded-lg shadow-sm">
+          <span className="text-primary-foreground text-sm font-bold">A</span>
+        </div>
+        <span className="text-sm font-semibold tracking-tight">Aplio</span>
+      </Link>
+
+      <div className="ml-auto">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Open menu"
+            onClick={() => setOpen(true)}
+          >
+            <Menu className="size-5" />
+          </Button>
+          <SheetContent side="left">
+            <SheetHeader className="border-sidebar-border border-b pb-4">
+              <SheetTitle>
+                <Link
+                  href="/"
+                  className="flex items-center gap-2"
+                  onClick={() => setOpen(false)}
+                >
+                  <div className="bg-primary flex size-8 items-center justify-center rounded-lg shadow-sm">
+                    <span className="text-primary-foreground text-sm font-bold">
+                      A
+                    </span>
+                  </div>
+                  <span className="text-sm font-semibold tracking-tight">
+                    Aplio
+                  </span>
+                </Link>
+              </SheetTitle>
+            </SheetHeader>
+
+            <nav className="flex flex-col gap-1 p-2">
+              {navItems.map(({ href, label, icon: Icon }) => {
+                const isActive = pathname.startsWith(href);
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    onClick={() => setOpen(false)}
+                    className={cn(
+                      'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                      isActive &&
+                        'bg-sidebar-accent text-sidebar-accent-foreground',
+                    )}
+                  >
+                    <Icon className="size-4 shrink-0" />
+                    {label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </header>
+  );
+}

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { BriefcaseBusiness, FileText, Users } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const navItems = [
+  { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
+  { href: '/applications', label: 'Applications', icon: FileText },
+  { href: '/users', label: 'Users', icon: Users },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="bg-sidebar border-sidebar-border flex h-full w-56 shrink-0 flex-col border-r">
+      <div className="border-sidebar-border flex h-14 items-center border-b px-4">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="bg-primary flex size-8 items-center justify-center rounded-lg shadow-sm">
+            <span className="text-primary-foreground text-sm font-bold">A</span>
+          </div>
+          <span className="text-sm font-semibold tracking-tight">Aplio</span>
+        </Link>
+      </div>
+
+      <nav className="flex flex-col gap-1 p-2">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const isActive = pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                isActive && 'bg-sidebar-accent text-sidebar-accent-foreground',
+              )}
+            >
+              <Icon className="size-4 shrink-0" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -17,7 +17,7 @@ export function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="bg-sidebar border-sidebar-border flex h-full w-56 shrink-0 flex-col border-r">
+    <aside className="bg-sidebar border-sidebar-border hidden h-full w-56 shrink-0 flex-col border-r md:flex">
       <div className="border-sidebar-border flex h-14 items-center border-b px-4">
         <Link href="/" className="flex items-center gap-2">
           <div className="bg-primary flex size-8 items-center justify-center rounded-lg shadow-sm">

--- a/components/providers/index.tsx
+++ b/components/providers/index.tsx
@@ -1,0 +1,16 @@
+import { ThemeProvider } from '@/components/providers/theme-provider';
+
+import { QueryProvider } from './query-provider';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <QueryProvider>{children}</QueryProvider>
+    </ThemeProvider>
+  );
+}

--- a/components/providers/query-provider.tsx
+++ b/components/providers/query-provider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useState } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { staleTime: 60 * 1000, refetchOnWindowFocus: false },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import * as React from 'react';
-
 import dynamic from 'next/dynamic';
+import * as React from 'react';
 
 const NextThemesProvider = dynamic(
   () => import('next-themes').then((e) => e.ThemeProvider),

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import * as React from 'react';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Sheet({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = 'left',
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  side?: 'left' | 'right' | 'top' | 'bottom';
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          'bg-background fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out',
+          side === 'left' &&
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+          side === 'right' &&
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+          side === 'top' &&
+            'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
+          side === 'bottom' &&
+            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          data-slot="sheet-close"
+          className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+        >
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};


### PR DESCRIPTION
## Summary
- Added `QueryProvider` (React Query) and `Providers` wrapper composing `ThemeProvider` + `QueryProvider`
- Built `Sidebar` with nav links for Positions, Applications, and Users with active state via `usePathname`
- Built `MainLayout` composing sidebar + scrollable content area
- Wired `Providers` and `MainLayout` into `app/layout.tsx`
- Added placeholder pages for `/positions`, `/applications`, `/users`

## Test plan
- [x] `npm run dev` starts without errors
- [x] Sidebar renders with all three nav links
- [ ] Active link highlights correctly on each route
- [ ] Theme toggle still works

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)