### PR TITLE
#127 Harden Pipeline: Broaden Agent Permissions, Prevent Runaways, Add Stop Controls

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -4,6 +4,8 @@ description: Pipeline Stage 2 — implements the approved plan from a GitHub iss
 model: sonnet
 isolation: worktree
 permissionMode: acceptEdits
+maxTurns: 150
+disallowedTools: Agent
 color: green
 ---
 
@@ -12,6 +14,13 @@ You are the Impl agent (Stage 2) of the pipeline in `.claude/docs/PIPELINE.md`. 
 **Input:** the issue number you were given (referred to below as `N`).
 
 **Your environment:** you run in your **own isolated git worktree** — a fresh checkout of `main`. All your work happens here. You do **not** create worktrees, symlinks, or `.env` files manually; none of that is needed.
+
+## Operating rules (read first)
+
+- **You are already in your own isolated git worktree (your cwd).** Do all work here using **cwd-relative paths**. Never `cd` out of it, never use `git -C` on the main repo, never write to absolute `.claude/worktrees/…` paths.
+- **Files:** use the **Write/Edit tools** with cwd-relative paths. Never create files with `cat >` or heredocs.
+- **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
+- **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP and emit `BLOCKED: <summary>`** (see Blockers below). **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
 

--- a/.claude/agents/plan-agent.md
+++ b/.claude/agents/plan-agent.md
@@ -3,14 +3,20 @@ name: plan-agent
 description: Pipeline Stage 1 — researches a GitHub issue and writes an implementation plan into its body. Dispatched by the /pipeline cockpit for issues labeled `ready` (fresh plan) or `plan changes requested` (revision). Reads code but never edits source.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Write
-disallowedTools: Edit
+disallowedTools: Edit, Agent
 permissionMode: acceptEdits
+maxTurns: 60
 color: blue
 ---
 
 You are the Plan agent (Stage 1) of the pipeline in `.claude/docs/PIPELINE.md`. You research an issue and write a high-quality implementation plan into its body. You read the codebase but never modify source files. Repo: `SGAOperations/aplio`.
 
 **Input:** the issue number you were given (referred to below as `N`).
+
+## Operating rules (read first)
+
+- **Files:** use the **Write tool** with cwd-relative paths for `.temp/` payloads — never `cat >`/heredocs, never absolute `.claude/worktrees/…` paths. You do not edit source.
+- **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP** and emit `QUESTIONS FOR HUMAN:` (below). **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
 

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -3,14 +3,20 @@ name: review-agent
 description: Pipeline Stage 3 — reviews a PR diff against the original plan, CI status, and .claude/docs/ENGINEERING.md, then posts a structured review comment and sets the verdict label. Dispatched by the /pipeline cockpit for PRs labeled `ready for review`. Read-only — never edits source.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Write
-disallowedTools: Edit
+disallowedTools: Edit, Agent
 permissionMode: acceptEdits
+maxTurns: 60
 color: orange
 ---
 
 You are the Review agent (Stage 3) of the pipeline in `.claude/docs/PIPELINE.md`. You review a PR and post a structured verdict. You read but never modify source. Repo: `SGAOperations/aplio`.
 
 **Input:** a PR number or an issue number (referred to below as `$INPUT`).
+
+## Operating rules (read first)
+
+- **Files:** use the **Write tool** with cwd-relative paths for `.temp/` payloads — never `cat >`/heredocs, never absolute `.claude/worktrees/…` paths. You do not edit source.
+- **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP** and post the partial review with what you have. **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
 
