### PR TITLE
#31 Document Spec Workflow In CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,3 +220,10 @@ git -C <worktree-path> rebase origin/main
 ```
 
 Never assume the local branch is up to date — always fetch first.
+
+### Design Specs
+
+- Specs are brainstormed and written collaboratively as a document
+- The final spec content goes into the **GitHub Issue description** for the relevant ticket — using `gh issue edit` to update the body
+- Spec files must **never be committed to git** — not to main, not to feature branches
+- The brainstormed document is for thinking only; the GitHub Issue is the source of truth


### PR DESCRIPTION
Adds a Design Specs section to CLAUDE.md documenting that specs are written collaboratively and placed in GitHub Issue descriptions — never committed to the repo.

Closes #31