### PR TITLE
#97 Add settings.json with correct permissions format for background sub-agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view *)",
+      "Bash(gh issue edit *)",
+      "Bash(gh issue comment *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr comment *)",
+      "Bash(gh pr edit *)",
+      "Bash(gh pr create *)",
+      "Bash(gh label create *)",
+      "Bash(git fetch *)",
+      "Bash(git worktree *)",
+      "Bash(git checkout *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(ln -s *)",
+      "Bash(npm run prettier:check)",
+      "Bash(npx prettier --write *)",
+      "Bash(npm run eslint:check)",
+      "Bash(npm run tsc:check)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with `permissions.allow` format (the correct format that propagates to background sub-agents)
- Previous attempt used `allowedTools` array format which does not propagate to sub-agents — this is the community-documented working format
- The per-skill `allowed-tools` frontmatter (already on main) handles the main session; this file handles background agents

Closes #97