### PR TITLE
#72 Dev Login Bypass

### DIFF
--- a/app/login/bypass/page.tsx
+++ b/app/login/bypass/page.tsx
@@ -1,4 +1,4 @@
-import { loginAsBypassUser } from '@/prisma/actions/dev-bypass';
+import { loginAsBypassUser } from '@/prisma/services/dev-bypass';
 
 import { Button } from '@/components/ui/button';
 

--- a/app/login/bypass/page.tsx
+++ b/app/login/bypass/page.tsx
@@ -1,0 +1,35 @@
+import { loginAsBypassUser } from '@/prisma/actions/dev-bypass';
+
+import { Button } from '@/components/ui/button';
+
+export default function BypassLoginPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-sm space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Dev Login</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Select a role to log in as a bypass user.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3">
+          <form action={loginAsBypassUser.bind(null, 'admin')}>
+            <Button type="submit" className="w-full">
+              Admin
+            </Button>
+          </form>
+          <form action={loginAsBypassUser.bind(null, 'applicant')}>
+            <Button type="submit" variant="outline" className="w-full">
+              Applicant
+            </Button>
+          </form>
+          <form action={loginAsBypassUser.bind(null, 'position-manager')}>
+            <Button type="submit" variant="outline" className="w-full">
+              Position Manager
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,4 +1,5 @@
 import { createAuthServer } from '@neondatabase/auth/next/server';
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import prisma from '@/lib/prisma';
@@ -6,6 +7,19 @@ import prisma from '@/lib/prisma';
 export const authServer = createAuthServer();
 
 export async function getCurrentUser() {
+  if (process.env.VERCEL_ENV !== 'production') {
+    const cookieStore = await cookies();
+    const bypassUserId = cookieStore.get('dev-bypass-user-id')?.value;
+
+    if (!bypassUserId) redirect('/login/bypass');
+
+    const user = await prisma.user.findUnique({ where: { id: bypassUserId } });
+
+    if (!user) redirect('/login/bypass');
+
+    return user;
+  }
+
   const { data: session } = await authServer.getSession();
   if (!session?.user) redirect('/auth/login');
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,23 @@
 import { neonAuthMiddleware } from '@neondatabase/auth/next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export default neonAuthMiddleware({ loginUrl: '/auth/login' });
+const isBypassActive = process.env.VERCEL_ENV !== 'production';
+
+function bypassMiddleware(request: NextRequest): NextResponse {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === '/login/bypass') return NextResponse.next();
+
+  const cookie = request.cookies.get('dev-bypass-user-id');
+  if (cookie) return NextResponse.next();
+
+  return NextResponse.redirect(new URL('/login/bypass', request.url));
+}
+
+export default function middleware(request: NextRequest) {
+  if (isBypassActive) return bypassMiddleware(request);
+  return neonAuthMiddleware({ loginUrl: '/auth/login' })(request);
+}
 
 export const config = {
   matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],

--- a/prisma/actions/dev-bypass.ts
+++ b/prisma/actions/dev-bypass.ts
@@ -1,0 +1,73 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import prisma from '@/lib/prisma';
+
+type BypassRole = 'admin' | 'applicant' | 'position-manager';
+
+const BYPASS_USERS: Record<
+  BypassRole,
+  { email: string; neonAuthId: string; isAdmin: boolean }
+> = {
+  admin: {
+    email: 'bypass-admin@example.com',
+    neonAuthId: 'bypass-admin',
+    isAdmin: true,
+  },
+  applicant: {
+    email: 'bypass-applicant@example.com',
+    neonAuthId: 'bypass-applicant',
+    isAdmin: false,
+  },
+  'position-manager': {
+    email: 'bypass-position-manager@example.com',
+    neonAuthId: 'bypass-position-manager',
+    isAdmin: false,
+  },
+};
+
+export async function loginAsBypassUser(role: string) {
+  if (process.env.VERCEL_ENV === 'production') return;
+
+  const config = BYPASS_USERS[role as BypassRole];
+  if (!config) return;
+
+  const { email, neonAuthId, isAdmin } = config;
+
+  const user = await prisma.user.upsert({
+    where: { neonAuthId },
+    update: { email, isAdmin },
+    create: { email, neonAuthId, isAdmin },
+  });
+
+  if (role === 'position-manager') {
+    const existingPosition = await prisma.position.findFirst({
+      where: { title: 'Bypass Position' },
+    });
+
+    if (existingPosition) {
+      await prisma.position.update({
+        where: { id: existingPosition.id },
+        data: { managers: { connect: { id: user.id } } },
+      });
+    } else {
+      await prisma.position.create({
+        data: {
+          title: 'Bypass Position',
+          description: 'A position for bypass testing.',
+          status: 'open',
+          createdById: user.id,
+          updatedById: user.id,
+          managers: { connect: { id: user.id } },
+        },
+      });
+    }
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set('dev-bypass-user-id', user.id, { httpOnly: true, path: '/' });
+
+  redirect('/positions');
+}

--- a/prisma/services/dev-bypass.ts
+++ b/prisma/services/dev-bypass.ts
@@ -28,10 +28,10 @@ const BYPASS_USERS: Record<
   },
 };
 
-export async function loginAsBypassUser(role: string) {
+export async function loginAsBypassUser(role: BypassRole) {
   if (process.env.VERCEL_ENV === 'production') return;
 
-  const config = BYPASS_USERS[role as BypassRole];
+  const config = BYPASS_USERS[role];
   if (!config) return;
 
   const { email, neonAuthId, isAdmin } = config;
@@ -67,7 +67,11 @@ export async function loginAsBypassUser(role: string) {
   }
 
   const cookieStore = await cookies();
-  cookieStore.set('dev-bypass-user-id', user.id, { httpOnly: true, path: '/' });
+  cookieStore.set('dev-bypass-user-id', user.id, {
+    httpOnly: true,
+    secure: true,
+    path: '/',
+  });
 
   redirect('/positions');
 }

--- a/prisma/services/dev-bypass.ts
+++ b/prisma/services/dev-bypass.ts
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation';
 
 import prisma from '@/lib/prisma';
 
-type BypassRole = 'admin' | 'applicant' | 'position-manager';
+export type BypassRole = 'admin' | 'applicant' | 'position-manager';
 
 const BYPASS_USERS: Record<
   BypassRole,
@@ -70,6 +70,7 @@ export async function loginAsBypassUser(role: BypassRole) {
   cookieStore.set('dev-bypass-user-id', user.id, {
     httpOnly: true,
     secure: true,
+    sameSite: 'lax',
     path: '/',
   });
 


### PR DESCRIPTION
## Summary
- Bypass page at `/login/bypass` with Admin, Applicant, and Position Manager role buttons
- Middleware redirects unauthenticated non-production requests to bypass page instead of Neon Auth
- `getCurrentUser()` reads `dev-bypass-user-id` cookie and looks up user directly in DB when bypass is active
- Server action upserts deterministic bypass users and sets the cookie

Closes #72