### PR TITLE
#129 Round 2 Pipeline Hardening: Convergence, Self-Posting Comments, npm Scripts, Output Formats

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -20,6 +20,7 @@ You are the Impl agent (Stage 2) of the pipeline in `.claude/docs/PIPELINE.md`. 
 - **You are already in your own isolated git worktree (your cwd).** Do all work here using **cwd-relative paths**. Never `cd` out of it, never use `git -C` on the main repo, never write to absolute `.claude/worktrees/…` paths.
 - **Files:** use the **Write/Edit tools** with cwd-relative paths. Never create files with `cat >` or heredocs.
 - **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
+- **Clean code only:** no dead scaffolding, shims, or transitional re-exports. Build to the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md`.
 - **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP and emit `BLOCKED: <summary>`** (see Blockers below). **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
@@ -43,7 +44,7 @@ gh issue edit N --repo SGAOperations/aplio --remove-label "plan approved" --add-
 
    ```bash
    npm ci
-   npx prisma generate
+   npm run prisma:generate
    ```
 
 3. **Implement the checklist.** Follow `.claude/docs/ENGINEERING.md` and project conventions: named exports only; server actions in `prisma/services/` each with auth check + zod validation; no API routes except `/api/auth`; Tailwind only; mobile-first responsive; strict TS, no `any`; server components by default, never `useEffect` for data fetching; every async surface ships loading + error + empty states. Commit each logical unit:
@@ -77,9 +78,14 @@ gh issue edit N --repo SGAOperations/aplio --remove-label "plan approved" --add-
 
    ```bash
    git push -u origin HEAD:N-ticket-name-in-kebab-case
+   ```
+
+   Then write the PR body to `.temp/pr-N.md` (Write tool) following the **PR description format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats" (`Closes #N` · **## Summary** · **## Changes** · **## Testing plan** as a runnable `- [ ]` checklist derived from the issue's Test/validation plan, covering happy-path + error/empty/edge + auth/roles · **## Automated checks** · **## Notes**), and open the PR:
+
+   ```bash
    gh pr create --repo SGAOperations/aplio \
      --title "#N <Ticket Title In Title Case>" \
-     --body "Closes #N" \
+     --body-file .temp/pr-N.md \
      --assignee "b-at-neu" \
      --head N-ticket-name-in-kebab-case
    ```

--- a/.claude/agents/plan-agent.md
+++ b/.claude/agents/plan-agent.md
@@ -60,7 +60,7 @@ mkdir -p .temp
 gh issue edit N --repo SGAOperations/aplio --body-file .temp/plan-N.md
 ```
 
-The plan must include: **Architecture decisions** (files to create/modify and why) · **Implementation checklist** as GitHub checkboxes (`- [ ]`) · **Edge cases & constraints** · **Schema changes** (Prisma) · **UX states** (loading/error/empty per async surface) · **Validation & auth** (zod + authorization scoping per server action) · **Test/validation plan** · **Conflicts flagged** (overlapping open branches).
+The plan must include: **Architecture decisions** (files to create/modify and why) · **Implementation checklist** as GitHub checkboxes (`- [ ]`) · **Edge cases & constraints** · **Schema changes** (Prisma) · **UX states** (loading/error/empty per async surface) · **Validation & auth** (zod + authorization scoping per server action) · **Test/validation plan** (written as **human-runnable manual steps** — this feeds the PR's Testing plan; see `.claude/docs/PIPELINE.md` → "Pipeline output formats") · **Conflicts flagged** (overlapping open branches).
 
 ## Handoff
 

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -49,7 +49,7 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "ready for revi
    ```bash
    gh pr diff <pr-number> --repo SGAOperations/aplio
    gh pr checks <pr-number> --repo SGAOperations/aplio    # failing required checks are Critical
