### PR TITLE
#97 Pipeline Agent Improvements: Background Execution, Bulk Dispatch, Input Flexibility, Per-Agent Permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "allowedTools": [
+    "Bash(gh issue view *)",
+    "Bash(gh issue edit *)",
+    "Bash(gh issue comment *)",
+    "Bash(gh pr list *)",
+    "Bash(gh pr view *)",
+    "Bash(gh pr diff *)",
+    "Bash(gh pr comment *)",
+    "Bash(gh pr edit *)",
+    "Bash(gh pr create *)",
+    "Bash(gh label create *)",
+    "Bash(git fetch *)",
+    "Bash(git worktree *)",
+    "Bash(git checkout *)",
+    "Bash(git add *)",
+    "Bash(git commit *)",
+    "Bash(git push *)",
+    "Bash(ln -s *)",
+    "Bash(npm run prettier:check)",
+    "Bash(npx prettier --write *)",
+    "Bash(npm run eslint:check)",
+    "Bash(npm run tsc:check)"
+  ]
+}

--- a/.claude/skills/impl-agent/SKILL.md
+++ b/.claude/skills/impl-agent/SKILL.md
@@ -8,6 +8,16 @@ description: Pipeline Stage 2 — reads the approved plan from an issue and impl
 **Trigger:** Issue labeled `plan approved`
 **Input:** `$ARGUMENTS` — the issue number
 
+Spawn a background sub-agent with the instructions below, then return immediately.
+
+```
+Agent({
+  description: "impl-agent for issue #$ARGUMENTS",
+  run_in_background: true,
+  prompt: "<paste the ## Work section below as the prompt>"
+})
+```
+
 ## Pre-flight
 
 Fetch the issue and verify it is labeled `plan approved`:
@@ -70,7 +80,24 @@ EOF
 )"
 ```
 
-If something unanticipated arises that the plan did not cover, pause and ask the user before continuing.
+If something unanticipated arises that the plan did not cover, do **not** pause — instead:
+
+1. Post a blocker comment on the issue:
+
+   ```bash
+   gh issue comment $ARGUMENTS --repo SGAOperations/aplio --body "## Blocker
+
+   <description of what was encountered and why it blocks progress>
+
+   **Stopped at:** <last completed checklist item>
+   **Needs:** <what decision or information is required to continue>"
+   ```
+
+2. Update labels:
+   ```bash
+   gh issue edit $ARGUMENTS --repo SGAOperations/aplio --remove-label "in progress" --add-label "blocked"
+   ```
+3. Exit without pushing any partial work.
 
 ### 5. Run CI checks
 

--- a/.claude/skills/review-agent/SKILL.md
+++ b/.claude/skills/review-agent/SKILL.md
@@ -1,24 +1,56 @@
 ---
 name: review-agent
-description: Pipeline Stage 3 — reviews a PR diff against the original plan and posts a structured review comment. Usage: /review-agent <pr-number>
+description: Pipeline Stage 3 — reviews a PR diff against the original plan and posts a structured review comment. Usage: /review-agent <pr-or-issue-number>
 ---
 
 # Review Agent — Stage 3
 
 **Trigger:** PR labeled `ready for review`
-**Input:** `$ARGUMENTS` — the PR number
+**Input:** `$ARGUMENTS` — a PR number or issue number
+
+Spawn a background sub-agent with the instructions below, then return immediately.
+
+```
+Agent({
+  description: "review-agent for #$ARGUMENTS",
+  run_in_background: true,
+  prompt: "<paste the ## Work section below as the prompt>"
+})
+```
 
 ## Pre-flight
 
-Fetch the PR and verify it is labeled `ready for review`:
+### Resolve input to a PR number
+
+Try to fetch the input as a PR directly:
 
 ```bash
 gh pr view $ARGUMENTS --repo SGAOperations/aplio --json labels,title,body
 ```
 
+If that succeeds, `$ARGUMENTS` is the PR number — proceed.
+
+If it fails (the input is an issue number), find the linked PR:
+
+```bash
+gh pr list --repo SGAOperations/aplio --search "closes #$ARGUMENTS" --json number,title
+```
+
+If a PR is found, use its number as the PR number for all steps below. If no PR is found, stop and say:
+
+> "No open PR found linked to issue #$ARGUMENTS. Nothing was changed."
+
+### Verify label
+
+Fetch the PR and confirm it is labeled `ready for review`:
+
+```bash
+gh pr view <pr-number> --repo SGAOperations/aplio --json labels,title,body
+```
+
 If the PR does not have the `ready for review` label, stop immediately and say:
 
-> "PR #$ARGUMENTS is not labeled `ready for review`. Current labels: [list them]. Nothing was changed."
+> "PR #<pr-number> is not labeled `ready for review`. Current labels: [list them]. Nothing was changed."
 
 ## Work
 
@@ -26,10 +58,10 @@ If the PR does not have the `ready for review` label, stop immediately and say:
 
 ```bash
 # Full PR diff
