### PR TITLE
#23 Document Issue Label Conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,24 @@
 - Never use Linear for this project
 - When starting work on a ticket, assign it first: `gh issue edit XXX --add-assignee "@me"`
 
+#### Issue Labels
+
+Three labels track the state of Claude-handled issues. Update them with `gh issue edit XXX --repo SGAOperations/aplio`:
+
+- `claude` — add when starting work on any ticket (signals Claude is handling it)
+- `in progress` — add when a worktree/branch is created and implementation begins
+- `pr opened` — add when a PR is opened; remove `in progress` at the same time
+
+Example workflow:
+
+```bash
+# Starting work
+gh issue edit 42 --repo SGAOperations/aplio --add-label "claude,in progress"
+
+# Opening a PR
+gh issue edit 42 --repo SGAOperations/aplio --add-label "pr opened" --remove-label "in progress"
+```
+
 ## Tech Stack
 
 - **Framework**: Next.js with App Router

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import * as React from 'react';
-
 import dynamic from 'next/dynamic';
+import * as React from 'react';
 
 const NextThemesProvider = dynamic(
   () => import('next-themes').then((e) => e.ThemeProvider),


### PR DESCRIPTION
## Summary
- Added Issue Labels subsection to the Issue Tracking section in CLAUDE.md
- Documents the `claude`, `in progress`, and `pr opened` labels with example `gh issue edit` commands

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)