### PR TITLE
#131 Round 3 Pipeline Hardening: Feature Quality, Inline Reviews, Worktree Reliability, Engineering Rules

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -17,8 +17,9 @@ You are the Impl agent (Stage 2) of the pipeline in `.claude/docs/PIPELINE.md`. 
 
 ## Operating rules (read first)
 
-- **You are already in your own isolated git worktree (your cwd).** Do all work here using **cwd-relative paths**. Never `cd` out of it, never use `git -C` on the main repo, never write to absolute `.claude/worktrees/…` paths.
+- **You are already in your own isolated git worktree (your cwd).** Do **all** work in-place with **cwd-relative paths**. **Never** `cd` out of it (incl. to the base repo), use `git -C`, run `git worktree list/add/remove/prune`, use `--ignore-other-worktrees`, or force anything.
 - **Files:** use the **Write/Edit tools** with cwd-relative paths. Never create files with `cat >` or heredocs.
+- **JSON/data:** use `gh … --json … --jq '…'` — never pipe to `python3` / `node -e` / interpreters.
 - **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
 - **Clean code only:** no dead scaffolding, shims, or transitional re-exports. Build to the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md`.
 - **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP and emit `BLOCKED: <summary>`** (see Blockers below). **Never spawn subagents; never improvise around a denial.**
@@ -47,7 +48,7 @@ gh issue edit N --repo SGAOperations/aplio --remove-label "plan approved" --add-
    npm run prisma:generate
    ```
 
-3. **Implement the checklist.** Follow `.claude/docs/ENGINEERING.md` and project conventions: named exports only; server actions in `prisma/services/` each with auth check + zod validation; no API routes except `/api/auth`; Tailwind only; mobile-first responsive; strict TS, no `any`; server components by default, never `useEffect` for data fetching; every async surface ships loading + error + empty states. Commit each logical unit:
+3. **Implement the checklist**, building to the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md` §8. Key conventions: server actions in **`prisma/actions/`**, data queries in **`prisma/data/`**, shared types/constants in **`lib/`** (reuse existing); every action authenticates + zod-validates, returns **`void`/data or `{ error }`** (never `{ ok }`; `throw` for unexpected) and gives a **toast** (`sonner`); **one global error boundary** (no per-page `error.tsx`); **no `useEffect`** (empty-deps especially); server-first; named exports; no API routes except `/api/auth`; Tailwind + `DESIGN.md` tokens; mobile-first; strict TS (no `any`); loading + empty states on every async surface. Commit each logical unit:
 
    ```bash
    git add <changed files>

--- a/.claude/agents/plan-agent.md
+++ b/.claude/agents/plan-agent.md
@@ -1,11 +1,11 @@
 ---
 name: plan-agent
 description: Pipeline Stage 1 — researches a GitHub issue and writes an implementation plan into its body. Dispatched by the /pipeline cockpit for issues labeled `ready` (fresh plan) or `plan changes requested` (revision). Reads code but never edits source.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, Write
 disallowedTools: Edit, Agent
 permissionMode: acceptEdits
-maxTurns: 60
+maxTurns: 100
 color: blue
 ---
 
@@ -16,6 +16,7 @@ You are the Plan agent (Stage 1) of the pipeline in `.claude/docs/PIPELINE.md`. 
 ## Operating rules (read first)
 
 - **Files:** use the **Write tool** with cwd-relative paths for `.temp/` payloads — never `cat >`/heredocs, never absolute `.claude/worktrees/…` paths. You do not edit source.
+- **JSON/data:** extract from `gh` output with `gh … --json … --jq '…'` or read the plain text — never pipe to `python3` / `node -e` / external interpreters.
 - **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP** and emit `QUESTIONS FOR HUMAN:` (below). **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
@@ -60,7 +61,12 @@ mkdir -p .temp
 gh issue edit N --repo SGAOperations/aplio --body-file .temp/plan-N.md
 ```
 
-The plan must include: **Architecture decisions** (files to create/modify and why) · **Implementation checklist** as GitHub checkboxes (`- [ ]`) · **Edge cases & constraints** · **Schema changes** (Prisma) · **UX states** (loading/error/empty per async surface) · **Validation & auth** (zod + authorization scoping per server action) · **Test/validation plan** (written as **human-runnable manual steps** — this feeds the PR's Testing plan; see `.claude/docs/PIPELINE.md` → "Pipeline output formats") · **Conflicts flagged** (overlapping open branches).
+The plan is a **product/UX design, not just a file checklist** — think through how the feature should actually work and look. It must include:
+
+- **UX/product spec** — the user flows (happy path **and** unhappy/edge paths), the layout & component hierarchy of each screen, key interactions, sensible defaults, and the **copy** (labels, empty-state and error messaging). **Design** each state; don't just list that it exists.
+- **Architecture decisions** — files to create/modify (server actions in `prisma/actions/`, queries in `prisma/data/`, components, shared `lib/` types/constants) and why.
+- **Implementation checklist** as GitHub checkboxes (`- [ ]`).
+- **Edge cases & constraints** · **Schema changes** (Prisma) · **Validation & auth** (zod + authorization scoping per action) · **Test/validation plan** (written as **human-runnable manual steps** — feeds the PR's Testing plan; see `.claude/docs/PIPELINE.md` → "Pipeline output formats") · **Conflicts flagged** (overlapping open branches).
 
 ## Handoff
 

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -16,6 +16,7 @@ You are the Review agent (Stage 3) of the pipeline in `.claude/docs/PIPELINE.md`
 ## Operating rules (read first)
 
 - **Files:** use the **Write tool** with cwd-relative paths for `.temp/` payloads — never `cat >`/heredocs, never absolute `.claude/worktrees/…` paths. You do not edit source.
+- **JSON/data:** use `gh … --json … --jq '…'` — never pipe to `python3` / `node -e` / interpreters.
 - **When blocked:** if a command is denied or you can't resolve something within 1–2 attempts, **STOP** and post the partial review with what you have. **Never spawn subagents; never improvise around a denial.**
 
 ## Pre-flight
@@ -49,8 +50,10 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "ready for revi
    ```bash
    gh pr diff <pr-number> --repo SGAOperations/aplio
    gh pr checks <pr-number> --repo SGAOperations/aplio    # failing required checks are Critical
-   gh pr view <pr-number> --repo SGAOperations/aplio --json body,title,headRefName,headRefOid   # "Closes #XXX"; headRefOid = SHA for line permalinks
+   gh pr view <pr-number> --repo SGAOperations/aplio --json body,title,headRefName,headRefOid,author   # "Closes #XXX"; headRefOid = line-permalink SHA; author = self-review check
    gh issue view <issue-number> --repo SGAOperations/aplio   # the original plan
