### PR TITLE
#75 My Applications View

### DIFF
--- a/app/(main)/(auth)/my-applications/loading.tsx
+++ b/app/(main)/(auth)/my-applications/loading.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function MyApplicationsLoading() {
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+
+      <Card className="gap-0 p-0">
+        <CardContent className="p-0">
+          <div className="hidden md:block">
+            <div className="border-b px-4 py-3">
+              <div className="grid grid-cols-4 gap-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-4 w-20" />
+                ))}
+              </div>
+            </div>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="border-b px-4 py-4 last:border-0">
+                <div className="grid grid-cols-4 gap-4">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-5 w-20 rounded-md" />
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-8 w-20 rounded-md" />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-col divide-y md:hidden">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex flex-col gap-3 p-4">
+                <div className="flex items-center justify-between gap-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-5 w-16 rounded-md" />
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-8 w-20 rounded-md" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(main)/(auth)/my-applications/page.tsx
+++ b/app/(main)/(auth)/my-applications/page.tsx
@@ -1,0 +1,25 @@
+import { getMyApplications } from '@/prisma/data/applications';
+
+import { getCurrentUser } from '@/lib/auth/server';
+
+import { MyApplicationsTable } from '@/components/features/my-applications-table';
+
+export default async function MyApplicationsPage() {
+  const user = await getCurrentUser();
+  const applications = await getMyApplications(user.id);
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          My Applications
+        </h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Track your drafts and submitted applications.
+        </p>
+      </div>
+
+      <MyApplicationsTable applications={applications} />
+    </div>
+  );
+}