-   gh pr view <pr-number> --repo SGAOperations/aplio --json body,title,headRefName   # find "Closes #XXX"
+   gh pr view <pr-number> --repo SGAOperations/aplio --json body,title,headRefName,headRefOid   # "Closes #XXX"; headRefOid = SHA for line permalinks
    gh issue view <issue-number> --repo SGAOperations/aplio   # the original plan
    ```
 
@@ -64,34 +64,47 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "ready for revi
 
    Note: `gh pr checks` exposes status in the **`bucket`** field (pass/fail/pending) if you pass `--json name,bucket,link` — there is **no** `status`/`conclusion` field on `gh pr checks`. For a failing **Vercel** check, cite the check name + its link as Critical; do not try to read Vercel logs.
 
-2. **Review the diff.** For each finding note file, line, severity, and whether it was **introduced in this PR** or is **preexisting**. Dimensions: **CI** (any failing required check = Critical, cite the check name) · **Correctness** vs. every plan checklist item · **Security** (OWASP, auth + zod on every server action, authorization scoping / no IDOR, input validation, dev-only code env-gated) · **Engineering standards** (cite `.claude/docs/ENGINEERING.md` §) · **Conventions** (named exports, no API routes except `/api/auth`, services in `prisma/services/`, Tailwind only, mobile-first, no `useEffect` data fetching) · **Type safety** (no `any`, Prisma-generated types) · **Performance** (revalidation after mutations, N+1) · **Completeness** (loading/error/empty per async surface).
+2. **Review the diff.** Be **exhaustive on the first review** — cover the whole changed surface across every dimension below. **Later reviews are delta-scoped** (the PR already has prior `## Code Review` comments): verify each prior Critical/Medium is resolved and check only for **regressions the revision introduced** — do not hunt fresh marginal issues. A genuinely-missed Critical/Medium still blocks; a new marginal item is noted Low/follow-up.
 