@@ -48,6 +54,15 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "ready for revi
    ```
 
    Also read `.claude/docs/ENGINEERING.md` — it is a review dimension.
+
+   **To diagnose a failing check** (so the finding is actionable), read its log:
+
+   ```bash
+   gh run list --repo SGAOperations/aplio --branch <headRefName> --json databaseId,name,conclusion,workflowName
+   gh run view <databaseId> --repo SGAOperations/aplio --log-failed
+   ```
+
+   Note: `gh pr checks` exposes status in the **`bucket`** field (pass/fail/pending) if you pass `--json name,bucket,link` — there is **no** `status`/`conclusion` field on `gh pr checks`. For a failing **Vercel** check, cite the check name + its link as Critical; do not try to read Vercel logs.
 
 2. **Review the diff.** For each finding note file, line, severity, and whether it was **introduced in this PR** or is **preexisting**. Dimensions: **CI** (any failing required check = Critical, cite the check name) · **Correctness** vs. every plan checklist item · **Security** (OWASP, auth + zod on every server action, authorization scoping / no IDOR, input validation, dev-only code env-gated) · **Engineering standards** (cite `.claude/docs/ENGINEERING.md` §) · **Conventions** (named exports, no API routes except `/api/auth`, services in `prisma/services/`, Tailwind only, mobile-first, no `useEffect` data fetching) · **Type safety** (no `any`, Prisma-generated types) · **Performance** (revalidation after mutations, N+1) · **Completeness** (loading/error/empty per async surface).
 

--- a/.claude/agents/revise-agent.md
+++ b/.claude/agents/revise-agent.md
@@ -4,6 +4,8 @@ description: Pipeline Stage 4 — reads the latest review comment on a PR, appli
 model: sonnet
 isolation: worktree
 permissionMode: acceptEdits
+maxTurns: 150
+disallowedTools: Agent
 color: purple
 ---
 
@@ -12,6 +14,13 @@ You are the Revise agent (Stage 4) of the pipeline in `.claude/docs/PIPELINE.md`
 **Input:** a PR number or an issue number (referred to below as `$INPUT`).
 
 **Your environment:** you run in your **own isolated git worktree** branched from `main`. You repoint it to the PR's branch (below). No manual symlinks or `.env` are needed.
+
+## Operating rules (read first)
+
+- **You are already in your own isolated git worktree (your cwd).** Do all work here using **cwd-relative paths**. Never `cd` out of it, never use `git -C` on the main repo, never write to absolute `.claude/worktrees/…` paths.
+- **Files:** use the **Write/Edit tools** with cwd-relative paths. Never create files with `cat >` or heredocs.
+- **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
+- **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP and emit `BLOCKED: <summary>`**. **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
 

--- a/.claude/docs/PIPELINE.md
+++ b/.claude/docs/PIPELINE.md
@@ -9,7 +9,7 @@ claude        # open a session (haiku recommended for the cockpit)
 /pipeline     # start the cockpit
 ```
 
-Then talk to it: `work on #142` · `scope out a notifications feature` · `status` · `pause #142` · `retry #142`.
+Then talk to it: `work on #142` · `scope out a notifications feature` · `status` · `pause #142` · `retry #142` · `drain` · `resume` · `stop #142`.
 
 ## The two flows
 
@@ -35,7 +35,7 @@ File the issue → in the cockpit: "work on #N, auto-approve the plan" → wait 
 
 ### Why background dispatch needs care
 
-Background subagents **auto-deny any tool call that would otherwise prompt** (they cannot show a permission dialog). So everything a worker needs must be pre-authorized: file edits via `permissionMode: acceptEdits` in the agent frontmatter, and every `gh`/`git`/`npm` command via `permissions.allow` in `.claude/settings.json`. The worktree is a checkout of `main`, so it carries the committed `settings.json` — **permission changes take effect for dispatched agents only after they land on `main`.**
+Background subagents **auto-deny any tool call that would otherwise prompt** (they cannot show a permission dialog), so a too-tight allowlist makes them stall silently — and, worse, improvise harmful workarounds (hand-edited lockfiles, abandoned libraries). We therefore **allow broad dev-command categories** (`gh`/`git`/`npm`/`npx`) in `.claude/settings.json` and rely on the **`deny`** list for the few genuinely dangerous operations (deny beats allow at every scope). File edits are covered by each worker's `permissionMode: acceptEdits`. The worktree is a checkout of `main`, so it carries the committed `settings.json` — **permission changes take effect for dispatched agents only after they land on `main`.** Agents also run with **`disallowedTools: Agent`** (no nested subagents), a **`maxTurns`** backstop, and an explicit rule to **stop and emit `BLOCKED:` rather than improvise** when a command is denied.
 
 ### File-based GitHub I/O
 
@@ -86,26 +86,19 @@ All four workers read `.claude/docs/ENGINEERING.md` before working; the review a
 
 ## Permission rationale
 
-Every entry in `.claude/settings.json`, what uses it, and why. **Any permission change must update this table.**
+The model is **broad allow + authoritative deny**: stage agents do real dev work (install packages, read CI logs, manage git in their worktree), so the allowlist grants broad categories and the `deny` list draws the safety line. **Any permission change must update this section.**
 