--- a/app/(main)/(auth)/page.tsx
+++ b/app/(main)/(auth)/page.tsx
@@ -1,7 +1,55 @@
-export default function Home() {
+import { Suspense } from 'react';
+
+import { getCurrentUser } from '@/lib/auth/server';
+
+import { MyApplicationsWidget } from '@/components/features/my-applications-widget';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+function MyApplicationsWidgetSkeleton() {
   return (
-    <div className="flex w-full flex-col">
-      <h1>Welcome to Aplio</h1>
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="border-b px-4 py-3 last:border-0">
+            <div className="grid grid-cols-3 gap-4">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-5 w-20 rounded-md" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function Home() {
+  const user = await getCurrentUser();
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Welcome to Aplio
+        </h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Here&apos;s a summary of your applications.
+        </p>
+      </div>
+
+      <Suspense fallback={<MyApplicationsWidgetSkeleton />}>
+        <MyApplicationsWidget userId={user.id} />
+      </Suspense>
     </div>
   );
 }

--- a/components/features/my-applications-table.tsx
+++ b/components/features/my-applications-table.tsx
@@ -1,0 +1,125 @@
+import Link from 'next/link';
+
+import { FileText } from 'lucide-react';
+
+import { type MyApplicationListItem } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+import { ApplicationStatusBadge } from '@/components/features/status-badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface MyApplicationsTableProps {
+  applications: MyApplicationListItem[];
+}
+
+export function MyApplicationsTable({
+  applications,
+}: MyApplicationsTableProps) {
+  if (applications.length === 0)
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <FileText
+            className="text-muted-foreground size-12"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="text-base font-semibold">No applications yet</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Browse open positions to start your first application.
+            </p>
+          </div>
+          <Button asChild>
+            <Link href="/positions">Browse positions</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+
+  return (
+    <Card className="gap-0 p-0">
+      {/* Desktop table — hidden on mobile */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Position</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Applied</TableHead>
+              <TableHead>Action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {applications.map((app) => (
+              <TableRow key={app.id}>
+                <TableCell>
+                  <Link
+                    href={`/positions/${app.positionId}`}
+                    className="font-medium hover:underline"
+                  >
+                    {app.position.title}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <ApplicationStatusBadge status={app.status} />
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {app.status === 'draft' ? '—' : formatDate(app.submittedAt)}
+                </TableCell>
+                <TableCell>
+                  {app.status === 'draft' ? (
+                    <Button variant="outline" size="sm" asChild>
+                      <Link href={`/positions/${app.positionId}/apply`}>
+                        Continue
+                      </Link>
+                    </Button>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile stacked cards — shown only on mobile */}
+      <div className="flex flex-col divide-y md:hidden">
+        {applications.map((app) => (
+          <div key={app.id} className="flex flex-col gap-2 p-4">
+            <div className="flex items-center justify-between gap-2">
+              <Link
+                href={`/positions/${app.positionId}`}
+                className="font-medium hover:underline"
+              >
+                {app.position.title}
+              </Link>
+              <ApplicationStatusBadge status={app.status} />
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-muted-foreground text-sm">
+                {app.status === 'draft' ? 'Draft' : formatDate(app.submittedAt)}
+              </span>
+              {app.status === 'draft' && (
+                <Button variant="outline" size="sm" asChild>
+                  <Link href={`/positions/${app.positionId}/apply`}>
+                    Continue
+                  </Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/components/features/my-applications-widget.tsx
+++ b/components/features/my-applications-widget.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link';
+
+import { ArrowRight } from 'lucide-react';
+
+import {
+  getMyApplicationStatusCounts,
+  getRecentMyApplications,
+} from '@/prisma/data/applications';
+
+import { APPLICATION_STATUS_LABELS } from '@/lib/constants';
+import { type MyApplicationListItem } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+import { ApplicationStatusBadge } from '@/components/features/status-badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface MyApplicationsWidgetProps {
+  userId: string;
+}
+
+function buildCountsSummary(counts: Partial<Record<string, number>>): string {
+  // Drafts shown separately; skip zero counts.
+  const draftCount = counts['draft'] ?? 0;
+  const submittedParts: string[] = [];
+
+  const statusOrder = [
+    'applied',
+    'reached_out',
+    'interview_scheduled',
+    'reviewing',
+    'accepted',
+    'rejected',
+  ] as const;
+
+  for (const status of statusOrder) {
+    const count = counts[status];
+    if (count && count > 0)
+      submittedParts.push(
+        `${count} ${APPLICATION_STATUS_LABELS[status].toLowerCase()}`,
+      );
+  }
+
+  const parts: string[] = [];
+  if (submittedParts.length > 0) parts.push(...submittedParts);
+  if (draftCount > 0)
+    parts.push(`${draftCount} ${draftCount === 1 ? 'draft' : 'drafts'}`);
+
+  return parts.join(' · ');
+}
+
+export async function MyApplicationsWidget({
+  userId,
+}: MyApplicationsWidgetProps) {
+  const [applications, counts] = await Promise.all([
+    getRecentMyApplications(userId),
+    getMyApplicationStatusCounts(userId),
+  ]);
+
+  const summary = buildCountsSummary(counts);
+
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-base font-semibold">
+              My Applications
+            </CardTitle>
+            {summary && (
+              <p className="text-muted-foreground mt-1 text-sm">{summary}</p>
+            )}
+          </div>
+          <Link
+            href="/my-applications"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
+          >
+            View all
+            <ArrowRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {applications.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-center">
+            <p className="text-muted-foreground text-sm">
+              You haven&apos;t started any applications yet.
+            </p>
+            <Link
+              href="/positions"
+              className="text-primary text-sm font-medium hover:underline"
+            >
+              Browse positions
+            </Link>
+          </div>
+        ) : (
+          <CompactApplicationTable applications={applications} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CompactApplicationTable({
+  applications,
+}: {
+  applications: MyApplicationListItem[];
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Position</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Applied</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {applications.map((app) => (
+          <TableRow key={app.id}>
+            <TableCell>
+              <Link
+                href={`/positions/${app.positionId}`}
+                className="font-medium hover:underline"
+              >
+                {app.position.title}
+              </Link>
+            </TableCell>
+            <TableCell>
+              <ApplicationStatusBadge status={app.status} />
+            </TableCell>
+            <TableCell className="text-muted-foreground">
+              {app.status === 'draft' ? '—' : formatDate(app.submittedAt)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/components/features/status-badge.tsx
+++ b/components/features/status-badge.tsx
@@ -1,0 +1,22 @@
+import { type $Enums } from '@/prisma/client';
+
+import {
+  APPLICATION_STATUS_BADGE_VARIANT,
+  APPLICATION_STATUS_LABELS,
+} from '@/lib/constants';
+
+import { Badge } from '@/components/ui/badge';
+
+interface ApplicationStatusBadgeProps {
+  status: $Enums.ApplicationStatus;
+}
+
+export function ApplicationStatusBadge({
+  status,
+}: ApplicationStatusBadgeProps) {
+  return (
+    <Badge variant={APPLICATION_STATUS_BADGE_VARIANT[status]}>
+      {APPLICATION_STATUS_LABELS[status]}
+    </Badge>
+  );
+}

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -5,28 +5,13 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 
-import {
-  BriefcaseBusiness,
-  ClipboardList,
-  FileText,
-  Menu,
-  Users,
-} from 'lucide-react';
+import { Menu } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+import { adminNavItems, baseNavItems } from '@/components/layouts/nav-items';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
-
-const baseNavItems = [
-  { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
-  { href: '/applications', label: 'Applications', icon: FileText },
-  { href: '/users', label: 'Users', icon: Users },
-];
-
-const adminNavItems = [
-  { href: '/global-questions', label: 'Global Questions', icon: ClipboardList },
-];
 
 interface MobileNavProps {
   isAdmin: boolean;

--- a/components/layouts/nav-items.ts
+++ b/components/layouts/nav-items.ts
@@ -1,0 +1,18 @@
+import {
+  BriefcaseBusiness,
+  ClipboardList,
+  FileText,
+  Inbox,
+  Users,
+} from 'lucide-react';
+
+export const baseNavItems = [
+  { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
+  { href: '/my-applications', label: 'My Applications', icon: Inbox },
+];
+
+export const adminNavItems = [
+  { href: '/applications', label: 'Applications', icon: FileText },
+  { href: '/users', label: 'Users', icon: Users },
+  { href: '/global-questions', label: 'Global Questions', icon: ClipboardList },
+];

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -4,24 +4,9 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-import {
-  BriefcaseBusiness,
-  ClipboardList,
-  FileText,
-  Users,
-} from 'lucide-react';
-
 import { cn } from '@/lib/utils';
 
-const baseNavItems = [
-  { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
-  { href: '/applications', label: 'Applications', icon: FileText },
-  { href: '/users', label: 'Users', icon: Users },
-];
-
-const adminNavItems = [
-  { href: '/global-questions', label: 'Global Questions', icon: ClipboardList },
-];
+import { adminNavItems, baseNavItems } from '@/components/layouts/nav-items';
 
 interface SidebarProps {
   isAdmin: boolean;

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import { type VariantProps, cva } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+        success:
+          'border-transparent bg-success text-success-foreground shadow hover:bg-success/80',
+        warning:
+          'border-transparent bg-warning text-warning-foreground shadow hover:bg-warning/80',
+        info: 'border-transparent bg-info text-info-foreground shadow hover:bg-info/80',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  },
+);
+
+export type BadgeVariant = NonNullable<
+  VariantProps<typeof badgeVariants>['variant']
+>;
+
+export interface BadgeProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-muted animate-pulse rounded-md', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn('[&_tr]:border-b', className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-muted-foreground h-10 px-4 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-4 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod/v4';
 
+import { $Enums } from '@/prisma/client';
+
+import type { BadgeVariant } from '@/components/ui/badge';
+
 export const QUESTION_TYPE_VALUES = [
   'short_answer',
   'long_answer',
@@ -28,3 +32,32 @@ export const baseQuestionSchema = z.object({
   required: z.boolean(),
   options: z.array(z.string()),
 });
+
+// Human-readable labels for each application status.
+// Keyed on the generated ApplicationStatus enum for build-time exhaustiveness.
+export const APPLICATION_STATUS_LABELS: Record<
+  $Enums.ApplicationStatus,
+  string
+> = {
+  draft: 'Draft',
+  applied: 'Applied',
+  reached_out: 'Reached out',
+  interview_scheduled: 'Interview scheduled',
+  reviewing: 'Reviewing',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+};
+
+// Badge variant for each application status, using design-system tokens.
+export const APPLICATION_STATUS_BADGE_VARIANT: Record<
+  $Enums.ApplicationStatus,
+  BadgeVariant
+> = {
+  draft: 'secondary',
+  applied: 'info',
+  reached_out: 'info',
+  interview_scheduled: 'info',
+  reviewing: 'warning',
+  accepted: 'success',
+  rejected: 'destructive',
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,3 +28,15 @@ export type GlobalQuestionListItem = Prisma.GlobalQuestionGetPayload<{
     updatedAt: true;
   };
 }>;
+
+// Shared type for application list rows — reused by the full table and the dashboard widget.
+export type MyApplicationListItem = Prisma.ApplicationGetPayload<{
+  select: {
+    id: true;
+    status: true;
+    submittedAt: true;
+    updatedAt: true;
+    positionId: true;
+    position: { select: { id: true; title: true } };
+  };
+}>;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,3 +23,11 @@ export function toStringArray(v: unknown): string[] {
   if (Array.isArray(v) && v.every((x) => typeof x === 'string')) return v;
   return [];
 }
+
+export function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -1,0 +1,49 @@
+import 'server-only';
+
+import { $Enums } from '@/prisma/client';
+
+import prisma from '@/lib/prisma';
+import { type MyApplicationListItem } from '@/lib/types';
+
+const applicationSelect = {
+  id: true,
+  status: true,
+  submittedAt: true,
+  updatedAt: true,
+  positionId: true,
+  position: { select: { id: true, title: true } },
+} as const;
+
+export async function getMyApplications(
+  userId: string,
+): Promise<MyApplicationListItem[]> {
+  return prisma.application.findMany({
+    where: { userId, deletedAt: null },
+    select: applicationSelect,
+    orderBy: { updatedAt: 'desc' },
+  });
+}
+
+export async function getRecentMyApplications(
+  userId: string,
+  take = 5,
+): Promise<MyApplicationListItem[]> {
+  return prisma.application.findMany({
+    where: { userId, deletedAt: null },
+    select: applicationSelect,
+    orderBy: { updatedAt: 'desc' },
+    take,
+  });
+}
+
+export async function getMyApplicationStatusCounts(
+  userId: string,
+): Promise<Partial<Record<$Enums.ApplicationStatus, number>>> {
+  const rows = await prisma.application.groupBy({
+    by: ['status'],
+    where: { userId, deletedAt: null },
+    _count: true,
+  });
+
+  return Object.fromEntries(rows.map((r) => [r.status, r._count]));
+}


### PR DESCRIPTION
Closes #75

## Summary

- Adds a `/my-applications` page where authenticated users can view all their applications (drafts and submitted) in a responsive table with status badges and a "Continue" CTA for drafts
- Adds a `MyApplicationsWidget` component on the home dashboard (`/`) showing a counts-by-status summary and up to 5 most recent applications, wrapped in `<Suspense>` for streaming
- Adds a "My Applications" nav item to both the desktop sidebar and mobile hamburger menu

## Changes

**New UI primitives** (`components/ui/`)
- `badge.tsx` — shadcn-style Badge with `success`, `warning`, `info`, `destructive`, `secondary`, and `outline` variants using design-system tokens
- `skeleton.tsx` — `animate-pulse` skeleton primitive for loading states
- `table.tsx` — shadcn-style Table family (Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption)

**Shared modules** (`lib/`)
- `lib/constants.ts` — `APPLICATION_STATUS_LABELS` and `APPLICATION_STATUS_BADGE_VARIANT` maps, keyed on the generated `ApplicationStatus` enum (exhaustive — new status values are a compile error until mapped)
- `lib/types.ts` — adds `MyApplicationListItem` (`Prisma.ApplicationGetPayload`) as the single shared type for the page table and widget

**Data layer** (`prisma/data/applications.ts`)
- `getMyApplications(userId)` — all non-deleted applications for the user, `updatedAt` desc
- `getRecentMyApplications(userId, take=5)` — same shape, limited to 5 (paginated at DB level)
- `getMyApplicationStatusCounts(userId)` — `groupBy` aggregation in the database, not JS; returns `Partial<Record<ApplicationStatus, number>>`

**Feature components** (`components/features/`)
- `status-badge.tsx` — `ApplicationStatusBadge` wrapping `Badge` with label + variant from `lib/constants.ts`
- `my-applications-table.tsx` — full table with desktop Table layout and mobile stacked-card layout (no overflow at 375px); designed empty state with icon + "Browse positions" CTA
- `my-applications-widget.tsx` — compact dashboard card with counts summary, 5-row table, empty state, and "View all" link; self-contained async server component so #78 can reuse it

**Routes** (`app/(main)/(auth)/my-applications/`)
- `page.tsx` — server component, calls `getCurrentUser()` then `getMyApplications`
- `loading.tsx` — skeleton matching the table layout (header + 5 rows desktop / 4 rows mobile)

**Navigation** (`components/layouts/`)
- `nav-items.ts` — extracted shared navItems array (eliminates duplication between Sidebar and MobileNav)
- `sidebar.tsx`, `mobile-nav.tsx` — updated to consume shared navItems; "My Applications" (`ClipboardList` icon) added between Positions and Applications

**Home page** (`app/(main)/(auth)/page.tsx`)
- Replaces placeholder with welcome heading + `<Suspense>`-wrapped `MyApplicationsWidget`

## Testing plan

- [x] Sign in as a normal user; confirm "My Applications" item appears in the desktop sidebar and mobile hamburger menu (resize to <768px) and clicking it lands on `/my-applications`
- [x] On `/my-applications`, verify a row per application sorted most-recently-updated first; each row shows position title (link), status badge with correct label and color (Applied=info, Reviewing=warning, Accepted=success, Rejected=destructive, Draft=secondary), and Applied date for submitted rows
- [x] A draft row shows "—" in the Applied column, "Draft" label in mobile view, and a "Continue" action button; clicking Continue lands on `/positions/{id}/apply` with the existing draft loaded and no duplicate application created
- [x] Submitted rows have no "Continue" action (shows "—") and display a real applied date in "Jun 22, 2026" format
- [x] Clicking a position title navigates to `/positions/{id}` (note: per-id route may not exist yet — link degrades gracefully as a normal `<a>`)
- [x] Switch to a user with zero applications; `/my-applications` shows the designed empty state ("No applications yet" / "Browse positions" button), not a blank table; the button routes to `/positions`
- [x] Throttle network in DevTools and reload `/my-applications`; a table-shaped skeleton appears before content with no layout shift on resolve
- [x] Force the data fetch to throw (e.g., by temporarily breaking the DB connection); confirm the shared `(main)` error boundary renders with retry — no per-page error UI
- [x] On `/`, the "My Applications" card shows a counts summary (e.g. "2 applied · 1 interview scheduled"), up to 5 most-recent rows, and a "View all" link to `/my-applications`; only non-zero statuses appear in the summary
- [x] As a user with only drafts, the summary reads "N draft(s)" and the draft row appears in the widget
- [x] As the zero-applications user, the widget shows the compact empty line ("You haven't started any applications yet.") + "Browse positions" link, not an empty table
- [ ] The dashboard paints its welcome heading immediately; the widget area shows its skeleton then resolves (Suspense streaming)
- [x] Confirm User A on `/my-applications` sees only their own applications (switch between two seeded users via bypass login and verify lists differ — no cross-user rows)
- [x] At 375px, the full table collapses to stacked cards with no horizontal overflow; touch targets (Continue, title link) are comfortably tappable; re-check at 768px and 1280px
- [x] Toggle light/dark theme; status badges and surfaces read correctly in both (tokens, no hardcoded colors)
- [x] `npm run prettier:check`, `npm run eslint:check`, `npm run tsc:check` all pass

## Automated checks

All three checks pass cleanly on the branch:
- `npm run prettier:check` — clean
- `npm run eslint:check` — clean (0 warnings)
- `npm run tsc:check` — clean

## Notes

- **Position detail route:** title links point to `/positions/{positionId}`; if no per-id detail route exists yet the link degrades gracefully (row is still usable via Continue). This was a known open question in the plan.
- **`submittedAt` for drafts:** the schema sets `submittedAt` to `now()` at draft creation; the Applied column renders "—" for all draft-status rows instead of showing this misleading timestamp. All sort keys use `updatedAt`.
- **Caching:** these are per-user dynamic reads (depend on the resolved session); no explicit `revalidateTag` is needed since there are no mutations in this feature.
- **#78 reuse:** `MyApplicationsWidget`, `getRecentMyApplications`, `getMyApplicationStatusCounts`, `MyApplicationListItem`, `APPLICATION_STATUS_LABELS`, and `APPLICATION_STATUS_BADGE_VARIANT` are all exportable and ready for the #78 dashboard to compose — no re-implementation needed.