-gh pr diff $ARGUMENTS --repo SGAOperations/aplio
+gh pr diff <pr-number> --repo SGAOperations/aplio
 
 # PR metadata — find the linked issue number in "Closes #XXX"
-gh pr view $ARGUMENTS --repo SGAOperations/aplio --json body,title,headRefName
+gh pr view <pr-number> --repo SGAOperations/aplio --json body,title,headRefName
 
 # Fetch the linked issue to get the original plan
 gh issue view <issue-number> --repo SGAOperations/aplio
@@ -51,7 +83,7 @@ Review across these dimensions:
 ### 3. Post structured review comment
 
 ```bash
-gh pr comment $ARGUMENTS --repo SGAOperations/aplio --body "<review comment>"
+gh pr comment <pr-number> --repo SGAOperations/aplio --body "<review comment>"
 ```
 
 Format:
@@ -81,12 +113,12 @@ Omit any severity section that has no findings.
 
 ```bash
 # Critical or Medium findings exist:
-gh pr edit $ARGUMENTS --repo SGAOperations/aplio \
+gh pr edit <pr-number> --repo SGAOperations/aplio \
   --remove-label "ready for review" \
   --add-label "needs revision"
 
 # Only Low/Nit findings (or none):
-gh pr edit $ARGUMENTS --repo SGAOperations/aplio \
+gh pr edit <pr-number> --repo SGAOperations/aplio \
   --remove-label "ready for review" \
   --add-label "approved"
 ```

--- a/.claude/skills/review-all/SKILL.md
+++ b/.claude/skills/review-all/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: review-all
+description: Dispatches background review-agents for all PRs labeled `ready for review`. Usage: /review-all
+---
+
+# Review All — Bulk Dispatcher
+
+**Trigger:** Manual
+**Input:** none
+
+## Work
+
+### 1. Fetch all PRs labeled `ready for review`
+
+```bash
+gh pr list --repo SGAOperations/aplio --label "ready for review" --json number,title
+```
+
+If no PRs are found, stop and say:
+
+> "No PRs labeled `ready for review`. Nothing was dispatched."
+
+### 2. Dispatch one background review-agent per PR
+
+Spawn all agents in a **single message** as parallel tool calls — one `Agent` call per PR, all with `run_in_background: true`.
+
+Each agent's prompt should contain the full review-agent ## Work instructions with the specific PR number substituted for `<pr-number>`.
+
+### 3. Report
+
+After dispatching, say:
+
+> "Dispatched review agents for PRs: #N, #N, #N. You'll be notified as each one completes."

--- a/.claude/skills/revise-agent/SKILL.md
+++ b/.claude/skills/revise-agent/SKILL.md
@@ -1,44 +1,74 @@
 ---
 name: revise-agent
-description: Pipeline Stage 4 — reads the review comment on a PR labeled `needs revision` and implements fixes. Usage: /revise-agent <pr-number>
+description: Pipeline Stage 4 — reads the review comment on a PR labeled `needs revision` and implements fixes. Usage: /revise-agent <pr-or-issue-number>
 ---
 
 # Revise Agent — Stage 4
 
 **Trigger:** PR labeled `needs revision`
-**Input:** `$ARGUMENTS` — the PR number
+**Input:** `$ARGUMENTS` — a PR number or issue number
+
+Spawn a background sub-agent with the instructions below, then return immediately.
+
+```
+Agent({
+  description: "revise-agent for #$ARGUMENTS",
+  run_in_background: true,
+  prompt: "<paste the ## Work section below as the prompt>"
+})
+```
 
 ## Pre-flight
 
-Fetch the PR and verify it is labeled `needs revision`:
+### Resolve input to a PR number
+
+Try to fetch the input as a PR directly:
 
 ```bash
 gh pr view $ARGUMENTS --repo SGAOperations/aplio --json labels,title,headRefName
 ```
 