-| Permission                                                                                               | Used by                       | Why                                                                  |
-| -------------------------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------- |
-| `Bash(gh issue view *)`                                                                                  | all stages                    | Read issue bodies (plans live there), labels, comments               |
-| `Bash(gh issue edit *)`                                                                                  | cockpit, plan, impl           | Label transitions; plan written into the issue body                  |
-| `Bash(gh issue comment *)`                                                                               | cockpit, plan, impl           | Blocker comments, plan feedback threads                              |
-| `Bash(gh issue create *)`                                                                                | scope                         | Create epics and sub-issues                                          |
-| `Bash(gh issue list *)`                                                                                  | cockpit                       | Tick queries over trigger/gate labels                                |
-| `Bash(gh pr list/view/diff/comment/edit/create/checks *)`                                                | cockpit, impl, review, revise | PR metadata, the diff under review, CI status, comments, labels      |
-| `Bash(gh label create *)`                                                                                | setup                         | Create/repair pipeline labels                                        |
-| `Bash(gh api repos/SGAOperations/aplio/*)`                                                               | scope                         | Sub-issue linking (REST, database ids) — scoped to this repo         |
-| `Bash(gh api graphql *)`                                                                                 | scope, cockpit                | Blocker relationships; blocked-by checks at opt-in                   |
-| `Bash(git fetch/checkout/add/commit/push/rebase/reset/branch *)`                                         | impl, revise                  | Work inside the agent's own isolated worktree (cwd — no `-C`)        |
-| `Bash(npm ci)`, `Bash(npx prisma generate)`                                                              | impl, revise                  | Fresh worktrees lack `node_modules` and the gitignored Prisma client |
-| `Bash(npm run prettier:check / prettier:fix / eslint:check / tsc:check)`, `Bash(npx prettier --write *)` | impl, revise                  | The pre-push CI checks                                               |
+| Allowed (`permissions.allow`)                                     | Used by             | Why                                                                                                                            |
+| ----------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `Bash(gh *)`                                                      | all stages, cockpit | Issues/PRs/labels, the diff under review, CI status **and run logs** (`gh run view --log-failed`), `gh api` for version checks |
+| `Bash(git *)`                                                     | impl, revise        | All git **inside the agent's own worktree** (fetch/checkout/rebase/commit/push/worktree) — no `git -C` on main                 |
+| `Bash(npm *)`                                                     | impl, revise        | `npm ci`, plus `npm install`/`uninstall`/`view` for dependency tickets                                                         |
+| `Bash(npx *)`                                                     | impl, revise        | `npx prisma generate`, `npx prettier`, etc.                                                                                    |
+| `WebFetch(domain:nextjs.org \| ui.shadcn.com \| code.claude.com)` | all stages          | Fetch current framework / Claude docs instead of stale recall                                                                  |
 
 File writes (source edits, `.temp/` payloads) are authorized by each worker's `permissionMode: acceptEdits`, not by `settings.json`.
 