+   gh api user --jq .login   # your login; equals author.login ⇒ self-authored PR ⇒ use COMMENT event (step 3)
+   gh pr view <pr-number> --repo SGAOperations/aplio --json reviews --jq '[.reviews[] | select(.body|startswith("## Code Review"))] | length'   # prior reviews → this cycle = that + 1
    ```
 
    Also read `.claude/docs/ENGINEERING.md` — it is a review dimension.
@@ -74,38 +77,46 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "ready for revi
    - **Low** — improvements, **performance tradeoffs, "consider…" suggestions** (these are **never** Medium), by-design choices.
    - **Nit** — style / naming.
 
-   Dimensions (use the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md` as the checklist): CI (failing required check = Critical) · correctness vs every plan checklist item · security (auth + zod on every action, authz scoping / no IDOR, dev-only code env-gated) · engineering standards (cite the §) · conventions (named exports, no API routes except `/api/auth`, services in `prisma/services/`, Tailwind/tokens, mobile-first, no `useEffect` fetching, shadcn primitives over raw elements, role-gated nav) · type safety (no `any`) · performance (revalidate after mutations, N+1) · completeness (all three async states + success/error feedback) · **no dead scaffolding/shims**.
+   Dimensions (use the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md` as the checklist):
+   - **UX/product quality** — is the feature _actually good_? layout & hierarchy, affordances, helpful copy, sensible defaults, the happy path **and** obvious edge/unhappy flows handled. Not just standards conformance.
+   - **CI** (failing required check = Critical) · **correctness** vs every plan checklist item.
+   - **Security** — auth + zod on every action, authz scoping / no IDOR, dev-only code env-gated, no sensitive/internal/other-users' fields reaching a client.
+   - **Error/feedback model** — server actions return `void`/data or `{ error }` (**never `{ ok }`**), throw for unexpected; **a toast for every action**; **one global error boundary, no per-page `error.tsx`**.
+   - **Conventions** — named exports (except route files); no API routes except `/api/auth`; **server actions in `prisma/actions/`, queries in `prisma/data/`, shared types/constants in `lib/`**; Tailwind/tokens; mobile-first; **no `useEffect` — empty-deps especially**; shadcn/Radix primitives over raw elements; role-gated nav; sensible abstraction / reused `lib` types (no over-abstraction).
+   - **Type safety** (no `any`) · **performance** (revalidate after mutations, N+1) · **completeness** (loading + empty states) · **no dead scaffolding/shims**.
 
-3. **Post the review (file-based).** Write the comment to `.temp/review-<pr>.md` (Write tool), then post it (avoids shell-quoting issues with markdown/backticks):
+3. **Post a real GitHub PR review** — inline line comments + a summary body (see `.claude/docs/PIPELINE.md` → "Pipeline output formats").
+
+   **Pick the event** by self-authorship (GitHub forbids `REQUEST_CHANGES`/`APPROVE` on your own PR):
+   - `gh api user --jq .login` **equals** the PR `author.login` (the common case — same account) → **`event: "COMMENT"`**.
+   - otherwise → `REQUEST_CHANGES` if any Critical/Medium, else `APPROVE`.
+
+   The pipeline **label** (set in Handoff) is the real control signal regardless of the event.
+
+   Build the payload with the **Write tool** at `.temp/review-<pr>.json`, then submit:
 
    ```bash
-   gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/review-<pr>.md
+   gh api repos/SGAOperations/aplio/pulls/<pr-number>/reviews --input .temp/review-<pr>.json
    ```
 
-   Follow the **PR-comment format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats". Each finding is a clickable permalink to the exact line(s) built from `headRefOid`. Omit empty sections; include the status sections only on later (delta) reviews:
+   Shape — `body` = the summary (cycle-numbered title, IDs, suggested fixes, status sections on delta reviews, and any **preexisting/non-diff** findings as `blob/<headRefOid>` permalinks); `comments[]` = **inline** findings on lines **in the diff** only:
 
+   ```json
+   {
+     "event": "COMMENT",
+     "body": "## Code Review — Cycle <n>\n\n_review-agent · PR #<pr> · against plan in #<issue>_\n\n### Resolved since last review (later reviews only)\n- **R<prev>-<id>** — confirmed fixed\n\n### 🔴 Critical\n- **R<n>-C1** — <problem>. Suggested fix: …\n### 🟠 Medium\n…\n\n---\n_Posted by the agent pipeline._",
+     "comments": [
+       {
+         "path": "path/file.ts",
+         "line": 42,
+         "side": "RIGHT",
+         "body": "**R<n>-M1** 🟠 Medium — <problem>. Suggested fix: …"
+       }
+     ]
+   }
    ```
-   ## Code Review
 
-   _review-agent · PR #<pr> · reviewed against plan in #<issue>_
-
-   ### Resolved since last review        <!-- later reviews only -->
-   - **R<prev>-<id>** — confirmed fixed
-   ### Still open                          <!-- later reviews only -->
-   - **R<prev>-<id>** [`path:line`](permalink) — still unaddressed
-
-   ### 🔴 Critical
-   - **R<c>-C1** [`path/file.ts:42`](https://github.com/SGAOperations/aplio/blob/<headRefOid>/path/file.ts#L42) — problem (introduced). **Suggested fix:** concrete approach.
-   ### 🟠 Medium
-   - **R<c>-M1** [`path/file.ts:88`](permalink) — problem (introduced). **Suggested fix:** …
-   ### 🟡 Low
-   - **R<c>-L1** [`path/file.ts:15`](permalink) — problem. **Suggested fix:** …
-   ### ⚪ Nit
-   - **R<c>-N1** [`path/file.ts:7`](permalink) — note.
-
-   ---
-   _Posted by the agent pipeline._
-   ```
+   `<n>` = prior review count + 1 (from pre-flight). Use the colored-circle severities (🔴/🟠/🟡/⚪). Inline `comments[]` must target lines **in the diff**; everything else goes in `body` with permalinks.
 
 ## Handoff
 

--- a/.claude/agents/revise-agent.md
+++ b/.claude/agents/revise-agent.md
@@ -17,8 +17,9 @@ You are the Revise agent (Stage 4) of the pipeline in `.claude/docs/PIPELINE.md`
 
 ## Operating rules (read first)
 
-- **You are already in your own isolated git worktree (your cwd).** Do all work here using **cwd-relative paths**. Never `cd` out of it, never use `git -C` on the main repo, never write to absolute `.claude/worktrees/…` paths.
+- **You are already in your own isolated git worktree (your cwd).** Do **all** work in-place with **cwd-relative paths**. **Never** `cd` out of it (including to the base repo), use `git -C`, run `git worktree list/add/remove/prune`, use `--ignore-other-worktrees`, or force anything. If a branch is locked to another worktree, **STOP + `BLOCKED:`** — never force or remove worktrees.
 - **Files:** use the **Write/Edit tools** with cwd-relative paths. Never create files with `cat >` or heredocs.
+- **JSON/data:** use `gh … --json … --jq '…'` (or plain `--comments`) — never pipe to `python3` / `node -e` / interpreters.
 - **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
 - **Sync first:** before anything else, `git fetch origin` and rebase your branch onto the PR's **base branch** (step 2) — never work from stale state.
 - **Clean code only:** no dead scaffolding, shims, or transitional re-exports; don't reintroduce issues from the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md`.
@@ -44,13 +45,20 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
 
 ## Work
 
-1. **Read the review.** `gh pr view <pr-number> --repo SGAOperations/aplio --comments` — find the most recent `## Code Review` comment; that is what you address. Also read `.claude/docs/ENGINEERING.md`.
+1. **Read the latest review.** Reviews are real GitHub PR reviews (see `.claude/docs/PIPELINE.md` → "Pipeline output formats") — read the most recent one's summary body **and** its inline line comments:
 
-2. **Check out the PR branch in your worktree** (`<branch>` = `headRefName`, `<base>` = `baseRefName` from pre-flight), sync to remote, and rebase onto the PR's **base branch** (not assumed `main`):
+   ```bash
+   gh pr view <pr-number> --repo SGAOperations/aplio --json reviews --jq '.reviews[-1].body'
+   gh api repos/SGAOperations/aplio/pulls/<pr-number>/comments --jq '.[] | "\(.path):\(.line) — \(.body)"'
+   ```
+
+   The latest review (titled `## Code Review — Cycle <n>`) is what you address — note its cycle `<n>`. Also read `.claude/docs/ENGINEERING.md`.
+
+2. **Check out the PR branch — detached, to avoid worktree branch-lock** (`<branch>` = `headRefName`, `<base>` = `baseRefName`). Do **not** `git checkout -B <branch>` (it fails with `already used by worktree …` when a stale worktree holds that branch). Use a detached checkout and push by refspec at the end:
 
    ```bash
    git fetch origin
-   git checkout -B <branch> origin/<branch>
+   git checkout --detach origin/<branch>
    git rebase origin/<base>
    npm ci
    npm run prisma:generate
@@ -73,13 +81,13 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
    ```bash
    git add <changed files>
    git commit -m "#<issue-number> address review feedback" -m "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
-   git push origin <branch>            # add --force-with-lease only if the rebase rewrote pushed commits
+   git push --force-with-lease origin HEAD:<branch>   # detached HEAD → PR branch (rebased ⇒ force-with-lease)
    ```
 
-6. **Post the summary (file-based).** Write to `.temp/revision-<pr>.md` (Write tool), then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/revision-<pr>.md`. Follow the **Revision Summary format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats": reference each review **finding ID** (e.g. `R2-M1`) and use clickable line permalinks. Format (omit empty sections):
+6. **Post the summary (file-based).** Write to `.temp/revision-<pr>.md` (Write tool), then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/revision-<pr>.md`. Follow the **Revision Summary format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats": title it `## Revision Summary — Cycle <n>` (the cycle of the review you addressed), reference each review **finding ID** (e.g. `R2-M1`), and use clickable line permalinks. Format (omit empty sections):
 
    ```
-   ## Revision Summary
+   ## Revision Summary — Cycle <n>
 
    ### Fixed
    - **R<c>-<id>** [`path/to/file.ts:42`](permalink) — what changed and why

--- a/.claude/docs/ENGINEERING.md
+++ b/.claude/docs/ENGINEERING.md
@@ -7,14 +7,16 @@ Stack context: Next.js App Router, Prisma, Tailwind CSS 4, shadcn/ui, Stack Auth
 ## 1. Architecture
 
 - **Server-first.** Every component is a server component until it provably needs interactivity, hooks, or browser APIs. Push `'use client'` to the smallest leaf possible — a page with one interactive button is a server page importing a small client component, not a client page.
-- **Data flows one way.** Server components fetch via service functions in `prisma/services/`; mutations go through server actions in `prisma/services/`; client components receive data as props. No fetching in client components, no `useEffect` synchronization, no API routes (except `/api/auth`).
+- **Data flows one way.** Server components fetch via **data-fetching functions in `prisma/data/`**; mutations go through **server actions in `prisma/actions/`**; client components receive data as props. No fetching in client components, no API routes (except `/api/auth`).
+- **Avoid `useEffect`.** In this server-first codebase almost every `useEffect` is a mistake — data fetching, deriving state from props, or syncing state all have better homes (server components, values computed during render, event handlers, `key` to reset state, `nuqs` for URL state). **An empty-deps `useEffect(() => {…}, [])` is essentially never correct here** — it almost always hides fetching/initialization that belongs server-side, so treat it as a near-automatic review finding. Use `useEffect` **only** to synchronize with a genuinely external system (a non-React widget, a subscription, a DOM measurement) when there is no alternative, and justify it with a comment.
 - **Composition over prop-drilling.** If a prop passes through more than two layers untouched, restructure: pass `children`, split the component, or fetch closer to where the data is used (server components make this cheap).
-- **Co-location.** Route-specific components live next to their route; anything used twice moves to `components/`. Service functions are grouped by domain (`application-actions.ts`, not `actions.ts`).
+- **Co-location & layering.** Route-specific components live next to their route; anything used twice moves to `components/`. **Server actions live in `prisma/actions/`, data-fetching queries in `prisma/data/`**, grouped by domain (`applications.ts`, never a catch-all `actions.ts`). **Shared types and constants are global — `lib/types.ts` and `lib/constants.ts` — not per-service files.**
+- **Abstract repetition, with judgment.** Logic, UI, types, constants, or zod schemas duplicated across **2+ places** get extracted to a single cohesive, intention-named home (`components/`, `lib/`, `prisma/{actions,data}/`). Don't abstract a single use or force unrelated cases into one helper (no premature/over-abstraction). Prefer composition and small focused units.
 - **Small files, one responsibility.** A component file that needs scrolling to understand is two components. A service file mixing unrelated domains is two service files.
 
 ## 2. Data & Integrity
 
-- **Select only what you render.** Default to `select`/`include` with explicit fields on every Prisma query touching user-facing lists. Never ship full rows to the client when three fields are rendered.
+- **Select what you render — but prefer reusing shared types.** Default to `select`/`include` with explicit fields. **However, prefer reusing an existing/abstracted query type even if it pulls slightly more data than a given view strictly needs** — a little over-fetch is worth one reused type over many near-identical bespoke ones (see §1 abstraction). **Hard limit:** this never overrides the server/client boundary (§3) — never widen a `select` to include sensitive, internal, or other-users' fields that reach a **client** component.
 - **No N+1.** Fetch relations with `include`/nested `select` in one query, never by mapping over results and querying per item.
 
 ```ts
@@ -65,27 +67,27 @@ const withdrawSchema = z.object({ applicationId: z.string().cuid() });
 
 export async function withdrawApplication(input: unknown) {
   const user = await getCurrentUser();
-  if (!user) return { ok: false as const, error: 'Not authenticated' };
+  if (!user) throw new Error('Unauthenticated'); // unexpected from the UI → generic message (§4)
 
   const parsed = withdrawSchema.safeParse(input);
-  if (!parsed.success) return { ok: false as const, error: 'Invalid input' };
+  if (!parsed.success) return { error: 'Invalid input' }; // user-facing → toast
 
   // Authorization: scope the write to the caller — no IDOR
   const result = await prisma.application.updateMany({
     where: { id: parsed.data.applicationId, applicantId: user.id },
     data: { status: ApplicationStatus.WITHDRAWN },
   });
-  if (result.count === 0) return { ok: false as const, error: 'Not found' };
+  if (result.count === 0) throw new Error('Application not found for caller'); // shouldn't be reachable from the UI
 
   revalidatePath('/applications');
-  return { ok: true as const };
+  // success: return nothing (or the updated record if the caller needs it)
 }
 ```
 
 - **Authorization ≠ authentication.** Being logged in is not permission. Every query/mutation is scoped to what the caller may see or change (`where: { ..., applicantId: user.id }` or an explicit role check). Watch for IDOR: any action taking an ID must verify the caller's right to that specific record.
 - **No mass assignment.** Never spread client input into `data:`. Build the `data` object explicitly from parsed, whitelisted fields.
 - **Server/client boundary.** No secrets, tokens, internal IDs beyond necessity, or other-users' data in props passed to client components. Anything serialized to the client is public to that user.
-- **Dev-only code is env-gated.** Anything like `prisma/services/dev-bypass.ts` must be impossible to trigger in production (explicit `NODE_ENV`/env-flag guard).
+- **Dev-only code is env-gated.** Anything like `prisma/actions/dev-bypass.ts` must be impossible to trigger in production (explicit `NODE_ENV`/env-flag guard).
 - **No raw SQL with interpolation.** Use Prisma query builders; if `$queryRaw` is unavoidable, use tagged-template parameters only.
 
 ## 4. UX Completeness
@@ -93,7 +95,8 @@ export async function withdrawApplication(input: unknown) {
 Every async surface ships **all three states** — loading, error, empty. A feature without them is incomplete, not minimal.
 
 - **Loading:** wrap slow server-component subtrees in `<Suspense>` with a skeleton that matches the final layout (no layout shift on resolve). Route-level `loading.tsx` for whole-page fetches.
-- **Error:** route segments with data fetching get an `error.tsx` boundary with a retry affordance. Server actions return typed `{ ok, error }` results that the form surfaces inline — never a silent failure or an unhandled throw rendered as a blank screen.
+- **Error:** use **one global error boundary** — `app/global-error.tsx` (root shell) plus a single route-group `error.tsx` with a retry affordance — **not** a per-page `error.tsx` in every route folder. The boundary is only for **unexpected render / data-fetch errors**; expected errors never reach it.
+- **Action results & feedback.** A server action either **succeeds** (returns nothing, or the relevant created/updated record) or returns **`{ error: 'message' }`** for a **user-facing** condition — **never `{ ok }`**. If something unexpected happens, **throw** (don't return a message that shouldn't be shown). **Every action gives toast feedback** (`sonner`): a success toast; a _specific_ error toast for a returned `{ error }`; a _generic_ error toast when the action **throws during an interaction**; a render-time throw hits the global boundary instead. Never leak internals.
 - **Empty:** zero-item lists render a designed empty state (icon, one-line explanation, primary action), not a blank container.
 
 ```tsx
@@ -143,9 +146,11 @@ if (applications.length === 0)
 
 A scannable summary of the issues that recur in this codebase. **impl** builds to it, **revise** must not reintroduce these, and **review** uses it as its dimensions. Detail lives in the sections above.
 
-- **Server actions:** every action authenticates, parses input with zod, and scopes the write to the caller — no IDOR. (§3)
-- **Queries:** `select` only rendered fields; never expose internal IDs or other users' data to client components; no N+1; `$transaction` for multi-step writes. (§2)
-- **Async states:** every async surface ships loading, error, **and** empty; mutations give success **and** error feedback (no silent failure); `revalidatePath`/`revalidateTag` after writes. (§4)
-- **Components:** server-first; `'use client'` only on the smallest leaf; never `useEffect` for data fetching; **use shadcn/Radix primitives, not hand-rolled raw elements**; gate nav items by role where the route is role-gated. (§1, §5)
-- **Conventions:** named exports only (except Next.js route files); services in `prisma/services/`; no API routes except `/api/auth`; **design tokens, never hardcoded colors** (`DESIGN.md`); strict TS, no `any`. (§1, §7)
-- **Hygiene:** no dead scaffolding, shims, or transitional re-exports; schema changes ship with their migration and are called out in the PR.
+- **Server actions:** authenticate, zod-parse input, scope writes to the caller (no IDOR). **Return `void`/relevant data on success, `{ error }` for user-facing failures, `throw` for unexpected ones — never `{ ok }`.** (§3, §4)
+- **Feedback:** **every action shows a toast** (`sonner`) — success, specific error for `{ error }`, generic on an unexpected throw; `revalidatePath`/`revalidateTag` after writes. (§4)
+- **Errors:** **one global boundary** (`global-error.tsx` + a single route-group `error.tsx`), **never per-page `error.tsx`**; expected errors are toasts, not the boundary. (§4)
+- **Queries:** `select` what's rendered but **reuse shared `lib` types** (slight over-fetch OK; never sensitive/internal/other-users' fields to a client); no N+1; `$transaction` for multi-step writes. (§2)
+- **Async states:** every async surface ships loading + empty (plus the error model above). (§4)
+- **Components:** server-first; `'use client'` only on the smallest leaf; **no `useEffect` (empty-deps especially)**; **shadcn/Radix primitives, not hand-rolled raw elements**; role-gate nav where the route is role-gated. (§1, §5)
+- **Structure & conventions:** server actions in `prisma/actions/`, queries in `prisma/data/`; **shared types/constants in `lib/types.ts`/`lib/constants.ts`** (not per-service); abstract repetition sensibly (no over-abstraction); named exports only (except route files); no API routes except `/api/auth`; **design tokens, never hardcoded colors**; strict TS, no `any`. (§1, §7)
+- **Hygiene:** no dead scaffolding/shims/transitional re-exports; schema changes ship with their migration. (§1)

