### PR TITLE
#27 Fix Always-Visible Scrollbar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -176,10 +176,11 @@
   }
   body {
     @apply bg-background text-foreground;
-    overflow-y: scroll;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
   }
   body[data-scroll-locked] {
-    overflow-y: scroll !important;
+    overflow-y: hidden !important;
     padding-right: 0 !important;
     margin-right: 0 !important;
   }

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import * as React from 'react';
-
 import dynamic from 'next/dynamic';
+import * as React from 'react';
 
 const NextThemesProvider = dynamic(
   () => import('next-themes').then((e) => e.ThemeProvider),


### PR DESCRIPTION
## Summary
- Replaced `overflow-y: scroll` (always shows scrollbar) with `overflow-y: auto` + `scrollbar-gutter: stable`
- `scrollbar-gutter: stable` reserves the scrollbar gutter space without forcing it visible — prevents layout shift when dialogs open, without the permanent scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)