### PR TITLE
#36 Profile Page: /profile Route And ProfileQuestion Component

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from '@/components/layouts/sidebar';
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-screen w-full overflow-hidden">
+    <div className="flex h-dvh w-full overflow-hidden">
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <MobileNav />

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,0 +1,30 @@
+import { getProfileData } from '@/prisma/data/profile';
+
+import { authServer } from '@/lib/auth/server';
+import prisma from '@/lib/prisma';
+
+import { ProfileQuestion } from '@/components/features/profile-question';
+
+export default async function ProfilePage() {
+  const session = await authServer.getSession();
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { neonAuthId: session.user.id },
+  });
+  const profileData = await getProfileData(user.id);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
+      <div className="flex flex-col gap-4">
+        {profileData.map(({ question, answer }) => (
+          <ProfileQuestion
+            key={question.id}
+            question={question}
+            answer={answer}
+            userId={user.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from 'next/navigation';
+
 import { getProfileData } from '@/prisma/data/profile';
 
 import { authServer } from '@/lib/auth/server';
@@ -6,7 +8,8 @@ import prisma from '@/lib/prisma';
 import { ProfileQuestion } from '@/components/features/profile-question';
 
 export default async function ProfilePage() {
-  const session = await authServer.getSession();
+  const { data: session } = await authServer.getSession();
+  if (!session?.user) redirect('/auth/login');
   const user = await prisma.user.findUniqueOrThrow({
     where: { neonAuthId: session.user.id },
   });

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -2,26 +2,11 @@ import { getProfileData } from '@/prisma/data/profile';
 
 import { getCurrentUser } from '@/lib/auth/server';
 
-import { ProfileQuestion } from '@/components/features/profile-question';
+import { ProfileForm } from '@/components/features/profile-form';
 
 export default async function ProfilePage() {
   const user = await getCurrentUser();
   const profileData = await getProfileData(user.id);
 
-  return (
-    <div className="flex flex-col gap-6">
-      <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
-      <div className="flex flex-col gap-4">
-        {profileData.map(({ question, answer }) => (
-          <ProfileQuestion
-            key={question.id}
-            question={question}
-            answer={answer}
-            userId={user.id}
-            isEditing={false}
-          />
-        ))}
-      </div>
-    </div>
-  );
+  return <ProfileForm profileData={profileData} userId={user.id} />;
 }

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,18 +1,11 @@
-import { redirect } from 'next/navigation';
-
 import { getProfileData } from '@/prisma/data/profile';
 
-import { authServer } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth/server';
 
 import { ProfileQuestion } from '@/components/features/profile-question';
 
 export default async function ProfilePage() {
-  const { data: session } = await authServer.getSession();
-  if (!session?.user) redirect('/auth/login');
-  const user = await prisma.user.findUniqueOrThrow({
-    where: { neonAuthId: session.user.id },
-  });
+  const user = await getCurrentUser();
   const profileData = await getProfileData(user.id);
 
   return (

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -18,6 +18,7 @@ export default async function ProfilePage() {
             question={question}
             answer={answer}
             userId={user.id}
+            isEditing={false}
           />
         ))}
       </div>

--- a/components/features/profile-form.tsx
+++ b/components/features/profile-form.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
+
+import { Button } from '@/components/ui/button';
+
+import { ProfileQuestion } from '@/components/features/profile-question';
+
+interface ProfileFormProps {
+  profileData: { question: GlobalQuestion; answer: GlobalAnswer | null }[];
+  userId: string;
+}
+
+export function ProfileForm({ profileData, userId }: ProfileFormProps) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
+        <Button variant={isEditing ? 'default' : 'outline'} size="sm" onClick={() => setIsEditing(!isEditing)}>
+          {isEditing ? 'Done' : 'Edit'}
+        </Button>
+      </div>
+      <div className="flex flex-col gap-4">
+        {profileData.map(({ question, answer }) => (
+          <ProfileQuestion
+            key={question.id}
+            question={question}
+            answer={answer}
+            userId={userId}
+            isEditing={isEditing}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/features/profile-form.tsx
+++ b/components/features/profile-form.tsx
@@ -4,9 +4,8 @@ import { useState } from 'react';
 
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
 
-import { Button } from '@/components/ui/button';
-
 import { ProfileQuestion } from '@/components/features/profile-question';
+import { Button } from '@/components/ui/button';
 
 interface ProfileFormProps {
   profileData: { question: GlobalQuestion; answer: GlobalAnswer | null }[];
@@ -20,7 +19,11 @@ export function ProfileForm({ profileData, userId }: ProfileFormProps) {
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
-        <Button variant={isEditing ? 'default' : 'outline'} size="sm" onClick={() => setIsEditing(!isEditing)}>
+        <Button
+          variant={isEditing ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setIsEditing(!isEditing)}
+        >
           {isEditing ? 'Done' : 'Edit'}
         </Button>
       </div>

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -26,11 +26,16 @@ export function ProfileQuestion({
   const [currentValue, setCurrentValue] = useState<string[]>(initial);
   const [savedValue, setSavedValue] = useState<string[]>(initial);
   const savingRef = useRef(false);
+  const pendingValueRef = useRef<string[] | null>(null);
 
   async function autosave(newValue: string[]) {
-    if (savingRef.current) return;
     if (JSON.stringify(newValue) === JSON.stringify(savedValue)) return;
+    if (savingRef.current) {
+      pendingValueRef.current = newValue;
+      return;
+    }
     savingRef.current = true;
+    pendingValueRef.current = null;
     try {
       await updateGlobalAnswer(userId, question.id, newValue);
       setSavedValue(newValue);
@@ -38,15 +43,20 @@ export function ProfileQuestion({
       // silent — autosave is best-effort
     } finally {
       savingRef.current = false;
+      const pending = pendingValueRef.current;
+      if (pending !== null) {
+        pendingValueRef.current = null;
+        autosave(pending);
+      }
     }
   }
 
   const displayValue =
-    savedValue.length === 0
+    currentValue.length === 0
       ? null
       : question.type === 'multiple_choice'
-        ? savedValue.join(', ')
-        : savedValue[0];
+        ? currentValue.join(', ')
+        : currentValue[0];
 
   return (
     <div className="bg-card rounded-lg border p-4 shadow-sm">

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+import { updateGlobalAnswer } from '@/prisma/actions/profile';
+import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+interface ProfileQuestionProps {
+  question: GlobalQuestion;
+  answer: GlobalAnswer | null;
+  userId: string;
+}
+
+export function ProfileQuestion({
+  question,
+  answer,
+  userId,
+}: ProfileQuestionProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [currentValue, setCurrentValue] = useState<string[]>(
+    answer?.value ?? [],
+  );
+  const [editValue, setEditValue] = useState<string[]>(answer?.value ?? []);
+  const [isPending, startTransition] = useTransition();
+
+  function displayValue() {
+    if (currentValue.length === 0) return null;
+    if (question.type === 'multiple_choice') return currentValue.join(', ');
+    return currentValue[0];
+  }
+
+  function handleEdit() {
+    setEditValue(currentValue);
+    setIsEditing(true);
+  }
+
+  function handleCancel() {
+    setEditValue(currentValue);
+    setIsEditing(false);
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      await updateGlobalAnswer(userId, question.id, editValue);
+      setCurrentValue(editValue);
+      setIsEditing(false);
+    });
+  }
+
+  function handleShortChange(val: string) {
+    setEditValue(val ? [val] : []);
+  }
+
+  function handleSingleChoice(option: string) {
+    setEditValue([option]);
+  }
+
+  function handleMultipleChoice(option: string, checked: boolean) {
+    if (checked) {
+      setEditValue((prev) => [...prev, option]);
+    } else {
+      setEditValue((prev) => prev.filter((v) => v !== option));
+    }
+  }
+
+  const display = displayValue();
+
+  return (
+    <div className="bg-card rounded-lg border p-4 shadow-sm">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <span className="text-sm leading-snug font-medium">
+          {question.label}
+          {question.required && (
+            <span className="text-destructive ml-1">*</span>
+          )}
+        </span>
+        {!isEditing && (
+          <Button variant="outline" size="sm" onClick={handleEdit}>
+            Edit
+          </Button>
+        )}
+      </div>
+
+      {!isEditing && (
+        <p className="text-muted-foreground text-sm">
+          {display ?? <span className="italic">No answer yet</span>}
+        </p>
+      )}
+
+      {isEditing && (
+        <div className="flex flex-col gap-3">
+          {question.type === 'short_answer' && (
+            <Input
+              value={editValue[0] ?? ''}
+              onChange={(e) => handleShortChange(e.target.value)}
+              placeholder="Your answer"
+            />
+          )}
+
+          {question.type === 'long_answer' && (
+            <Textarea
+              value={editValue[0] ?? ''}
+              onChange={(e) => handleShortChange(e.target.value)}
+              placeholder="Your answer"
+              className="min-h-[100px]"
+            />
+          )}
+
+          {question.type === 'single_choice' && (
+            <div className="flex flex-col gap-2">
+              {question.options.map((option: string) => (
+                <Label
+                  key={option}
+                  className="flex cursor-pointer items-center gap-2 font-normal"
+                >
+                  <input
+                    type="radio"
+                    name={question.id}
+                    value={option}
+                    checked={editValue[0] === option}
+                    onChange={() => handleSingleChoice(option)}
+                    className="accent-primary size-4"
+                  />
+                  {option}
+                </Label>
+              ))}
+            </div>
+          )}
+
+          {question.type === 'multiple_choice' && (
+            <div className="flex flex-col gap-2">
+              {question.options.map((option: string) => (
+                <Label
+                  key={option}
+                  className="flex cursor-pointer items-center gap-2 font-normal"
+                >
+                  <input
+                    type="checkbox"
+                    value={option}
+                    checked={editValue.includes(option)}
+                    onChange={(e) =>
+                      handleMultipleChoice(option, e.target.checked)
+                    }
+                    className="accent-primary size-4"
+                  />
+                  {option}
+                </Label>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Button size="sm" onClick={handleSave} disabled={isPending}>
+              {isPending ? 'Saving...' : 'Save'}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCancel}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -61,99 +61,86 @@ export function ProfileQuestion({
         </p>
       )}
 
-      {isEditing && question.type === 'short_answer' && (
+      {isEditing && (
         <Controller
           control={control}
           name="value"
-          render={({ field }) => (
-            <Input
-              value={field.value[0] ?? ''}
-              onChange={(e) =>
-                field.onChange(e.target.value ? [e.target.value] : [])
-              }
-              onBlur={handleBlur}
-              placeholder="Your answer"
-            />
-          )}
-        />
-      )}
+          render={({ field }) => {
+            if (question.type === 'short_answer')
+              return (
+                <Input
+                  value={field.value[0] ?? ''}
+                  onChange={(e) =>
+                    field.onChange(e.target.value ? [e.target.value] : [])
+                  }
+                  onBlur={handleBlur}
+                  placeholder="Your answer"
+                />
+              );
 
-      {isEditing && question.type === 'long_answer' && (
-        <Controller
-          control={control}
-          name="value"
-          render={({ field }) => (
-            <Textarea
-              value={field.value[0] ?? ''}
-              onChange={(e) =>
-                field.onChange(e.target.value ? [e.target.value] : [])
-              }
-              onBlur={handleBlur}
-              placeholder="Your answer"
-              className="min-h-[100px]"
-            />
-          )}
-        />
-      )}
+            if (question.type === 'long_answer')
+              return (
+                <Textarea
+                  value={field.value[0] ?? ''}
+                  onChange={(e) =>
+                    field.onChange(e.target.value ? [e.target.value] : [])
+                  }
+                  onBlur={handleBlur}
+                  placeholder="Your answer"
+                  className="min-h-[100px]"
+                />
+              );
 
-      {isEditing && question.type === 'single_choice' && (
-        <Controller
-          control={control}
-          name="value"
-          render={({ field }) => (
-            <div className="flex flex-col gap-2">
-              {question.options.map((option: string) => (
-                <Label
-                  key={option}
-                  className="flex cursor-pointer items-center gap-2 font-normal"
-                >
-                  <input
-                    type="radio"
-                    name={question.id}
-                    value={option}
-                    checked={field.value[0] === option}
-                    onChange={() => {
-                      field.onChange([option]);
-                      save([option]);
-                    }}
-                    className="accent-primary size-4"
-                  />
-                  {option}
-                </Label>
-              ))}
-            </div>
-          )}
-        />
-      )}
+            if (question.type === 'single_choice')
+              return (
+                <div className="flex flex-col gap-2">
+                  {question.options.map((option: string) => (
+                    <Label
+                      key={option}
+                      className="flex cursor-pointer items-center gap-2 font-normal"
+                    >
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option}
+                        checked={field.value[0] === option}
+                        onChange={() => {
+                          field.onChange([option]);
+                          save([option]);
+                        }}
+                        className="accent-primary size-4"
+                      />
+                      {option}
+                    </Label>
+                  ))}
+                </div>
+              );
 
-      {isEditing && question.type === 'multiple_choice' && (
-        <Controller
-          control={control}
-          name="value"
-          render={({ field }) => (
-            <div className="flex flex-col gap-2">
-              {question.options.map((option: string) => (
-                <Label
-                  key={option}
-                  className="flex cursor-pointer items-center gap-2 font-normal"
-                >
-                  <input
-                    type="checkbox"
-                    checked={field.value.includes(option)}
-                    onChange={() => {
-                      const next = field.value.includes(option)
-                        ? field.value.filter((v) => v !== option)
-                        : [...field.value, option];
-                      field.onChange(next);
-                      save(next);
-                    }}
-                    className="accent-primary size-4"
-                  />
-                  {option}
-                </Label>
-              ))}
-            </div>
-          )}
+            return (
+              <div className="flex flex-col gap-2">
+                {question.options.map((option: string) => (
+                  <Label
+                    key={option}
+                    className="flex cursor-pointer items-center gap-2 font-normal"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={field.value.includes(option)}
+                      onChange={() => {
+                        const next = field.value.includes(option)
+                          ? field.value.filter((v) => v !== option)
+                          : [...field.value, option];
+                        field.onChange(next);
+                        save(next);
+                      }}
+                      className="accent-primary size-4"
+                    />
+                    {option}
+                  </Label>
+                ))}
+              </div>
+            );
+          }}
         />
       )}
     </div>

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { updateGlobalAnswer } from '@/prisma/actions/profile';
@@ -25,18 +24,15 @@ export function ProfileQuestion({
   userId,
   isEditing,
 }: ProfileQuestionProps) {
-  const initial = answer?.value ?? [];
-  const [savedValue, setSavedValue] = useState(initial);
   const { control, formState, getValues, reset } = useForm<FormValues>({
-    defaultValues: { value: initial },
+    defaultValues: { value: answer?.value ?? [] },
   });
 
-  const displayValue = savedValue.join(', ') || null;
+  const displayValue = getValues('value').join(', ') || null;
 
   async function save(value: string[]) {
     try {
       await updateGlobalAnswer(userId, question.id, value);
-      setSavedValue(value);
       reset({ value });
     } catch {
       // silent — autosave is best-effort

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { updateGlobalAnswer } from '@/prisma/actions/profile';
@@ -24,36 +25,27 @@ export function ProfileQuestion({
   userId,
   isEditing,
 }: ProfileQuestionProps) {
+  const initial = answer?.value ?? [];
+  const [savedValue, setSavedValue] = useState(initial);
   const { control, formState, getValues, reset } = useForm<FormValues>({
-    defaultValues: { value: answer?.value ?? [] },
+    defaultValues: { value: initial },
   });
 
-  const displayValue =
-    ((formState.defaultValues?.value as string[] | undefined) ?? []).join(
-      ', ',
-    ) || null;
+  const displayValue = savedValue.join(', ') || null;
 
-  async function handleBlur() {
-    if (!formState.isDirty) return;
-    const value = getValues('value');
+  async function save(value: string[]) {
     try {
       await updateGlobalAnswer(userId, question.id, value);
+      setSavedValue(value);
       reset({ value });
     } catch {
       // silent — autosave is best-effort
     }
   }
 
-  async function handleChoiceChange(newValue: string[]) {
-    const saved =
-      (formState.defaultValues?.value as string[] | undefined) ?? [];
-    if (JSON.stringify(newValue) === JSON.stringify(saved)) return;
-    try {
-      await updateGlobalAnswer(userId, question.id, newValue);
-      reset({ value: newValue });
-    } catch {
-      // silent — autosave is best-effort
-    }
+  async function handleBlur() {
+    if (!formState.isDirty) return;
+    save(getValues('value'));
   }
 
   return (
@@ -127,9 +119,8 @@ export function ProfileQuestion({
                     value={option}
                     checked={field.value[0] === option}
                     onChange={() => {
-                      const next = [option];
-                      field.onChange(next);
-                      handleChoiceChange(next);
+                      field.onChange([option]);
+                      save([option]);
                     }}
                     className="accent-primary size-4"
                   />
@@ -154,14 +145,13 @@ export function ProfileQuestion({
                 >
                   <input
                     type="checkbox"
-                    value={option}
                     checked={field.value.includes(option)}
-                    onChange={(e) => {
-                      const next = e.target.checked
-                        ? [...field.value, option]
-                        : field.value.filter((v) => v !== option);
+                    onChange={() => {
+                      const next = field.value.includes(option)
+                        ? field.value.filter((v) => v !== option)
+                        : [...field.value, option];
                       field.onChange(next);
-                      handleChoiceChange(next);
+                      save(next);
                     }}
                     className="accent-primary size-4"
                   />

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -16,15 +16,13 @@ interface ProfileQuestionProps {
   isEditing: boolean;
 }
 
-type FormValues = { value: string[] };
-
 export function ProfileQuestion({
   question,
   answer,
   userId,
   isEditing,
 }: ProfileQuestionProps) {
-  const { control, formState, getValues, reset } = useForm<FormValues>({
+  const { control, formState, getValues, reset } = useForm<{ value: string[] }>({
     defaultValues: { value: answer?.value ?? [] },
   });
 

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 
 import { updateGlobalAnswer } from '@/prisma/actions/profile';
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
@@ -22,53 +26,44 @@ export function ProfileQuestion({
   userId,
 }: ProfileQuestionProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const [currentValue, setCurrentValue] = useState<string[]>(
-    answer?.value ?? [],
-  );
-  const [editValue, setEditValue] = useState<string[]>(answer?.value ?? []);
-  const [isPending, startTransition] = useTransition();
+  const [savedValue, setSavedValue] = useState<string[]>(answer?.value ?? []);
+
+  const schema = z.object({
+    value: question.required
+      ? z.array(z.string()).min(1, 'This field is required')
+      : z.array(z.string()),
+  });
+  type FormValues = z.infer<typeof schema>;
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { value: answer?.value ?? [] },
+  });
 
   function displayValue() {
-    if (currentValue.length === 0) return null;
-    if (question.type === 'multiple_choice') return currentValue.join(', ');
-    return currentValue[0];
+    if (savedValue.length === 0) return null;
+    if (question.type === 'multiple_choice') return savedValue.join(', ');
+    return savedValue[0];
   }
 
   function handleEdit() {
-    setEditValue(currentValue);
+    form.reset({ value: savedValue });
     setIsEditing(true);
   }
 
   function handleCancel() {
-    setEditValue(currentValue);
+    form.reset({ value: savedValue });
     setIsEditing(false);
   }
 
-  function handleSave() {
-    startTransition(async () => {
-      await updateGlobalAnswer(userId, question.id, editValue);
-      setCurrentValue(editValue);
-      setIsEditing(false);
-    });
-  }
-
-  function handleShortChange(val: string) {
-    setEditValue(val ? [val] : []);
-  }
-
-  function handleSingleChoice(option: string) {
-    setEditValue([option]);
-  }
-
-  function handleMultipleChoice(option: string, checked: boolean) {
-    if (checked) {
-      setEditValue((prev) => [...prev, option]);
-    } else {
-      setEditValue((prev) => prev.filter((v) => v !== option));
-    }
+  async function handleSave(data: FormValues) {
+    await updateGlobalAnswer(userId, question.id, data.value);
+    setSavedValue(data.value);
+    setIsEditing(false);
   }
 
   const display = displayValue();
+  const isPending = form.formState.isSubmitting;
 
   return (
     <div className="bg-card rounded-lg border p-4 shadow-sm">
@@ -93,72 +88,115 @@ export function ProfileQuestion({
       )}
 
       {isEditing && (
-        <div className="flex flex-col gap-3">
+        <form
+          onSubmit={form.handleSubmit(handleSave)}
+          className="flex flex-col gap-3"
+        >
           {question.type === 'short_answer' && (
-            <Input
-              value={editValue[0] ?? ''}
-              onChange={(e) => handleShortChange(e.target.value)}
-              placeholder="Your answer"
+            <Controller
+              control={form.control}
+              name="value"
+              render={({ field }) => (
+                <Input
+                  value={field.value[0] ?? ''}
+                  onChange={(e) =>
+                    field.onChange(e.target.value ? [e.target.value] : [])
+                  }
+                  placeholder="Your answer"
+                />
+              )}
             />
           )}
 
           {question.type === 'long_answer' && (
-            <Textarea
-              value={editValue[0] ?? ''}
-              onChange={(e) => handleShortChange(e.target.value)}
-              placeholder="Your answer"
-              className="min-h-[100px]"
+            <Controller
+              control={form.control}
+              name="value"
+              render={({ field }) => (
+                <Textarea
+                  value={field.value[0] ?? ''}
+                  onChange={(e) =>
+                    field.onChange(e.target.value ? [e.target.value] : [])
+                  }
+                  placeholder="Your answer"
+                  className="min-h-[100px]"
+                />
+              )}
             />
           )}
 
           {question.type === 'single_choice' && (
-            <div className="flex flex-col gap-2">
-              {question.options.map((option: string) => (
-                <Label
-                  key={option}
-                  className="flex cursor-pointer items-center gap-2 font-normal"
-                >
-                  <input
-                    type="radio"
-                    name={question.id}
-                    value={option}
-                    checked={editValue[0] === option}
-                    onChange={() => handleSingleChoice(option)}
-                    className="accent-primary size-4"
-                  />
-                  {option}
-                </Label>
-              ))}
-            </div>
+            <Controller
+              control={form.control}
+              name="value"
+              render={({ field }) => (
+                <div className="flex flex-col gap-2">
+                  {question.options.map((option: string) => (
+                    <Label
+                      key={option}
+                      className="flex cursor-pointer items-center gap-2 font-normal"
+                    >
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option}
+                        checked={field.value[0] === option}
+                        onChange={() => field.onChange([option])}
+                        className="accent-primary size-4"
+                      />
+                      {option}
+                    </Label>
+                  ))}
+                </div>
+              )}
+            />
           )}
 
           {question.type === 'multiple_choice' && (
-            <div className="flex flex-col gap-2">
-              {question.options.map((option: string) => (
-                <Label
-                  key={option}
-                  className="flex cursor-pointer items-center gap-2 font-normal"
-                >
-                  <input
-                    type="checkbox"
-                    value={option}
-                    checked={editValue.includes(option)}
-                    onChange={(e) =>
-                      handleMultipleChoice(option, e.target.checked)
-                    }
-                    className="accent-primary size-4"
-                  />
-                  {option}
-                </Label>
-              ))}
-            </div>
+            <Controller
+              control={form.control}
+              name="value"
+              render={({ field }) => (
+                <div className="flex flex-col gap-2">
+                  {question.options.map((option: string) => (
+                    <Label
+                      key={option}
+                      className="flex cursor-pointer items-center gap-2 font-normal"
+                    >
+                      <input
+                        type="checkbox"
+                        value={option}
+                        checked={field.value.includes(option)}
+                        onChange={(e) => {
+                          if (e.target.checked)
+                            field.onChange([...field.value, option]);
+                          else
+                            field.onChange(
+                              field.value.filter((v) => v !== option),
+                            );
+                        }}
+                        className="accent-primary size-4"
+                      />
+                      {option}
+                    </Label>
+                  ))}
+                </div>
+              )}
+            />
+          )}
+
+          {form.formState.errors.value?.message && (
+            <p className="text-destructive text-sm">
+              {form.formState.errors.value.message}
+            </p>
           )}
 
           <div className="flex items-center gap-2">
-            <Button size="sm" onClick={handleSave} disabled={isPending}>
+            <Button type="submit" size="sm" disabled={isPending}>
               {isPending ? 'Saving...' : 'Save'}
             </Button>
             <Button
+              type="button"
               variant="outline"
               size="sm"
               onClick={handleCancel}
@@ -167,7 +205,7 @@ export function ProfileQuestion({
               Cancel
             </Button>
           </div>
-        </div>
+        </form>
       )}
     </div>
   );

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -22,9 +22,9 @@ export function ProfileQuestion({
   userId,
   isEditing,
 }: ProfileQuestionProps) {
-  const { control, formState, getValues, reset } = useForm<{ value: string[] }>({
-    defaultValues: { value: answer?.value ?? [] },
-  });
+  const { control, formState, getValues, reset } = useForm<{ value: string[] }>(
+    { defaultValues: { value: answer?.value ?? [] } },
+  );
 
   const displayValue = getValues('value').join(', ') || null;
 

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -1,15 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
-
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { useRef, useState } from 'react';
 
 import { updateGlobalAnswer } from '@/prisma/actions/profile';
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
 
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -18,194 +13,111 @@ interface ProfileQuestionProps {
   question: GlobalQuestion;
   answer: GlobalAnswer | null;
   userId: string;
+  isEditing: boolean;
 }
 
-export function ProfileQuestion({
-  question,
-  answer,
-  userId,
-}: ProfileQuestionProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [savedValue, setSavedValue] = useState<string[]>(answer?.value ?? []);
+export function ProfileQuestion({ question, answer, userId, isEditing }: ProfileQuestionProps) {
+  const initial = answer?.value ?? [];
+  const [currentValue, setCurrentValue] = useState<string[]>(initial);
+  const [savedValue, setSavedValue] = useState<string[]>(initial);
+  const savingRef = useRef(false);
 
-  const schema = z.object({
-    value: question.required
-      ? z.array(z.string()).min(1, 'This field is required')
-      : z.array(z.string()),
-  });
-  type FormValues = z.infer<typeof schema>;
-
-  const form = useForm<FormValues>({
-    resolver: zodResolver(schema),
-    defaultValues: { value: answer?.value ?? [] },
-  });
-
-  function displayValue() {
-    if (savedValue.length === 0) return null;
-    if (question.type === 'multiple_choice') return savedValue.join(', ');
-    return savedValue[0];
+  async function autosave(newValue: string[]) {
+    if (savingRef.current) return;
+    if (JSON.stringify(newValue) === JSON.stringify(savedValue)) return;
+    savingRef.current = true;
+    try {
+      await updateGlobalAnswer(userId, question.id, newValue);
+      setSavedValue(newValue);
+    } catch {
+      // silent — autosave is best-effort
+    } finally {
+      savingRef.current = false;
+    }
   }
 
-  function handleEdit() {
-    form.reset({ value: savedValue });
-    setIsEditing(true);
-  }
-
-  function handleCancel() {
-    form.reset({ value: savedValue });
-    setIsEditing(false);
-  }
-
-  async function handleSave(data: FormValues) {
-    await updateGlobalAnswer(userId, question.id, data.value);
-    setSavedValue(data.value);
-    setIsEditing(false);
-  }
-
-  const display = displayValue();
-  const isPending = form.formState.isSubmitting;
+  const displayValue =
+    savedValue.length === 0
+      ? null
+      : question.type === 'multiple_choice'
+        ? savedValue.join(', ')
+        : savedValue[0];
 
   return (
     <div className="bg-card rounded-lg border p-4 shadow-sm">
-      <div className="mb-3 flex items-start justify-between gap-2">
-        <span className="text-sm leading-snug font-medium">
-          {question.label}
-          {question.required && (
-            <span className="text-destructive ml-1">*</span>
-          )}
-        </span>
-        {!isEditing && (
-          <Button variant="outline" size="sm" onClick={handleEdit}>
-            Edit
-          </Button>
-        )}
-      </div>
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {question.label}
+        {question.required && <span className="text-destructive ml-1">*</span>}
+      </p>
 
       {!isEditing && (
-        <p className="text-muted-foreground text-sm">
-          {display ?? <span className="italic">No answer yet</span>}
+        <p className={displayValue ? 'text-base font-medium text-foreground' : 'text-sm italic text-muted-foreground'}>
+          {displayValue ?? 'No answer yet'}
         </p>
       )}
 
-      {isEditing && (
-        <form
-          onSubmit={form.handleSubmit(handleSave)}
-          className="flex flex-col gap-3"
-        >
-          {question.type === 'short_answer' && (
-            <Controller
-              control={form.control}
-              name="value"
-              render={({ field }) => (
-                <Input
-                  value={field.value[0] ?? ''}
-                  onChange={(e) =>
-                    field.onChange(e.target.value ? [e.target.value] : [])
-                  }
-                  placeholder="Your answer"
-                />
-              )}
-            />
-          )}
+      {isEditing && question.type === 'short_answer' && (
+        <Input
+          value={currentValue[0] ?? ''}
+          onChange={(e) => setCurrentValue(e.target.value ? [e.target.value] : [])}
+          onBlur={() => autosave(currentValue)}
+          placeholder="Your answer"
+        />
+      )}
 
-          {question.type === 'long_answer' && (
-            <Controller
-              control={form.control}
-              name="value"
-              render={({ field }) => (
-                <Textarea
-                  value={field.value[0] ?? ''}
-                  onChange={(e) =>
-                    field.onChange(e.target.value ? [e.target.value] : [])
-                  }
-                  placeholder="Your answer"
-                  className="min-h-[100px]"
-                />
-              )}
-            />
-          )}
+      {isEditing && question.type === 'long_answer' && (
+        <Textarea
+          value={currentValue[0] ?? ''}
+          onChange={(e) => setCurrentValue(e.target.value ? [e.target.value] : [])}
+          onBlur={() => autosave(currentValue)}
+          placeholder="Your answer"
+          className="min-h-[100px]"
+        />
+      )}
 
-          {question.type === 'single_choice' && (
-            <Controller
-              control={form.control}
-              name="value"
-              render={({ field }) => (
-                <div className="flex flex-col gap-2">
-                  {question.options.map((option: string) => (
-                    <Label
-                      key={option}
-                      className="flex cursor-pointer items-center gap-2 font-normal"
-                    >
-                      <input
-                        type="radio"
-                        name={question.id}
-                        value={option}
-                        checked={field.value[0] === option}
-                        onChange={() => field.onChange([option])}
-                        className="accent-primary size-4"
-                      />
-                      {option}
-                    </Label>
-                  ))}
-                </div>
-              )}
-            />
-          )}
+      {isEditing && question.type === 'single_choice' && (
+        <div className="flex flex-col gap-2">
+          {question.options.map((option: string) => (
+            <Label key={option} className="flex cursor-pointer items-center gap-2 font-normal">
+              <input
+                type="radio"
+                name={question.id}
+                value={option}
+                checked={currentValue[0] === option}
+                onChange={() => {
+                  const next = [option];
+                  setCurrentValue(next);
+                  autosave(next);
+                }}
+                className="accent-primary size-4"
+              />
+              {option}
+            </Label>
+          ))}
+        </div>
+      )}
 
-          {question.type === 'multiple_choice' && (
-            <Controller
-              control={form.control}
-              name="value"
-              render={({ field }) => (
-                <div className="flex flex-col gap-2">
-                  {question.options.map((option: string) => (
-                    <Label
-                      key={option}
-                      className="flex cursor-pointer items-center gap-2 font-normal"
-                    >
-                      <input
-                        type="checkbox"
-                        value={option}
-                        checked={field.value.includes(option)}
-                        onChange={(e) => {
-                          if (e.target.checked)
-                            field.onChange([...field.value, option]);
-                          else
-                            field.onChange(
-                              field.value.filter((v) => v !== option),
-                            );
-                        }}
-                        className="accent-primary size-4"
-                      />
-                      {option}
-                    </Label>
-                  ))}
-                </div>
-              )}
-            />
-          )}
-
-          {form.formState.errors.value?.message && (
-            <p className="text-destructive text-sm">
-              {form.formState.errors.value.message}
-            </p>
-          )}
-
-          <div className="flex items-center gap-2">
-            <Button type="submit" size="sm" disabled={isPending}>
-              {isPending ? 'Saving...' : 'Save'}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleCancel}
-              disabled={isPending}
-            >
-              Cancel
-            </Button>
-          </div>
-        </form>
+      {isEditing && question.type === 'multiple_choice' && (
+        <div className="flex flex-col gap-2">
+          {question.options.map((option: string) => (
+            <Label key={option} className="flex cursor-pointer items-center gap-2 font-normal">
+              <input
+                type="checkbox"
+                value={option}
+                checked={currentValue.includes(option)}
+                onChange={(e) => {
+                  const next = e.target.checked
+                    ? [...currentValue, option]
+                    : currentValue.filter((v) => v !== option);
+                  setCurrentValue(next);
+                  autosave(next);
+                }}
+                className="accent-primary size-4"
+              />
+              {option}
+            </Label>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -16,7 +16,12 @@ interface ProfileQuestionProps {
   isEditing: boolean;
 }
 
-export function ProfileQuestion({ question, answer, userId, isEditing }: ProfileQuestionProps) {
+export function ProfileQuestion({
+  question,
+  answer,
+  userId,
+  isEditing,
+}: ProfileQuestionProps) {
   const initial = answer?.value ?? [];
   const [currentValue, setCurrentValue] = useState<string[]>(initial);
   const [savedValue, setSavedValue] = useState<string[]>(initial);
@@ -45,13 +50,19 @@ export function ProfileQuestion({ question, answer, userId, isEditing }: Profile
 
   return (
     <div className="bg-card rounded-lg border p-4 shadow-sm">
-      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      <p className="text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase">
         {question.label}
         {question.required && <span className="text-destructive ml-1">*</span>}
       </p>
 
       {!isEditing && (
-        <p className={displayValue ? 'text-base font-medium text-foreground' : 'text-sm italic text-muted-foreground'}>
+        <p
+          className={
+            displayValue
+              ? 'text-foreground text-base font-medium'
+              : 'text-muted-foreground text-sm italic'
+          }
+        >
           {displayValue ?? 'No answer yet'}
         </p>
       )}
@@ -59,7 +70,9 @@ export function ProfileQuestion({ question, answer, userId, isEditing }: Profile
       {isEditing && question.type === 'short_answer' && (
         <Input
           value={currentValue[0] ?? ''}
-          onChange={(e) => setCurrentValue(e.target.value ? [e.target.value] : [])}
+          onChange={(e) =>
+            setCurrentValue(e.target.value ? [e.target.value] : [])
+          }
           onBlur={() => autosave(currentValue)}
           placeholder="Your answer"
         />
@@ -68,7 +81,9 @@ export function ProfileQuestion({ question, answer, userId, isEditing }: Profile
       {isEditing && question.type === 'long_answer' && (
         <Textarea
           value={currentValue[0] ?? ''}
-          onChange={(e) => setCurrentValue(e.target.value ? [e.target.value] : [])}
+          onChange={(e) =>
+            setCurrentValue(e.target.value ? [e.target.value] : [])
+          }
           onBlur={() => autosave(currentValue)}
           placeholder="Your answer"
           className="min-h-[100px]"
@@ -78,7 +93,10 @@ export function ProfileQuestion({ question, answer, userId, isEditing }: Profile
       {isEditing && question.type === 'single_choice' && (
         <div className="flex flex-col gap-2">
           {question.options.map((option: string) => (
-            <Label key={option} className="flex cursor-pointer items-center gap-2 font-normal">
+            <Label
+              key={option}
+              className="flex cursor-pointer items-center gap-2 font-normal"
+            >
               <input
                 type="radio"
                 name={question.id}
@@ -100,7 +118,10 @@ export function ProfileQuestion({ question, answer, userId, isEditing }: Profile
       {isEditing && question.type === 'multiple_choice' && (
         <div className="flex flex-col gap-2">
           {question.options.map((option: string) => (
-            <Label key={option} className="flex cursor-pointer items-center gap-2 font-normal">
+            <Label
+              key={option}
+              className="flex cursor-pointer items-center gap-2 font-normal"
+            >
               <input
                 type="checkbox"
                 value={option}

--- a/components/features/profile-question.tsx
+++ b/components/features/profile-question.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 
 import { updateGlobalAnswer } from '@/prisma/actions/profile';
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
@@ -16,47 +16,45 @@ interface ProfileQuestionProps {
   isEditing: boolean;
 }
 
+type FormValues = { value: string[] };
+
 export function ProfileQuestion({
   question,
   answer,
   userId,
   isEditing,
 }: ProfileQuestionProps) {
-  const initial = answer?.value ?? [];
-  const [currentValue, setCurrentValue] = useState<string[]>(initial);
-  const [savedValue, setSavedValue] = useState<string[]>(initial);
-  const savingRef = useRef(false);
-  const pendingValueRef = useRef<string[] | null>(null);
+  const { control, formState, getValues, reset } = useForm<FormValues>({
+    defaultValues: { value: answer?.value ?? [] },
+  });
 
-  async function autosave(newValue: string[]) {
-    if (JSON.stringify(newValue) === JSON.stringify(savedValue)) return;
-    if (savingRef.current) {
-      pendingValueRef.current = newValue;
-      return;
-    }
-    savingRef.current = true;
-    pendingValueRef.current = null;
+  const displayValue =
+    ((formState.defaultValues?.value as string[] | undefined) ?? []).join(
+      ', ',
+    ) || null;
+
+  async function handleBlur() {
+    if (!formState.isDirty) return;
+    const value = getValues('value');
     try {
-      await updateGlobalAnswer(userId, question.id, newValue);
-      setSavedValue(newValue);
+      await updateGlobalAnswer(userId, question.id, value);
+      reset({ value });
     } catch {
       // silent — autosave is best-effort
-    } finally {
-      savingRef.current = false;
-      const pending = pendingValueRef.current;
-      if (pending !== null) {
-        pendingValueRef.current = null;
-        autosave(pending);
-      }
     }
   }
 
-  const displayValue =
-    currentValue.length === 0
-      ? null
-      : question.type === 'multiple_choice'
-        ? currentValue.join(', ')
-        : currentValue[0];
+  async function handleChoiceChange(newValue: string[]) {
+    const saved =
+      (formState.defaultValues?.value as string[] | undefined) ?? [];
+    if (JSON.stringify(newValue) === JSON.stringify(saved)) return;
+    try {
+      await updateGlobalAnswer(userId, question.id, newValue);
+      reset({ value: newValue });
+    } catch {
+      // silent — autosave is best-effort
+    }
+  }
 
   return (
     <div className="bg-card rounded-lg border p-4 shadow-sm">
@@ -78,77 +76,101 @@ export function ProfileQuestion({
       )}
 
       {isEditing && question.type === 'short_answer' && (
-        <Input
-          value={currentValue[0] ?? ''}
-          onChange={(e) =>
-            setCurrentValue(e.target.value ? [e.target.value] : [])
-          }
-          onBlur={() => autosave(currentValue)}
-          placeholder="Your answer"
+        <Controller
+          control={control}
+          name="value"
+          render={({ field }) => (
+            <Input
+              value={field.value[0] ?? ''}
+              onChange={(e) =>
+                field.onChange(e.target.value ? [e.target.value] : [])
+              }
+              onBlur={handleBlur}
+              placeholder="Your answer"
+            />
+          )}
         />
       )}
 
       {isEditing && question.type === 'long_answer' && (
-        <Textarea
-          value={currentValue[0] ?? ''}
-          onChange={(e) =>
-            setCurrentValue(e.target.value ? [e.target.value] : [])
-          }
-          onBlur={() => autosave(currentValue)}
-          placeholder="Your answer"
-          className="min-h-[100px]"
+        <Controller
+          control={control}
+          name="value"
+          render={({ field }) => (
+            <Textarea
+              value={field.value[0] ?? ''}
+              onChange={(e) =>
+                field.onChange(e.target.value ? [e.target.value] : [])
+              }
+              onBlur={handleBlur}
+              placeholder="Your answer"
+              className="min-h-[100px]"
+            />
+          )}
         />
       )}
 
       {isEditing && question.type === 'single_choice' && (
-        <div className="flex flex-col gap-2">
-          {question.options.map((option: string) => (
-            <Label
-              key={option}
-              className="flex cursor-pointer items-center gap-2 font-normal"
-            >
-              <input
-                type="radio"
-                name={question.id}
-                value={option}
-                checked={currentValue[0] === option}
-                onChange={() => {
-                  const next = [option];
-                  setCurrentValue(next);
-                  autosave(next);
-                }}
-                className="accent-primary size-4"
-              />
-              {option}
-            </Label>
-          ))}
-        </div>
+        <Controller
+          control={control}
+          name="value"
+          render={({ field }) => (
+            <div className="flex flex-col gap-2">
+              {question.options.map((option: string) => (
+                <Label
+                  key={option}
+                  className="flex cursor-pointer items-center gap-2 font-normal"
+                >
+                  <input
+                    type="radio"
+                    name={question.id}
+                    value={option}
+                    checked={field.value[0] === option}
+                    onChange={() => {
+                      const next = [option];
+                      field.onChange(next);
+                      handleChoiceChange(next);
+                    }}
+                    className="accent-primary size-4"
+                  />
+                  {option}
+                </Label>
+              ))}
+            </div>
+          )}
+        />
       )}
 
       {isEditing && question.type === 'multiple_choice' && (
-        <div className="flex flex-col gap-2">
-          {question.options.map((option: string) => (
-            <Label
-              key={option}
-              className="flex cursor-pointer items-center gap-2 font-normal"
-            >
-              <input
-                type="checkbox"
-                value={option}
-                checked={currentValue.includes(option)}
-                onChange={(e) => {
-                  const next = e.target.checked
-                    ? [...currentValue, option]
-                    : currentValue.filter((v) => v !== option);
-                  setCurrentValue(next);
-                  autosave(next);
-                }}
-                className="accent-primary size-4"
-              />
-              {option}
-            </Label>
-          ))}
-        </div>
+        <Controller
+          control={control}
+          name="value"
+          render={({ field }) => (
+            <div className="flex flex-col gap-2">
+              {question.options.map((option: string) => (
+                <Label
+                  key={option}
+                  className="flex cursor-pointer items-center gap-2 font-normal"
+                >
+                  <input
+                    type="checkbox"
+                    value={option}
+                    checked={field.value.includes(option)}
+                    onChange={(e) => {
+                      const next = e.target.checked
+                        ? [...field.value, option]
+                        : field.value.filter((v) => v !== option);
+                      field.onChange(next);
+                      handleChoiceChange(next);
+                    }}
+                    className="accent-primary size-4"
+                  />
+                  {option}
+                </Label>
+              ))}
+            </div>
+          )}
+        />
       )}
     </div>
   );

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -8,10 +8,24 @@ export const authServer = createAuthServer();
 export async function getCurrentUser() {
   const { data: session } = await authServer.getSession();
   if (!session?.user) redirect('/auth/login');
-  return prisma.user.upsert({
-    where: { neonAuthId: session.user.id },
-    update: {},
-    create: {
+
+  const existing = await prisma.user.findFirst({
+    where: {
+      OR: [{ neonAuthId: session.user.id }, { email: session.user.email }],
+    },
+  });
+
+  if (existing) {
+    if (existing.neonAuthId !== session.user.id)
+      return prisma.user.update({
+        where: { id: existing.id },
+        data: { neonAuthId: session.user.id },
+      });
+    return existing;
+  }
+
+  return prisma.user.create({
+    data: {
       neonAuthId: session.user.id,
       email: session.user.email,
       name: session.user.name ?? null,

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,3 +1,20 @@
 import { createAuthServer } from '@neondatabase/auth/next/server';
+import { redirect } from 'next/navigation';
+
+import prisma from '@/lib/prisma';
 
 export const authServer = createAuthServer();
+
+export async function getCurrentUser() {
+  const { data: session } = await authServer.getSession();
+  if (!session?.user) redirect('/auth/login');
+  return prisma.user.upsert({
+    where: { neonAuthId: session.user.id },
+    update: {},
+    create: {
+      neonAuthId: session.user.id,
+      email: session.user.email,
+      name: session.user.name ?? null,
+    },
+  });
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -9,26 +9,11 @@ export async function getCurrentUser() {
   const { data: session } = await authServer.getSession();
   if (!session?.user) redirect('/auth/login');
 
-  const existing = await prisma.user.findFirst({
-    where: {
-      OR: [{ neonAuthId: session.user.id }, { email: session.user.email }],
-    },
+  const user = await prisma.user.findUnique({
+    where: { neonAuthId: session.user.id },
   });
 
-  if (existing) {
-    if (existing.neonAuthId !== session.user.id)
-      return prisma.user.update({
-        where: { id: existing.id },
-        data: { neonAuthId: session.user.id },
-      });
-    return existing;
-  }
+  if (!user) redirect('/auth/login');
 
-  return prisma.user.create({
-    data: {
-      neonAuthId: session.user.id,
-      email: session.user.email,
-      name: session.user.name ?? null,
-    },
-  });
+  return user;
 }


### PR DESCRIPTION
## Summary

- Replaces per-field Edit/Save/Cancel buttons with a single global **Edit/Done** toggle in the page header
- Rewrites `ProfileQuestion` to use react-hook-form natively — autosaves on blur (text fields) or onChange (choice fields) using `formState.isDirty` and `reset()` to track saved state
- Adds `ProfileForm` client component to own the `isEditing` state and page header
- Updates read mode display: uppercase label, full-size readable answer, card per question, `.join(', ')` for all display values
- Fixes mobile scroll cut-off by changing `h-screen` to `h-dvh` in the app layout
- Simplifies `getCurrentUser` to look up by `neonAuthId` only — removes dual lookup, ID patching, and on-the-fly user creation

## Test Plan

### Read mode
- [x] Navigate to `/profile` as a logged-in user — page loads with a list of question cards and an **Edit** button in the top right
- [x] Each card shows a small uppercase label and a full-size, readable answer below it (not small/gray)
- [x] Required questions show a red `*` next to the label
- [x] Questions with no answer show "No answer yet" in italic
- [x] Multiple-choice answers are displayed as a comma-separated string

### Edit mode
- [x] Clicking **Edit** puts all fields into edit mode simultaneously — no per-field Edit buttons
- [x] The **Edit** button changes to **Done**
- [x] Clicking **Done** returns all fields to read mode

### Autosave — text fields
- [x] `short_answer`: type a new value, tab away — value saves and is shown in read mode after clicking Done
- [x] `long_answer`: type a new value, tab away — value saves and is shown in read mode after clicking Done
- [x] Tab away from a text field without changing it — no network request is made (no save if not dirty)

### Autosave — choice fields
- [x] `single_choice`: selecting a radio option saves immediately
- [x] `multiple_choice`: toggling a checkbox saves immediately
- [x] Selecting the already-selected option again does not trigger a save

### Mobile
- [x] On a small viewport, the last question card is fully reachable by scrolling — nothing cut off at the bottom
- [x] Edit/Done button and all question cards are usable at mobile widths

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)