--- a/.claude/docs/PIPELINE.md
+++ b/.claude/docs/PIPELINE.md
@@ -73,14 +73,14 @@ Rule: **every stage agent's first action is swapping its trigger label for its i
 
 ## Stages and models
 
-| Stage        | Definition                       | Model                                     | Why                                                     |
-| ------------ | -------------------------------- | ----------------------------------------- | ------------------------------------------------------- |
-| Cockpit      | `.claude/skills/pipeline/`       | haiku (session)                           | Mechanical: queries, label swaps, dispatch, relaying    |
-| 0. Scope     | `.claude/skills/scope/`          | inherits session (opus/fable recommended) | Highest-leverage thinking; human is in the conversation |
-| 1. Plan      | `.claude/agents/plan-agent.md`   | sonnet                                    | Research + writing; plan quality amplifies downstream   |
-| 2. Implement | `.claude/agents/impl-agent.md`   | sonnet                                    | Bulk of code volume; cost/quality sweet spot            |
-| 3. Review    | `.claude/agents/review-agent.md` | sonnet                                    | Must catch real issues reliably                         |
-| 4. Revise    | `.claude/agents/revise-agent.md` | sonnet                                    | Targeted fixes from a structured list                   |
+| Stage        | Definition                       | Model                                     | Why                                                                  |
+| ------------ | -------------------------------- | ----------------------------------------- | -------------------------------------------------------------------- |
+| Cockpit      | `.claude/skills/pipeline/`       | haiku (session)                           | Mechanical: queries, label swaps, dispatch, relaying                 |
+| 0. Scope     | `.claude/skills/scope/`          | inherits session (opus/fable recommended) | Highest-leverage thinking; human is in the conversation              |
+| 1. Plan      | `.claude/agents/plan-agent.md`   | **opus**                                  | Design-rich planning (UX/product spec); quality amplifies downstream |
+| 2. Implement | `.claude/agents/impl-agent.md`   | sonnet                                    | Bulk of code volume; cost/quality sweet spot                         |
+| 3. Review    | `.claude/agents/review-agent.md` | sonnet                                    | Must catch real issues reliably                                      |
+| 4. Revise    | `.claude/agents/revise-agent.md` | sonnet                                    | Targeted fixes from a structured list                                |
 
 All four workers read `.claude/docs/ENGINEERING.md` before working; the review agent treats it as a review dimension.
 