-3. **Post the review (file-based).** Write the comment to `.temp/review-<pr>.md` (Write tool), then post it — this avoids shell-quoting failures with the markdown/backticks in findings:
+   For each finding record: a **stable ID** (`R<cycle>-<sev><n>`, e.g. `R1-M2`), the **exact line(s)**, severity, **introduced** vs **preexisting**, and a **suggested fix**.
+
+   **Severity rubric — apply strictly; only Critical/Medium block:**
+   - **Critical** — broken behavior, security hole, or a failing required CI check.
+   - **Medium** — a clear correctness / convention / `ENGINEERING.md` violation, or a missing _required_ state (loading/error/empty, auth, validation).
+   - **Low** — improvements, **performance tradeoffs, "consider…" suggestions** (these are **never** Medium), by-design choices.
+   - **Nit** — style / naming.
+
+   Dimensions (use the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md` as the checklist): CI (failing required check = Critical) · correctness vs every plan checklist item · security (auth + zod on every action, authz scoping / no IDOR, dev-only code env-gated) · engineering standards (cite the §) · conventions (named exports, no API routes except `/api/auth`, services in `prisma/services/`, Tailwind/tokens, mobile-first, no `useEffect` fetching, shadcn primitives over raw elements, role-gated nav) · type safety (no `any`) · performance (revalidate after mutations, N+1) · completeness (all three async states + success/error feedback) · **no dead scaffolding/shims**.
+
+3. **Post the review (file-based).** Write the comment to `.temp/review-<pr>.md` (Write tool), then post it (avoids shell-quoting issues with markdown/backticks):
 
    ```bash
-   mkdir -p .temp
    gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/review-<pr>.md
    ```
 
-   Format (omit any empty severity section):
+   Follow the **PR-comment format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats". Each finding is a clickable permalink to the exact line(s) built from `headRefOid`. Omit empty sections; include the status sections only on later (delta) reviews:
 
    ```
    ## Code Review
 
-   ### Critical
-   - `path/to/file.ts:42` — issue
+   _review-agent · PR #<pr> · reviewed against plan in #<issue>_
 
-   ### Medium
-   - `path/to/file.ts:88` — issue
+   ### Resolved since last review        <!-- later reviews only -->
+   - **R<prev>-<id>** — confirmed fixed
+   ### Still open                          <!-- later reviews only -->
+   - **R<prev>-<id>** [`path:line`](permalink) — still unaddressed
 
-   ### Low
-   - `path/to/file.ts:15` — issue
-
-   ### Nit
-   - `path/to/file.ts:7` — issue
+   ### 🔴 Critical
+   - **R<c>-C1** [`path/file.ts:42`](https://github.com/SGAOperations/aplio/blob/<headRefOid>/path/file.ts#L42) — problem (introduced). **Suggested fix:** concrete approach.
+   ### 🟠 Medium
+   - **R<c>-M1** [`path/file.ts:88`](permalink) — problem (introduced). **Suggested fix:** …
+   ### 🟡 Low
+   - **R<c>-L1** [`path/file.ts:15`](permalink) — problem. **Suggested fix:** …
+   ### ⚪ Nit
+   - **R<c>-N1** [`path/file.ts:7`](permalink) — note.
 
    ---
-   _Reviewed against plan in issue #XXX_
+   _Posted by the agent pipeline._
    ```
 
 ## Handoff

--- a/.claude/agents/revise-agent.md
+++ b/.claude/agents/revise-agent.md
@@ -20,6 +20,8 @@ You are the Revise agent (Stage 4) of the pipeline in `.claude/docs/PIPELINE.md`
 - **You are already in your own isolated git worktree (your cwd).** Do all work here using **cwd-relative paths**. Never `cd` out of it, never use `git -C` on the main repo, never write to absolute `.claude/worktrees/…` paths.
 - **Files:** use the **Write/Edit tools** with cwd-relative paths. Never create files with `cat >` or heredocs.
 - **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
+- **Sync first:** before anything else, `git fetch origin` and rebase your branch onto the PR's **base branch** (step 2) — never work from stale state.
+- **Clean code only:** no dead scaffolding, shims, or transitional re-exports; don't reintroduce issues from the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md`.
 - **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP and emit `BLOCKED: <summary>`**. **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
@@ -27,10 +29,10 @@ You are the Revise agent (Stage 4) of the pipeline in `.claude/docs/PIPELINE.md`
 Resolve `$INPUT` to a PR number and capture its branch:
 
 ```bash
-gh pr view $INPUT --repo SGAOperations/aplio --json labels,title,headRefName
+gh pr view $INPUT --repo SGAOperations/aplio --json labels,title,headRefName,baseRefName
 ```
 
-If that fails (it's an issue number): `gh pr list --repo SGAOperations/aplio --search "closes #$INPUT" --json number,title,headRefName`. If no PR is found, stop and report: "No open PR found linked to issue #$INPUT. Nothing was changed."
+If that fails (it's an issue number): `gh pr list --repo SGAOperations/aplio --search "closes #$INPUT" --json number,title,headRefName,baseRefName`. If no PR is found, stop and report: "No open PR found linked to issue #$INPUT. Nothing was changed."
 
 Confirm the PR is labeled `needs revision`. If not, stop and report current labels; change nothing.
 
@@ -44,17 +46,17 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
 
 1. **Read the review.** `gh pr view <pr-number> --repo SGAOperations/aplio --comments` — find the most recent `## Code Review` comment; that is what you address. Also read `.claude/docs/ENGINEERING.md`.
 
-2. **Check out the PR branch in your worktree** (`<branch>` = the `headRefName` above), sync to remote, and rebase onto main:
+2. **Check out the PR branch in your worktree** (`<branch>` = `headRefName`, `<base>` = `baseRefName` from pre-flight), sync to remote, and rebase onto the PR's **base branch** (not assumed `main`):
 
    ```bash
    git fetch origin
    git checkout -B <branch> origin/<branch>
-   git rebase origin/main
+   git rebase origin/<base>
    npm ci
-   npx prisma generate
+   npm run prisma:generate
    ```
 
-   If the rebase conflicts: `git rebase --abort`, write the conflict description to `.temp/conflict-<pr>.md`, `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/conflict-<pr>.md`, `gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "revising" --add-label "needs human"`, and end with: `BLOCKED: rebase of <branch> onto origin/main conflicts in <files>; human decision needed.`
+   If the rebase conflicts: `git rebase --abort`, write the conflict description to `.temp/conflict-<pr>.md`, `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/conflict-<pr>.md`, `gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "revising" --add-label "needs human"`, and end with: `BLOCKED: rebase of <branch> onto origin/<base> conflicts in <files>; human decision needed.`
 
 3. **Apply fixes** per the review's decision table. Fix all Critical/Medium **introduced in this PR**; fix Low/Nit unless genuinely not an issue (explain skips). **Preexisting** findings of any severity: do not fix — note them as suggested future tickets in the summary. No scope creep beyond the review comment.
 
@@ -74,16 +76,16 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
    git push origin <branch>            # add --force-with-lease only if the rebase rewrote pushed commits
    ```
 
-6. **Post the summary (file-based).** Write to `.temp/revision-<pr>.md` (Write tool), then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/revision-<pr>.md`. Format (omit empty sections):
+6. **Post the summary (file-based).** Write to `.temp/revision-<pr>.md` (Write tool), then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/revision-<pr>.md`. Follow the **Revision Summary format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats": reference each review **finding ID** (e.g. `R2-M1`) and use clickable line permalinks. Format (omit empty sections):
 
    ```
    ## Revision Summary
 
    ### Fixed
-   - `path/to/file.ts:42` — what changed and why
+   - **R<c>-<id>** [`path/to/file.ts:42`](permalink) — what changed and why
 
    ### Skipped (not an issue)
-   - `path/to/file.ts:15` — why this is not actually a problem
+   - **R<c>-<id>** [`path/to/file.ts:15`](permalink) — why this is not actually a problem
 
    ### Preexisting issues — suggested for future tickets
    - description + suggested ticket scope

--- a/.claude/docs/ENGINEERING.md
+++ b/.claude/docs/ENGINEERING.md
@@ -138,3 +138,14 @@ if (applications.length === 0)
 - **Naming follows the neighborhood.** Match the file's existing patterns for casing, ordering, and component structure before introducing anything new.
 - **Comments explain constraints, not code.** A comment states a non-obvious invariant or external requirement; it never narrates what the next line does.
 - **Leave it better, narrowly.** Fix problems in code you touch when they affect your change; do not refactor unrelated code in a feature PR.
+
+## 8. Pre-PR self-check (shared by impl, revise, and review)
+
+A scannable summary of the issues that recur in this codebase. **impl** builds to it, **revise** must not reintroduce these, and **review** uses it as its dimensions. Detail lives in the sections above.
+
+- **Server actions:** every action authenticates, parses input with zod, and scopes the write to the caller — no IDOR. (§3)
+- **Queries:** `select` only rendered fields; never expose internal IDs or other users' data to client components; no N+1; `$transaction` for multi-step writes. (§2)
+- **Async states:** every async surface ships loading, error, **and** empty; mutations give success **and** error feedback (no silent failure); `revalidatePath`/`revalidateTag` after writes. (§4)
+- **Components:** server-first; `'use client'` only on the smallest leaf; never `useEffect` for data fetching; **use shadcn/Radix primitives, not hand-rolled raw elements**; gate nav items by role where the route is role-gated. (§1, §5)
+- **Conventions:** named exports only (except Next.js route files); services in `prisma/services/`; no API routes except `/api/auth`; **design tokens, never hardcoded colors** (`DESIGN.md`); strict TS, no `any`. (§1, §7)
+- **Hygiene:** no dead scaffolding, shims, or transitional re-exports; schema changes ship with their migration and are called out in the PR.

--- a/.claude/docs/PIPELINE.md
+++ b/.claude/docs/PIPELINE.md
@@ -19,7 +19,7 @@ Then talk to it: `work on #142` · `scope out a notifications feature` · `statu
 | --------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | 1. Describe     | "scope out X" — short conversation                                       | `/scope` creates the epic + sub-tickets, linked and dependency-ordered                                                          |
 | 2. Start        | "work on #N" + choose: review the plan, or auto-approve                  | `plan-agent` researches the codebase and writes a plan into the issue; its questions pop up in your terminal                    |
-| 3. Approve plan | Read the summary, approve — or give feedback (it revises and comes back) | `impl-agent` builds in an isolated worktree, runs CI, opens a PR; `review-agent`/`revise-agent` loop until clean (max 3 rounds) |
+| 3. Approve plan | Read the summary, approve — or give feedback (it revises and comes back) | `impl-agent` builds in an isolated worktree, runs CI, opens a PR; `review-agent`/`revise-agent` loop until clean (max 5 rounds) |
 | 4. Merge        | Click merge on GitHub                                                    | Issue closes automatically                                                                                                      |
 
 ### Bug fix
@@ -30,12 +30,12 @@ File the issue → in the cockpit: "work on #N, auto-approve the plan" → wait 
 
 - **Cockpit** (`/pipeline`, a skill) runs in the human's interactive session. It owns the conversation, the human gates (`AskUserQuestion`), and the wakeup schedule (`ScheduleWakeup`) — tools that only exist in a main session, not a subagent.
 - **Stage workers** are **subagents** in `.claude/agents/` (`plan-agent`, `impl-agent`, `review-agent`, `revise-agent`). Each carries its own `model`, tool scope, `permissionMode`, and (for the two that write code) `isolation: worktree` in its frontmatter. The cockpit dispatches by `subagent_type`; it sets nothing else at the call site.
-- **`impl-agent` and `revise-agent` get their own isolated git worktree** off `main` — a fresh checkout where they `npm ci` + `npx prisma generate`, do the work, and push a feature branch. No manual `git worktree`, symlinks, or `.env` are involved (the CI checks and Prisma generate need none).
+- **`impl-agent` and `revise-agent` get their own isolated git worktree** — a fresh checkout where they `npm ci` + `npm run prisma:generate`, do the work, and push a feature branch. impl branches from `main`; **revise rebases onto the PR's base branch** (`baseRefName`, not assumed `main`). No manual `git worktree`, symlinks, or `.env` are involved.
 - **`plan-agent` and `review-agent` are read-only on source** (`disallowedTools: Edit`); they only read code and write to GitHub via `gh`.
 
 ### Why background dispatch needs care
 
-Background subagents **auto-deny any tool call that would otherwise prompt** (they cannot show a permission dialog), so a too-tight allowlist makes them stall silently — and, worse, improvise harmful workarounds (hand-edited lockfiles, abandoned libraries). We therefore **allow broad dev-command categories** (`gh`/`git`/`npm`/`npx`) in `.claude/settings.json` and rely on the **`deny`** list for the few genuinely dangerous operations (deny beats allow at every scope). File edits are covered by each worker's `permissionMode: acceptEdits`. The worktree is a checkout of `main`, so it carries the committed `settings.json` — **permission changes take effect for dispatched agents only after they land on `main`.** Agents also run with **`disallowedTools: Agent`** (no nested subagents), a **`maxTurns`** backstop, and an explicit rule to **stop and emit `BLOCKED:` rather than improvise** when a command is denied.
+Background subagents **auto-deny any tool call that would otherwise prompt** (they cannot show a permission dialog), so a too-tight allowlist makes them stall silently — and, worse, improvise harmful workarounds (hand-edited lockfiles, abandoned libraries). We therefore **allow broad dev-command categories** (`gh`/`git`/`npm`) — with **`npx` scoped to `shadcn` only** (broad `npx` runs arbitrary packages, e.g. an interactive `npx vercel` login) — and use the **`deny`** list as the real safety surface for dangerous/interactive commands (merge, issue/repo delete, push-`main`, `npm publish`, `gh auth`, `npm login`/`adduser`, `vercel`). Deny beats allow at every scope. File edits are covered by each worker's `permissionMode: acceptEdits`. The worktree is a checkout of `main`, so it carries the committed `settings.json` — **permission changes take effect for dispatched agents only after they land on `main`.** Agents also run with **`disallowedTools: Agent`** (no nested subagents), a **`maxTurns`** backstop, and an explicit rule to **stop and emit `BLOCKED:` rather than improvise** when a command is denied.
 
 ### File-based GitHub I/O
 
@@ -69,7 +69,7 @@ Rule: **every stage agent's first action is swapping its trigger label for its i
 | `needs revision`   | `review-agent`                | trigger   | Dispatch `revise-agent` (subject to cycle cap)                  |
 | `revising`         | `revise-agent`                | in-flight | Fixes underway                                                  |
 | `approved`         | `review-agent`                | terminal  | Only Low/Nit findings; human merges on GitHub                   |
-| `needs human`      | Cockpit / `revise-agent`      | gate      | 3 cycles without convergence or rebase conflict; pipeline stops |
+| `needs human`      | Cockpit / `revise-agent`      | gate      | 5 cycles without convergence or rebase conflict; pipeline stops |
 
 ## Stages and models
 
@@ -93,16 +93,33 @@ The model is **broad allow + authoritative deny**: stage agents do real dev work
 | `Bash(gh *)`                                                      | all stages, cockpit | Issues/PRs/labels, the diff under review, CI status **and run logs** (`gh run view --log-failed`), `gh api` for version checks |
 | `Bash(git *)`                                                     | impl, revise        | All git **inside the agent's own worktree** (fetch/checkout/rebase/commit/push/worktree) — no `git -C` on main                 |
 | `Bash(npm *)`                                                     | impl, revise        | `npm ci`, plus `npm install`/`uninstall`/`view` for dependency tickets                                                         |
-| `Bash(npx *)`                                                     | impl, revise        | `npx prisma generate`, `npx prettier`, etc.                                                                                    |
+| `Bash(npx shadcn *)`                                              | impl, revise        | shadcn component CLI only; `npx` otherwise runs arbitrary packages — prettier/prisma/tsx go via `npm run`                      |
 | `WebFetch(domain:nextjs.org \| ui.shadcn.com \| code.claude.com)` | all stages          | Fetch current framework / Claude docs instead of stale recall                                                                  |
 
-File writes (source edits, `.temp/` payloads) are authorized by each worker's `permissionMode: acceptEdits`, not by `settings.json`.
+File writes: source edits via each worker's `permissionMode: acceptEdits`; `.temp/` scratch payloads via an explicit `Edit(.temp/**)` / `Write(.temp/**)` allow, so **every** component — including the no-worktree read-only agents and the cockpit — writes its `--body-file` payloads and **posts its own comments** without prompts.
 
-**Deny rules (`permissions.deny`) — the safety line:** `gh pr merge` (the human merge gate is absolute), `gh issue delete`, `gh repo delete`, pushes to `main` (`git push * main` / `git push origin main`), and `npm publish`. Deny beats allow at every scope, so these hold even with broad allows. _(Minor known gap: a `git push origin HEAD:main` refspec isn't caught by the `_ main`pattern — rely on the agent instruction + GitHub branch protection.)* Agents **may** edit CI workflow files and lockfiles (some tickets require it) but are instructed to use`npm`for dependencies and **not hand-edit`package.json`/`package-lock.json` as a workaround\*\*.
+**Deny rules (`permissions.deny`) — the safety surface:** `gh pr merge` (the human merge gate is absolute), `gh issue delete`, `gh repo delete`, `gh auth`, pushes to `main` (`git push * main` / `git push origin main`), `npm publish`, `npm login`, `npm adduser`, and `npx vercel` / `vercel` (interactive-auth footgun). Deny beats allow at every scope, so these hold even with broad allows. _(Minor known gap: a `git push origin HEAD:main` refspec isn't caught by the `_ main`pattern — rely on the agent instruction + GitHub branch protection.)* Agents **may** edit CI workflow files and lockfiles (some tickets require it) but are instructed to use`npm`for dependencies and **not hand-edit`package.json`/`package-lock.json` as a workaround\*\*.
+
+## Pipeline output formats
+
+Defined once here; the stage agents follow these exactly.
+
+### PR comments (review, revise, escalation; blockers go on the issue)
+
+- **Title keyword (no emoji):** `## Code Review` · `## Revision Summary` · `## Pipeline Escalation` (and `## Blocker` on issues). Keep the literal `Code Review` text — the cockpit's cycle-cap counts it.
+- **Provenance line** under the title: `_<stage> · PR #<pr> · against plan in #<issue>_`.
+- **Findings** carry a **stable ID** (`R<cycle>-<sev><n>`) and a **clickable permalink to the exact line(s)**: ``[`path/file.ts:42`](https://github.com/SGAOperations/aplio/blob/<headRefOid>/path/file.ts#L42)`` (range `#L42-L48`); get `<headRefOid>` from `gh pr view <pr> --json headRefOid`.
+- **Severity headers use colored circles:** `### 🔴 Critical` · `### 🟠 Medium` · `### 🟡 Low` · `### ⚪ Nit`. Only Critical/Medium block (review agent's rubric). Each finding ends with **`Suggested fix:`** (+ an alternative where useful).
+- **Later (delta) reviews** open with `### Resolved since last review` / `### Still open` (referencing prior IDs) before the new findings.
+- **Footer:** `_Posted by the agent pipeline._`
+
+### PR description (impl writes it via `gh pr create --body-file`)
+
+`Closes #N` · **## Summary** (what was built + approach) · **## Changes** (notable files/areas) · **## Testing plan** — reproducible **manual** steps as a `- [ ]` checklist a human runs before merge (setup → actions → expected results; happy-path + error/empty/edge + auth/roles; derived from the issue's Test/validation plan) · **## Automated checks** (prettier/eslint/tsc) · **## Notes** (schema/migrations, risks, follow-ups).
 
 ## Escalation
 
-- **Review ↔ revise non-convergence** — before each revise dispatch the cockpit counts `## Code Review` comments; at 3 with Critical/Medium still found it labels `needs human`, comments, and stops dispatching for it.
+- **Review ↔ revise non-convergence** — before each revise dispatch the cockpit counts `## Code Review` comments; at 5 with Critical/Medium still found it labels `needs human`, comments, and stops dispatching for it.
 - **Impl blocker** — `impl-agent` comments `## Blocker`, labels `blocked`, and reports `BLOCKED:`; the cockpit relays and resumes the same agent with the human's decision.
 - **Rebase conflict during revision** — `revise-agent` aborts the rebase, comments, labels `needs human`.
 - **Plan questions** — `plan-agent` never guesses: it returns `QUESTIONS FOR HUMAN:` and the cockpit relays, then resumes it with answers.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,9 @@
       "Bash(gh *)",
       "Bash(git *)",
       "Bash(npm *)",
-      "Bash(npx *)",
+      "Bash(npx shadcn *)",
+      "Edit(.temp/**)",
+      "Write(.temp/**)",
       "WebFetch(domain:nextjs.org)",
       "WebFetch(domain:ui.shadcn.com)",
       "WebFetch(domain:code.claude.com)"
@@ -13,9 +15,14 @@
       "Bash(gh pr merge *)",
       "Bash(gh issue delete *)",
       "Bash(gh repo delete *)",
+      "Bash(gh auth *)",
       "Bash(git push * main)",
       "Bash(git push origin main)",
-      "Bash(npm publish *)"
+      "Bash(npm publish *)",
+      "Bash(npm login *)",
+      "Bash(npm adduser *)",
+      "Bash(npx vercel *)",
+      "Bash(vercel *)"
     ]
   },
   "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" }

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -69,7 +69,7 @@ Stage → trigger mapping:
 gh pr view <pr-number> --repo SGAOperations/aplio --comments
 ```
 
-Count `## Code Review` occurrences. If **3 or more** reviews exist and the latest still produced Critical/Medium findings, escalate instead of dispatching: write the escalation note to `.temp/escalation-<pr>.md` (Write tool) and
+Count `## Code Review` occurrences. If **5 or more** reviews exist and the latest still produced Critical/Medium findings, escalate instead of dispatching: write the escalation note to `.temp/escalation-<pr>.md` (Write tool) and
 
 ```bash
 gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision" --add-label "needs human"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint:check": "eslint . --max-warnings=0",
     "eslint:fix": "eslint . --fix",
     "tsc:check": "tsc --noEmit",
+    "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "npx tsx --env-file=.env prisma/seed.ts",
     "db:start": "docker compose up -d",


### PR DESCRIPTION
Closes #129

Round 2 pipeline hardening (follow-up to #128), from re-testing — findings F11–F19.

- **Self-posting comments (F11/F12):** `Edit/Write(.temp/**)` allow so read-only agents (plan/review) and the cockpit write scratch files and post their **own** comments — no offloading, no per-file prompts. (`isolation: worktree` kept as fallback only — not needed.)
- **npm scripts + npx scope (F14):** added `prisma:generate` script; agents use `npm run …` for prettier/prisma; `npx` scoped to `shadcn` only; `deny` extended with `npx vercel`/`vercel`, `gh auth`, `npm login`, `npm adduser` — closes the `npx vercel` auth-tab footgun.
- **Reviewer convergence (F16/F17):** pinned severity rubric (perf/"consider" = Low, never Medium), exhaustive first review + delta-scoped later reviews, finding IDs + Resolved/Still-open status, and a `Suggested fix:` per finding.
- **Impl/revise discipline (F16/F18/F19):** shared Pre-PR self-check (new `ENGINEERING.md` §8), clean fixes (no dead shims), revise sync-first, rebase onto the PR's **base branch** (`baseRefName`, not hardcoded `main`).
- **Output formats (F13/F15):** standardized PR-comment format (no emoji titles, colored-circle severities, clickable exact-line permalinks) and PR-description format (Summary + human-runnable Testing-plan checklist) — defined once in `PIPELINE.md`.
- **Cycle cap 3 → 5 (F16).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