+If that succeeds, `$ARGUMENTS` is the PR number — proceed.
+
+If it fails (the input is an issue number), find the linked PR:
+
+```bash
+gh pr list --repo SGAOperations/aplio --search "closes #$ARGUMENTS" --json number,title,headRefName
+```
+
+If a PR is found, use its number as the PR number for all steps below. If no PR is found, stop and say:
+
+> "No open PR found linked to issue #$ARGUMENTS. Nothing was changed."
+
+### Verify label
+
+Confirm the PR is labeled `needs revision`:
+
+```bash
+gh pr view <pr-number> --repo SGAOperations/aplio --json labels,title,headRefName
+```
+
 If the PR does not have the `needs revision` label, stop immediately and say:
 
-> "PR #$ARGUMENTS is not labeled `needs revision`. Current labels: [list them]. Nothing was changed."
+> "PR #<pr-number> is not labeled `needs revision`. Current labels: [list them]. Nothing was changed."
 
 ## Work
 
 ### 1. Fetch the review comment
 
 ```bash
-gh pr view $ARGUMENTS --repo SGAOperations/aplio --comments
+gh pr view <pr-number> --repo SGAOperations/aplio --comments
 ```
 
 Find the most recent `## Code Review` comment. That is the review to address.
 
 ### 2. Derive the issue number and check out the branch
 
-Parse the issue number from the PR body — it appears as `Closes #XXX`:
+If input was already an issue number, use it directly. Otherwise parse from the PR body (`Closes #XXX`):
 
 ```bash
-gh pr view $ARGUMENTS --repo SGAOperations/aplio --json body --jq '.body'
+gh pr view <pr-number> --repo SGAOperations/aplio --json body --jq '.body'
 ```
-
-Extract the number after `Closes #` — this is `<issue-number>`, used in the commit message below.
 
 Check out the branch:
 
@@ -88,7 +118,7 @@ git push origin <headRefName>
 ### 6. Post summary comment
 
 ```bash
-gh pr comment $ARGUMENTS --repo SGAOperations/aplio --body "<summary>"
+gh pr comment <pr-number> --repo SGAOperations/aplio --body "<summary>"
 ```
 
 Format:
@@ -111,7 +141,7 @@ Omit any section with no entries.
 ## Handoff
 
 ```bash
-gh pr edit $ARGUMENTS --repo SGAOperations/aplio \
+gh pr edit <pr-number> --repo SGAOperations/aplio \
   --remove-label "needs revision" \
   --add-label "ready for review"
 ```

--- a/.claude/skills/revise-all/SKILL.md
+++ b/.claude/skills/revise-all/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: revise-all
+description: Dispatches background revise-agents for all PRs labeled `needs revision`. Usage: /revise-all
+---
+
+# Revise All — Bulk Dispatcher
+
+**Trigger:** Manual
+**Input:** none
+
+## Work
+
+### 1. Fetch all PRs labeled `needs revision`
+
+```bash
+gh pr list --repo SGAOperations/aplio --label "needs revision" --json number,title
+```
+
+If no PRs are found, stop and say:
+
+> "No PRs labeled `needs revision`. Nothing was dispatched."
+
+### 2. Dispatch one background revise-agent per PR
+
+Spawn all agents in a **single message** as parallel tool calls — one `Agent` call per PR, all with `run_in_background: true`.
+
+Each agent's prompt should contain the full revise-agent ## Work instructions with the specific PR number substituted for `<pr-number>`.
+
+### 3. Report
+
+After dispatching, say:
+
+> "Dispatched revise agents for PRs: #N, #N, #N. You'll be notified as each one completes."


### PR DESCRIPTION
## Summary
- Updated `/impl-agent`, `/review-agent`, `/revise-agent` to always spawn as background sub-agents
- `/review-agent` and `/revise-agent` now accept an issue number OR PR number
- Added `/review-all` skill to bulk-dispatch review agents for all `ready for review` PRs
- Added `/revise-all` skill to bulk-dispatch revise agents for all `needs revision` PRs
- `impl-agent` now posts a blocker comment + sets `blocked` label instead of pausing for user input
- Added `.claude/settings.json` with pre-granted `allowedTools` for all pipeline agents
- Created `blocked` issue label in the repo

Closes #97