@@ -104,9 +104,11 @@ File writes: source edits via each worker's `permissionMode: acceptEdits`; `.tem
 
 Defined once here; the stage agents follow these exactly.
 
-### PR comments (review, revise, escalation; blockers go on the issue)
+### PR comments & reviews (review, revise, escalation; blockers on the issue)
 
-- **Title keyword (no emoji):** `## Code Review` · `## Revision Summary` · `## Pipeline Escalation` (and `## Blocker` on issues). Keep the literal `Code Review` text — the cockpit's cycle-cap counts it.
+The **code review is a real GitHub PR review** (`gh api …/pulls/<pr>/reviews --input`) — a summary body **plus inline line comments** on changed lines — not a plain comment. **Event:** `COMMENT` when the reviewer is the PR author (common case — same account; GitHub forbids `REQUEST_CHANGES`/`APPROVE` on your own PR), else `REQUEST_CHANGES` (Critical/Medium) or `APPROVE`. The pipeline **label** is the real control signal regardless. Revision summaries, escalations, and blockers use `gh … --body-file`.
+
+- **Title (no emoji, cycle-numbered):** `## Code Review — Cycle <n>` · `## Revision Summary — Cycle <n>` · `## Pipeline Escalation` (and `## Blocker` on issues). `<n>` = prior review count + 1. Keep the literal `Code Review` text — the cockpit's cycle-cap counts it.
 - **Provenance line** under the title: `_<stage> · PR #<pr> · against plan in #<issue>_`.
 - **Findings** carry a **stable ID** (`R<cycle>-<sev><n>`) and a **clickable permalink to the exact line(s)**: ``[`path/file.ts:42`](https://github.com/SGAOperations/aplio/blob/<headRefOid>/path/file.ts#L42)`` (range `#L42-L48`); get `<headRefOid>` from `gh pr view <pr> --json headRefOid`.
 - **Severity headers use colored circles:** `### 🔴 Critical` · `### 🟠 Medium` · `### 🟡 Low` · `### ⚪ Nit`. Only Critical/Medium block (review agent's rubric). Each finding ends with **`Suggested fix:`** (+ an alternative where useful).

--- a/.claude/docs/nextjs-notes.md
+++ b/.claude/docs/nextjs-notes.md
@@ -10,7 +10,7 @@ Current-behavior reference so agents don't code from stale training data. This r
 
 What that means in practice:
 
-- Data is fetched in **server components** via Prisma service functions (`prisma/services/`). Reading request data (`cookies()`, `headers()`, `searchParams`) opts a route into **dynamic (request-time) rendering** — expected for authed, per-user pages.
+- Data is fetched in **server components** via data-fetching functions in `prisma/data/`. Reading request data (`cookies()`, `headers()`, `searchParams`) opts a route into **dynamic (request-time) rendering** — expected for authed, per-user pages.
 - After a mutation, refresh caches explicitly with **`revalidatePath(path)`** or **`revalidateTag(tag)`** from the server action. This is the canonical pattern; always revalidate after a write.
 - Reference (previous model): https://nextjs.org/docs/app/guides/caching-without-cache-components and https://nextjs.org/docs/app/getting-started/revalidating
 

--- a/.claude/skills/add-prisma-model/SKILL.md
+++ b/.claude/skills/add-prisma-model/SKILL.md
@@ -21,8 +21,8 @@ Schema changes are high-risk; this runs only when you invoke it. Follow `.claude
 
    Inspect the generated SQL under `prisma/migrations/` for accidental data loss (drops, non-nullable columns without defaults on populated tables).
 
-4. **Regenerate the client:** `npx prisma generate`.
-5. **Update the service layer** in `prisma/services/` — new queries `select` only needed fields, fetch relations with `include`/nested `select` (no N+1), multi-step writes in `prisma.$transaction`. Use Prisma-generated types, not hand-written duplicates.
+4. **Regenerate the client:** `npm run prisma:generate`.
+5. **Update the data/action layer** — queries in `prisma/data/`, server actions in `prisma/actions/` (reuse shared `lib/` types): `select` needed fields, fetch relations with `include`/nested `select` (no N+1), multi-step writes in `prisma.$transaction`. Use Prisma-generated types, not hand-written duplicates.
 6. **Verify** — `npm run tsc:check`.
 
 > Migrations are committed with the feature. Call out the schema change explicitly in the PR/plan.

--- a/.claude/skills/build-route-states/SKILL.md
+++ b/.claude/skills/build-route-states/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-route-states
-description: Add the three required async states — loading, error, and empty — to a Next.js App Router route or data-driven component, per .claude/docs/ENGINEERING.md §4. Use when a route fetches data and is missing loading.tsx, error.tsx, a Suspense skeleton, or a designed empty state.
+description: Add loading, error, and empty handling to a Next.js App Router route — loading.tsx/Suspense skeletons, a designed empty state, and error handling via the GLOBAL boundary + toasts (no per-page error.tsx), per .claude/docs/ENGINEERING.md §4.
 allowed-tools: Read, Grep, Glob, Edit, Write
 ---
 
@@ -20,28 +20,9 @@ Every async surface ships **all three** states (`.claude/docs/ENGINEERING.md` §
    </Suspense>
    ```
 
-3. **Error** — add `error.tsx` (a client component) for the segment, with a retry affordance via `reset()`:
-
-   ```tsx
-   'use client';
-   export default function Error({
-     reset,
-   }: {
-     error: Error;
-     reset: () => void;
-   }) {
-     return (
-       <div className="text-card-foreground border-border rounded-lg border p-6">
-         <p className="text-sm">Something went wrong loading this page.</p>
-         <button onClick={reset} className="text-primary mt-2 text-sm">
-           Try again
-         </button>
-       </div>
-     );
-   }
-   ```
-
-   Server actions return typed `{ ok, error }` — surface those inline in forms; never render an unhandled throw as a blank screen.
+3. **Error — do NOT add a per-page `error.tsx`.** Errors are handled centrally (`.claude/docs/ENGINEERING.md` §4):
+   - **Unexpected render/data-fetch errors** → the **global** boundary (`app/global-error.tsx` + a single route-group `error.tsx`). Create those only if missing — never one per route.
+   - **Expected errors** (server-action failures) → surfaced as **toasts** (`sonner`): an action returns `{ error: 'message' }` (user-facing → specific toast) or **throws** (unexpected → generic toast). Never `{ ok }`, never a silent failure.
 
 4. **Empty** — zero-item lists render a designed empty state (icon + one-line explanation + primary action), not a blank container:
 

--- a/.claude/skills/new-feature-slice/SKILL.md
+++ b/.claude/skills/new-feature-slice/SKILL.md
@@ -11,8 +11,8 @@ Orchestrates the smaller skills into one vertical slice. Read `.claude/docs/ENGI
 ## Order of work
 
 1. **Schema (if needed)** — add models/fields via the `add-prisma-model` skill (manual migration), then regenerate.
-2. **Service layer** — query functions in `prisma/services/` that `select` only what's rendered and avoid N+1.
-3. **Mutations** — server action(s) via the `scaffold-server-action` skill (auth + zod + scoping + typed result + revalidate).
+2. **Data layer** — query functions in `prisma/data/` (reuse shared `lib/` types) that `select` what's rendered and avoid N+1.
+3. **Mutations** — server action(s) in `prisma/actions/` via the `scaffold-server-action` skill (auth + zod + scoping; return `void`/data or `{ error }`; revalidate; toast).
 4. **Route & data** — a server component page under `app/`, fetching via the service layer; `'use client'` only on small interactive leaves (run `rsc-boundary-check`).
 5. **Form** — via the `scaffold-form` skill where the feature has input.
 6. **States** — loading/error/empty via the `build-route-states` skill for every async surface.

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pipeline
 description: Interactive pipeline cockpit — polls GitHub labels, dispatches background stage subagents, relays their questions, and runs the human gates conversationally. Run the session on haiku. Usage: /pipeline
-allowed-tools: Bash(gh issue list *) Bash(gh issue view *) Bash(gh issue edit *) Bash(gh issue comment *) Bash(gh pr list *) Bash(gh pr view *) Bash(gh pr edit *) Bash(gh pr comment *) Bash(gh api graphql *) Write TaskList TaskStop
+allowed-tools: Bash(gh issue list *) Bash(gh issue view *) Bash(gh issue edit *) Bash(gh issue comment *) Bash(gh pr list *) Bash(gh pr view *) Bash(gh pr edit *) Bash(gh pr comment *) Bash(gh api graphql *) Bash(git worktree *) Write TaskList TaskStop
 ---
 
 # Pipeline Cockpit
@@ -40,6 +40,8 @@ gh pr list --repo SGAOperations/aplio --label "needs human" --json number,title
 
 Then, in order: **(1)** handle human gates, **(2)** **unless draining,** dispatch for every actionable trigger item (all Agent calls in one message), **(3)** schedule the next wakeup (**skip while draining**).
 
+**Worktree hygiene (each tick):** run `git worktree prune` (clears dangling registrations — safe), then remove the worktree of any item whose work is done (PR merged/closed or no active pipeline label) with `git worktree remove --force <exact path from \`git worktree list\`>`. **Never** remove a worktree for an item that is currently in-flight. (Revise's detached checkout already avoids branch-lock; this just prevents accumulation. Windows: use the exact listed path.)
+
 ## Dispatching
 
 One background subagent per actionable item. The `subagent_type` **is** the stage; everything else is in the agent definition:
@@ -66,10 +68,10 @@ Stage → trigger mapping:
 ### Cycle cap (before every revise dispatch)
 
 ```bash
-gh pr view <pr-number> --repo SGAOperations/aplio --comments
+gh pr view <pr-number> --repo SGAOperations/aplio --json reviews --jq '[.reviews[] | select(.body|startswith("## Code Review"))] | length'
 ```
 
-Count `## Code Review` occurrences. If **5 or more** reviews exist and the latest still produced Critical/Medium findings, escalate instead of dispatching: write the escalation note to `.temp/escalation-<pr>.md` (Write tool) and
+If that count is **5 or more** and the latest review still produced Critical/Medium findings, escalate instead of dispatching: write the escalation note to `.temp/escalation-<pr>.md` (Write tool) and
 
 ```bash
 gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision" --add-label "needs human"
@@ -106,7 +108,7 @@ When a background subagent completes, read its final message:
 
 Interpret intent, not literal syntax:
 
-- **"work on #N"** — opt-in. Ask (AskUserQuestion): plan gate **Interactive** or **Auto-approve**? Then:
+- **"work on #N"** — opt-in. Ask (AskUserQuestion): plan gate **Interactive** (review the plan — **default for features**, so the human shapes the UX before any code) or **Auto-approve** (only for small/bug-fix tickets). Then:
   ```bash
   gh issue edit <n> --repo SGAOperations/aplio --add-label "claude,ready"            # interactive
   gh issue edit <n> --repo SGAOperations/aplio --add-label "claude,ready,auto plan"  # auto-approve

--- a/.claude/skills/scaffold-form/SKILL.md
+++ b/.claude/skills/scaffold-form/SKILL.md
@@ -10,11 +10,11 @@ Wire a form to a Server Action with one zod schema as the source of truth for bo
 
 ## Steps
 
-1. **Read context.** Look at an existing form under `components/forms/` and the matching server action in `prisma/services/`. Use the shadcn `Form`/`FieldGroup` primitives (`@/components/ui`) and `@hookform/resolvers/zod`. If the server action doesn't exist yet, scaffold it first (see the `scaffold-server-action` skill).
-2. **Share the schema.** Define the zod schema once (co-located or in the service module) and import it on both sides. The server action re-parses input (never trust the client).
+1. **Read context.** Look at an existing form under `components/forms/` and the matching server action in `prisma/actions/`. Use the shadcn `Form`/`FieldGroup` primitives (`@/components/ui`) and `@hookform/resolvers/zod`. If the server action doesn't exist yet, scaffold it first (see the `scaffold-server-action` skill).
+2. **Share the schema.** Define the zod schema once (co-located, or in `lib/` if shared — reuse existing) and import it on both sides. The server action re-parses input (never trust the client).
 3. **Client component** (`'use client'`, smallest leaf):
    - `useForm({ resolver: zodResolver(schema) })`, shadcn `<Form>` + `<FormField>`/`<FormLabel>`/`<FormControl>`/`<FormMessage>` per field.
-   - Submit calls the server action; disable the submit button while `isSubmitting` (spinner); surface the action's `{ ok, error }` inline (toast via `sonner` or a `FormMessage`); preserve input on failure; reset/redirect on success.
+   - Submit calls the server action inside `try/catch`; disable the submit button while `isSubmitting` (spinner). On a returned `{ error }` → **specific error toast** (`sonner`) / inline `FormMessage`; on an unexpected `throw` → **generic error toast**; on success → **success toast** (and reset/redirect, using any returned record). Preserve input on failure. Never expect `{ ok }`.
    - Every input has a label; icon-only buttons get `aria-label`.
 4. **Progressive enhancement** where practical (the `<form action={...}>` path works without JS).
 5. **Tokens** — style via `.claude/docs/DESIGN.md` semantic tokens only; mobile-first widths.

--- a/.claude/skills/scaffold-server-action/SKILL.md
+++ b/.claude/skills/scaffold-server-action/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: scaffold-server-action
-description: Scaffold a new Server Action in prisma/services/ following Aplio conventions — auth check, zod validation, authorization scoping, typed result, and cache revalidation. Use when adding a mutation (create/update/delete/submit/withdraw) for this Next.js + Prisma app.
+description: Scaffold a new Server Action in prisma/actions/ following Aplio conventions — auth check, zod validation, authorization scoping, void/data-or-{error} return (throw for unexpected), toast feedback, and cache revalidation. Use when adding a mutation (create/update/delete/submit/withdraw) for this Next.js + Prisma app.
 allowed-tools: Read, Grep, Glob, Edit, Write
 ---
 
 # Scaffold a Server Action
 
-Generate a mutation as a Server Action in `prisma/services/`, meeting `.claude/docs/ENGINEERING.md` §2–3. Never put mutations in API routes or client components.
+Generate a mutation as a Server Action in `prisma/actions/`, meeting `.claude/docs/ENGINEERING.md` §2–4. Never put mutations in API routes or client components.
 
 ## Steps
 
-1. **Read context.** Skim `.claude/docs/ENGINEERING.md` §2 (Data & Integrity) and §3 (Security), and an existing file in `prisma/services/` to match the neighborhood's naming and style. Confirm the auth helper (`@/lib/auth/server`) and Prisma client import paths used in this repo.
-2. **Place it by domain.** Add to the matching domain file (e.g. `prisma/services/application-actions.ts`), or create one named by domain — never a catch-all `actions.ts`.
+1. **Read context.** Skim `.claude/docs/ENGINEERING.md` §2 (Data & Integrity), §3 (Security), §4 (action returns + toasts), and an existing file in `prisma/actions/` to match the neighborhood's naming and style. Confirm the auth helper (`@/lib/auth/server`) and Prisma client import paths. **Reuse shared types/constants from `lib/types.ts` / `lib/constants.ts`** — don't create per-service ones.
+2. **Place it by domain.** Add to the matching domain file in **`prisma/actions/`** (e.g. `prisma/actions/applications.ts`), or create one named by domain — never a catch-all `actions.ts`. (Data-fetching queries live in `prisma/data/`, not here.)
 3. **Follow this shape** (adapt names/fields; build `data` explicitly from parsed fields — no mass assignment; scope every write to the caller to prevent IDOR):
 
    ```ts
@@ -30,10 +30,10 @@ Generate a mutation as a Server Action in `prisma/services/`, meeting `.claude/d
 
    export async function doThing(input: unknown) {
      const user = await getCurrentUser();
-     if (!user) return { ok: false as const, error: 'Not authenticated' };
+     if (!user) throw new Error('Unauthenticated'); // unexpected in the UI → generic toast/boundary
 
      const parsed = inputSchema.safeParse(input);
-     if (!parsed.success) return { ok: false as const, error: 'Invalid input' };
+     if (!parsed.success) return { error: 'Invalid input' }; // user-facing → specific toast
 
      // Authorization: scope to the caller — never trust client-supplied ownership
      const result = await prisma.model.updateMany({
@@ -42,14 +42,14 @@ Generate a mutation as a Server Action in `prisma/services/`, meeting `.claude/d
          /* explicit, parsed fields only */
        },
      });
-     if (result.count === 0) return { ok: false as const, error: 'Not found' };
+     if (result.count === 0) throw new Error('Not found for caller'); // shouldn't be reachable from the UI
 
      revalidatePath('/relevant-path'); // or revalidateTag(...)
-     return { ok: true as const };
+     // success: return nothing (or the created/updated record if the caller needs it)
    }
    ```
 
 4. **Multi-step writes** → wrap in `prisma.$transaction` (e.g. mutation + audit log) so partial failure can't corrupt state.
 5. **Type safety** — input is `unknown` until zod parses it; use Prisma-generated types for results; no `any`.
-6. **Wire-up note** — remind the caller how the form/component should consume the `{ ok, error }` result (inline error, preserved input, success feedback). For the form side, pair with the form scaffold.
+6. **Wire-up & feedback** — the caller checks `if (result && 'error' in result)` → **specific error toast**; on success → **success toast** (and uses the returned record if any); an unexpected `throw` surfaces a **generic error toast** (`sonner`). Preserve input on failure. Pair with the form scaffold. (Errors that must **not** be shown to the user are thrown, not returned — §4.)
 7. **Verify** — run `npm run tsc:check` on the new file.

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -21,7 +21,7 @@ This is a conversation, not a form. Ask **one question at a time**, multiple cho
 - **Success criteria** — how a human verifies the feature works
 - **Decomposition** — independently shippable sub-tickets, each one PR-sized, ordered by dependency
 
-Read `.claude/docs/ENGINEERING.md` and the relevant parts of the codebase as needed so the decomposition reflects how this app is actually built (server components, services in `prisma/services/`, etc.).
+Read `.claude/docs/ENGINEERING.md` and the relevant parts of the codebase as needed so the decomposition reflects how this app is actually built (server components, server actions in `prisma/actions/`, queries in `prisma/data/`, etc.).
 
 ## 2. Present the breakdown — get approval before creating anything
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,12 @@ Next.js 16 (App Router, React 19) · Prisma 7 · Tailwind CSS 4 · shadcn/ui (Ra
 ## Architecture (the load-bearing rules — `.claude/docs/ENGINEERING.md` has the full bar)
 
 - **IMPORTANT: never create API routes** (`app/api/`). The only permitted route is `app/api/auth/[...path]/route.ts` (required by Neon Auth).
-- **Mutations are Server Actions** in `prisma/services/`, each with `'use server'`, an auth check, and zod validation, returning a typed `{ ok, error }` result.
-- **Data fetching is server-side** — server components call service functions in `prisma/services/`. **NEVER fetch data or sync state with `useEffect`.** Prisma never runs in a client component.
+- **Mutations are Server Actions** in `prisma/actions/`, each with `'use server'`, an auth check, and zod validation. They return **`void` / the relevant data on success, `{ error }` for a user-facing failure, and `throw` for unexpected ones — never `{ ok }`** (`.claude/docs/ENGINEERING.md` §4).
+- **Data fetching is server-side** — server components call data-fetching functions in `prisma/data/`; Prisma never runs in a client component. **Avoid `useEffect`** — almost every use is a mistake here, and an empty-deps `useEffect` is essentially never right.
 - **Default to server components**; add `'use client'` only for interactivity/hooks/browser APIs, on the smallest leaf possible.
-- **Every async surface ships loading, error, and empty states** (see `.claude/docs/ENGINEERING.md` §4).
+- **Every async surface ships loading + empty states**; errors use **one global boundary + toasts** (never per-page `error.tsx`); **every action gives a toast** (`sonner`) — see `.claude/docs/ENGINEERING.md` §4.
 - Components live in `components/` (`ui/` shadcn, `forms/`, `layouts/`, `features/`); route-specific components co-locate with their route.
+- **Shared types/constants live in `lib/` (`lib/types.ts`, `lib/constants.ts`) — reuse them** (a little over-fetch to reuse a type is fine; never expose sensitive/internal fields to a client). Abstract repetition sensibly; avoid over-abstraction.
 
 ## Code Style
 
@@ -27,7 +28,7 @@ Next.js 16 (App Router, React 19) · Prisma 7 · Tailwind CSS 4 · shadcn/ui (Ra
 - Tailwind only — avoid custom CSS. **Mobile-first**: base styles target mobile, add `md:`/`lg:` upward; sidebars collapse to a Sheet/drawer on small screens; no fixed pixel widths that break narrow viewports.
 - `async`/`await` over promise chains. Single-line loops/conditionals: no curly braces.
 - Comments explain non-obvious constraints, never narrate the next line.
-- `revalidatePath`/`revalidateTag` after every mutation.
+- `revalidatePath`/`revalidateTag` after every mutation; **toast feedback (`sonner`) on every action**.
 
 ## Commits, Branches, PRs
 
@@ -53,7 +54,7 @@ Never push with known failures. Use `npx prisma` (never `node_modules/.bin/prism
 ## Worktrees & local dev
 
 - Pipeline agents get their own isolated worktree automatically (`isolation: worktree`) — they handle setup; see `.claude/docs/PIPELINE.md`. Do not script worktree creation for them.
-- For manual local work in a worktree, install deps with `npm ci` (then `npx prisma generate`). **Do not `ln -s node_modules` — symlinks fall back to copies on Windows here.** Sync before resuming: `git fetch origin && git rebase origin/main`.
+- For manual local work in a worktree, install deps with `npm ci` (then `npm run prisma:generate`). **Do not `ln -s node_modules` — symlinks fall back to copies on Windows here.** Sync before resuming: `git fetch origin && git rebase origin/main`.
 
 ## Design Specs
 


### PR DESCRIPTION
Closes #131

Round 3 pipeline hardening (follow-up to #128/#130), from re-testing + the first human review of finished features — findings F20–F31.

**Feature quality (F24)**
- `plan-agent` now runs on **opus** and must produce a **UX/product spec** (flows, each state's design, interactions, copy, defaults, edge/unhappy paths) — not just a file checklist.
- Cockpit `work on #N` **defaults feature tickets to interactive plan review** (auto-approve is opt-in for small fixes).
- `review-agent` gains a **UX/product quality** review dimension.

**Worktree reliability (F20)**
- `revise-agent` uses a **detached checkout** of `origin/<branch>` + rebase onto the PR's base + `push HEAD:<branch>` — no branch-name collision.
- Cockpit **prunes/removes stale worktrees each tick**; strengthened cwd-only operating rules (no `git -C`/absolute `cd`/`git worktree`/force).

**Inline reviews + cycle (F22/F25)**
- Reviews are now real GitHub **PR reviews** with inline line comments (`COMMENT` event when self-authored), titled `## Code Review — Cycle <n>`; revise reads the latest review; revision summaries cycle-numbered.

**No interpreters (F21):** agents use `gh --jq`, never `python3`.

**ENGINEERING.md corrections (F23/F26/F27/F28/F29/F31)** — several fix rules that were wrong:
- `useEffect` red-flag rule (empty-deps = near-automatic Medium).
- **One global error boundary**, not per-page `error.tsx`.
- Server actions return **`void`/data or `{ error }`**, `throw` for unexpected — never `{ ok }`.
- Return-message-only-if-user-facing, else throw → generic toast (action) / boundary (render).
- **Toasts for all actions.**
- Abstraction rule (DRY with judgment).

**File org (F30):** canonical **`prisma/actions/` + `prisma/data/`**; global **`lib/types.ts`/`lib/constants.ts`**; prefer reusing types (slight over-fetch OK; security boundary absolute). Added `prisma:generate` script.

No `settings.json` change (F20 chose structural fixes + instruction, no deny/hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