-**Deny rules (`permissions.deny`):** `gh pr merge` (the human merge gate is absolute), `gh issue delete`, `gh repo delete`, and pushes to `main`. Deny beats allow at every scope, so these hold even if an agent misbehaves. Feature-branch force pushes use `--force-with-lease` only (revise agent, after a rebase) and are covered by the `git push *` allow minus the `main` deny.
+**Deny rules (`permissions.deny`) — the safety line:** `gh pr merge` (the human merge gate is absolute), `gh issue delete`, `gh repo delete`, pushes to `main` (`git push * main` / `git push origin main`), and `npm publish`. Deny beats allow at every scope, so these hold even with broad allows. _(Minor known gap: a `git push origin HEAD:main` refspec isn't caught by the `_ main`pattern — rely on the agent instruction + GitHub branch protection.)* Agents **may** edit CI workflow files and lockfiles (some tickets require it) but are instructed to use`npm`for dependencies and **not hand-edit`package.json`/`package-lock.json` as a workaround\*\*.
 
 ## Escalation
 
@@ -113,6 +106,16 @@ File writes (source edits, `.temp/` payloads) are authorized by each worker's `p
 - **Impl blocker** — `impl-agent` comments `## Blocker`, labels `blocked`, and reports `BLOCKED:`; the cockpit relays and resumes the same agent with the human's decision.
 - **Rebase conflict during revision** — `revise-agent` aborts the rebase, comments, labels `needs human`.
 - **Plan questions** — `plan-agent` never guesses: it returns `QUESTIONS FOR HUMAN:` and the cockpit relays, then resumes it with answers.
+
+## Stopping & draining
+
+The pipeline runs autonomously once started; these cockpit commands are the clean off-switch:
+
+- **`drain` / `pause`** — finish in-flight work, start nothing new (stops dispatch **and** wakeups). **`resume`** restarts ticking.
+- **`stop #N`** — halt one item: drop its trigger label and `TaskStop` its in-flight agent, resetting the label so it can be retried.
+- **`stop` / `halt`** — drain + `TaskStop` all running agents + reset their labels.
+
+Closing the cockpit session also halts dispatch (it is the only dispatcher) but cuts off in-flight agents mid-run — prefer `drain` for a graceful stop.
 
 ## Recovery runbook
 
@@ -123,6 +126,8 @@ File writes (source edits, `.temp/` payloads) are authorized by each worker's `p
 | A stage misbehaved and you want to run it by hand                                                 | —                                                     | @-mention the subagent (`@agent-impl-agent implement #N`) or run `claude --agent impl-agent`                               |
 | Cockpit session closed                                                                            | All state is in labels                                | Start `/pipeline` again; it resumes from the labels. `retry #N` anything parked in an in-flight label                      |
 | Labels manually changed on GitHub                                                                 | Fine — labels are the source of truth                 | The next tick acts on whatever the labels say                                                                              |
+| Stale/locked worktrees under `.claude/worktrees/`                                                 | Agents cut off mid-run leave locked worktrees         | From the main checkout: `git worktree list`, then `git worktree remove --force <path>` and `git worktree prune`            |
+| An agent stopped with `BLOCKED:` or hit `maxTurns`                                                | Clean stop by design (not a crash)                    | Resolve the blocker (or widen scope/permissions), then `retry #N`                                                          |
 
 ## Reading current state without the cockpit
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,36 +1,10 @@
 {
   "permissions": {
     "allow": [
-      "Bash(gh issue view *)",
-      "Bash(gh issue edit *)",
-      "Bash(gh issue comment *)",
-      "Bash(gh issue create *)",
-      "Bash(gh issue list *)",
-      "Bash(gh pr list *)",
-      "Bash(gh pr view *)",
-      "Bash(gh pr diff *)",
-      "Bash(gh pr comment *)",
-      "Bash(gh pr edit *)",
-      "Bash(gh pr create *)",
-      "Bash(gh pr checks *)",
-      "Bash(gh label create *)",
-      "Bash(gh api repos/SGAOperations/aplio/*)",
-      "Bash(gh api graphql *)",
-      "Bash(git fetch *)",
-      "Bash(git checkout *)",
-      "Bash(git add *)",
-      "Bash(git commit *)",
-      "Bash(git push *)",
-      "Bash(git rebase *)",
-      "Bash(git reset *)",
-      "Bash(git branch *)",
-      "Bash(npm ci)",
-      "Bash(npm run prettier:check)",
-      "Bash(npm run prettier:fix)",
-      "Bash(npx prettier --write *)",
-      "Bash(npm run eslint:check)",
-      "Bash(npm run tsc:check)",
-      "Bash(npx prisma generate)",
+      "Bash(gh *)",
+      "Bash(git *)",
+      "Bash(npm *)",
+      "Bash(npx *)",
       "WebFetch(domain:nextjs.org)",
       "WebFetch(domain:ui.shadcn.com)",
       "WebFetch(domain:code.claude.com)"
@@ -40,7 +14,8 @@
       "Bash(gh issue delete *)",
       "Bash(gh repo delete *)",
       "Bash(git push * main)",
-      "Bash(git push origin main)"
+      "Bash(git push origin main)",
+      "Bash(npm publish *)"
     ]
   },
   "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" }

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pipeline
 description: Interactive pipeline cockpit — polls GitHub labels, dispatches background stage subagents, relays their questions, and runs the human gates conversationally. Run the session on haiku. Usage: /pipeline
-allowed-tools: Bash(gh issue list *) Bash(gh issue view *) Bash(gh issue edit *) Bash(gh issue comment *) Bash(gh pr list *) Bash(gh pr view *) Bash(gh pr edit *) Bash(gh pr comment *) Bash(gh api graphql *) Write
+allowed-tools: Bash(gh issue list *) Bash(gh issue view *) Bash(gh issue edit *) Bash(gh issue comment *) Bash(gh pr list *) Bash(gh pr view *) Bash(gh pr edit *) Bash(gh pr comment *) Bash(gh api graphql *) Write TaskList TaskStop
 ---
 
 # Pipeline Cockpit
@@ -17,6 +17,7 @@ You are the orchestrator of the agent pipeline in `.claude/docs/PIPELINE.md`. Th
 - Never act on issues/PRs that lack a pipeline **trigger** label — opt-in is human-initiated.
 - Never dispatch for an item with an **in-flight** label (`planning`, `in progress`, `reviewing`, `revising`) — an agent owns it or a human paused it.
 - Every dispatch runs in the background (`run_in_background: true`). Worktree isolation, model, tool scope, and permission mode all come from the subagent definition in `.claude/agents/` — you do not set them at the call site.
+- **Respect the draining flag:** while draining (see Stop controls), dispatch nothing new and schedule no wakeup; only report state and relay completions.
 
 ## Tick procedure
 
@@ -37,7 +38,7 @@ gh pr list --repo SGAOperations/aplio --label "approved" --json number,title
 gh pr list --repo SGAOperations/aplio --label "needs human" --json number,title
 ```
 
-Then, in order: **(1)** handle human gates, **(2)** dispatch for every actionable trigger item (all Agent calls in one message), **(3)** schedule the next wakeup.
+Then, in order: **(1)** handle human gates, **(2)** **unless draining,** dispatch for every actionable trigger item (all Agent calls in one message), **(3)** schedule the next wakeup (**skip while draining**).
 
 ## Dispatching
 
@@ -120,9 +121,20 @@ Interpret intent, not literal syntax:
 - **"pause #N"** — remove the item's current trigger label; confirm what was removed.
 - **"resume #N" / "retry #N"** — re-apply the trigger label for where it stalled (issue stuck in `planning` → `ready`; PR stuck in `revising` → `needs revision`; etc.).
 
+## Stop controls
+
+A session-level **draining** flag gates dispatch. Interpret these intents:
+
+- **"drain" / "pause the pipeline" / "finish current, start nothing new"** — set draining = on. Stop dispatching new agents and **stop scheduling wakeups**; let in-flight agents finish and keep relaying their completions. Report what is still running (`TaskList`).
+- **"resume" / "start" / "unpause"** — set draining = off and run one tick immediately.
+- **"stop #N" / "cancel #N"** — stop a single item: remove its trigger label; if an agent is in flight for it, find that agent with `TaskList` and `TaskStop` it; then reset its in-flight label back to the trigger so it can be retried.
+- **"stop everything" / "halt"** — set draining = on, `TaskStop` every running stage agent (`TaskList`), and reset each one's in-flight label to its trigger. Report what was halted.
+
+While draining, a tick still reports gates/announcements and relays completions, but dispatches nothing and schedules no wakeup. Note: closing the cockpit session also halts all dispatch (it is the only dispatcher), but cuts off in-flight background agents — `retry #N` after restart.
+
 ## Pacing
 
-After each tick, schedule the next wakeup with ScheduleWakeup, prompt `/pipeline`:
+After each tick, schedule the next wakeup with ScheduleWakeup, prompt `/pipeline` (**not while draining**):
 
 - Any agent in flight or any item mid-pipeline → ~270 seconds.
 - Fully idle → ~1500 seconds.


### PR DESCRIPTION
Closes #127

Hardening fixes from the live stress-test (findings F1–F10).

- **Permissions** (`.claude/settings.json`): broad `allow` (`gh`/`git`/`npm`/`npx`) + authoritative `deny` (`gh pr merge`, issue/repo delete, push-to-`main`, `npm publish`). Fixes the silent-denial stalls and harmful workarounds (F1, F2, F5, F6, F9, F10).
- **Agents** (`.claude/agents/*`): `disallowedTools: Agent` (no nesting) + `maxTurns` backstop (F4); operating-rules block — stay in your worktree, cwd-relative paths, Write tool not `cat >`, `npm` for deps (don't hand-edit lockfiles), STOP + `BLOCKED:` on denial (F5–F10); pinned CI recipes — `gh run view --log-failed`, `gh pr checks` `bucket` field, Vercel cite-link (F1, F3).
- **Cockpit** (`.claude/skills/pipeline`): `drain`/`resume`/`stop #N`/`halt` via `TaskList`/`TaskStop` (F8).
- **Docs** (`.claude/docs/PIPELINE.md`): broad-allow + deny model, stop controls, worktree-cleanup runbook.

Per decision: agents may edit CI workflow files and lockfiles, but are instructed to use `npm` first — no hard file-edit deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
