### PR TITLE
#64 Position Applications: Table View With Status Updates

### DIFF
--- a/app/(main)/(auth)/positions/[id]/applications/loading.tsx
+++ b/app/(main)/(auth)/positions/[id]/applications/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function PositionApplicationsLoading() {
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      {/* Header skeleton */}
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-4 w-28" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="rounded-lg border">
+        <div className="border-b p-4">
+          <div className="flex gap-4">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b p-4 last:border-b-0"
+          >
+            <div className="flex flex-1 flex-col gap-1">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-44" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/(auth)/positions/[id]/applications/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/applications/page.tsx
@@ -39,9 +39,9 @@ export default async function PositionApplicationsPage({
     <div className="mx-auto flex max-w-5xl flex-col gap-6">
       <div>
         <Button variant="ghost" size="sm" asChild className="mb-2 -ml-2">
-          <Link href={`/positions/${id}/edit`}>
+          <Link href="/positions">
             <ArrowLeft className="size-4" />
-            Back to position
+            Back to positions
           </Link>
         </Button>
         <h1 className="text-3xl font-bold tracking-tight">{position.title}</h1>

--- a/app/(main)/(auth)/positions/[id]/applications/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/applications/page.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { ArrowLeft } from 'lucide-react';
+
+import { getPositionApplications } from '@/prisma/data/applications';
+import { getPositionAccess } from '@/prisma/data/positions';
+
+import { getCurrentUser } from '@/lib/auth/server';
+
+import { PositionApplicationsTable } from '@/components/features/position-applications-table';
+import { Button } from '@/components/ui/button';
+
+interface PositionApplicationsPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PositionApplicationsPage({
+  params,
+}: PositionApplicationsPageProps) {
+  const { id } = await params;
+  const user = await getCurrentUser();
+
+  const position = await getPositionAccess(id);
+
+  if (!position) redirect('/positions');
+
+  // Access check: admins always have access; managers are confirmed via the DB fetch.
+  const isManager = position.managers.some((m) => m.id === user.id);
+  if (!user.isAdmin && !isManager) redirect(`/positions/${id}`);
+
+  const applications = await getPositionApplications(id);
+
+  const count = applications.length;
+  const countLabel =
+    count === 1 ? '1 application' : count > 0 ? `${count} applications` : null;
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <div>
+        <Button variant="ghost" size="sm" asChild className="mb-2 -ml-2">
+          <Link href={`/positions/${id}/edit`}>
+            <ArrowLeft className="size-4" />
+            Back to position
+          </Link>
+        </Button>
+        <h1 className="text-3xl font-bold tracking-tight">{position.title}</h1>
+        {countLabel && (
+          <p className="text-muted-foreground mt-1 text-sm">{countLabel}</p>
+        )}
+      </div>
+
+      <PositionApplicationsTable applications={applications} />
+    </div>
+  );
+}

--- a/components/features/application-status-select.tsx
+++ b/components/features/application-status-select.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { updateApplicationStatus } from '@/prisma/actions/applications';
+import type { $Enums } from '@/prisma/client';
+
+import {
+  APPLICATION_STATUS_LABELS,
+  MANAGEABLE_APPLICATION_STATUSES,
+} from '@/lib/constants';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+type ManageableStatus = (typeof MANAGEABLE_APPLICATION_STATUSES)[number];
+
+interface ApplicationStatusSelectProps {
+  applicationId: string;
+  currentStatus: $Enums.ApplicationStatus;
+  applicantName: string;
+}
+
+export function ApplicationStatusSelect({
+  applicationId,
+  currentStatus,
+  applicantName,
+}: ApplicationStatusSelectProps) {
+  const [isPending, startTransition] = useTransition();
+  // Controlled from local state so we can revert on failure.
+  const [value, setValue] = useState<ManageableStatus>(
+    currentStatus as ManageableStatus,
+  );
+
+  function handleChange(next: string) {
+    const nextStatus = next as ManageableStatus;
+    const previous = value;
+    setValue(nextStatus);
+    startTransition(async () => {
+      try {
+        await updateApplicationStatus({ applicationId, status: nextStatus });
+        toast.success(
+          `Status updated to ${APPLICATION_STATUS_LABELS[nextStatus]}`,
+        );
+      } catch {
+        setValue(previous);
+        toast.error('Something went wrong');
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={value} onValueChange={handleChange} disabled={isPending}>
+        <SelectTrigger
+          className="w-[180px]"
+          aria-label={`Status for ${applicantName}`}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {MANAGEABLE_APPLICATION_STATUSES.map((status) => (
+            <SelectItem key={status} value={status}>
+              {APPLICATION_STATUS_LABELS[status]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {isPending && (
+        <Loader2
+          className="text-muted-foreground size-4 animate-spin"
+          aria-hidden="true"
+        />
+      )}
+    </div>
+  );
+}

--- a/components/features/application-status-select.tsx
+++ b/components/features/application-status-select.tsx
@@ -36,6 +36,8 @@ export function ApplicationStatusSelect({
 }: ApplicationStatusSelectProps) {
   const [isPending, startTransition] = useTransition();
   // Controlled from local state so we can revert on failure.
+  // Safe: getPositionApplications filters status: { not: 'draft' }, so currentStatus
+  // is always one of the six manageable values — never ApplicationStatus.draft.
   const [value, setValue] = useState<ManageableStatus>(
     currentStatus as ManageableStatus,
   );
@@ -61,7 +63,7 @@ export function ApplicationStatusSelect({
     <div className="flex items-center gap-2">
       <Select value={value} onValueChange={handleChange} disabled={isPending}>
         <SelectTrigger
-          className="w-[180px]"
+          className="w-full"
           aria-label={`Status for ${applicantName}`}
         >
           <SelectValue />

--- a/components/features/position-applications-table.tsx
+++ b/components/features/position-applications-table.tsx
@@ -1,0 +1,110 @@
+import { Inbox } from 'lucide-react';
+
+import { type PositionApplicationListItem } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+import { ApplicationStatusSelect } from '@/components/features/application-status-select';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface PositionApplicationsTableProps {
+  applications: PositionApplicationListItem[];
+}
+
+export function PositionApplicationsTable({
+  applications,
+}: PositionApplicationsTableProps) {
+  if (applications.length === 0)
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <Inbox className="text-muted-foreground size-12" aria-hidden="true" />
+          <div>
+            <p className="text-base font-semibold">No applications yet</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Applications will appear here once candidates apply to this
+              position.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+
+  return (
+    <Card className="gap-0 p-0">
+      {/* Desktop table — hidden on mobile */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Applicant</TableHead>
+              <TableHead>Submitted</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {applications.map((app) => {
+              const displayName = app.user.name ?? app.user.email;
+              return (
+                <TableRow key={app.id}>
+                  <TableCell>
+                    <span className="font-medium">{displayName}</span>
+                    {app.user.name && (
+                      <span className="text-muted-foreground block text-xs">
+                        {app.user.email}
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {formatDate(app.submittedAt)}
+                  </TableCell>
+                  <TableCell>
+                    <ApplicationStatusSelect
+                      applicationId={app.id}
+                      currentStatus={app.status}
+                      applicantName={displayName}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile stacked cards — shown only on mobile */}
+      <div className="flex flex-col divide-y md:hidden">
+        {applications.map((app) => {
+          const displayName = app.user.name ?? app.user.email;
+          return (
+            <div key={app.id} className="flex flex-col gap-3 p-4">
+              <div>
+                <span className="font-medium">{displayName}</span>
+                {app.user.name && (
+                  <span className="text-muted-foreground block text-xs">
+                    {app.user.email}
+                  </span>
+                )}
+              </div>
+              <span className="text-muted-foreground text-sm">
+                {formatDate(app.submittedAt)}
+              </span>
+              <ApplicationStatusSelect
+                applicationId={app.id}
+                currentStatus={app.status}
+                applicantName={displayName}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/components/features/position-applications-table.tsx
+++ b/components/features/position-applications-table.tsx
@@ -84,7 +84,7 @@ export function PositionApplicationsTable({
         {applications.map((app) => {
           const displayName = app.user.name ?? app.user.email;
           return (
-            <div key={app.id} className="flex flex-col gap-3 p-4">
+            <div key={app.id} className="flex flex-col gap-2 p-4">
               <div>
                 <span className="font-medium">{displayName}</span>
                 {app.user.name && (

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 
-import { ChevronDown, ChevronUp, Pencil } from 'lucide-react';
+import { ChevronDown, ChevronUp, Inbox, Pencil } from 'lucide-react';
 
 import { STATUS_LABELS, STATUS_VARIANTS } from '@/lib/constants';
 import type { PositionWithQuestions } from '@/lib/types';
@@ -74,12 +74,20 @@ export function PositionCard({
               </Button>
             )}
             {showAdminActions && (
-              <Button asChild variant="outline">
-                <Link href={`/positions/${position.id}/edit`}>
-                  <Pencil className="size-4" />
-                  Edit
-                </Link>
-              </Button>
+              <>
+                <Button asChild variant="outline">
+                  <Link href={`/positions/${position.id}/edit`}>
+                    <Pencil className="size-4" />
+                    Edit
+                  </Link>
+                </Button>
+                <Button asChild variant="outline">
+                  <Link href={`/positions/${position.id}/applications`}>
+                    <Inbox className="size-4" />
+                    Applications
+                  </Link>
+                </Button>
+              </>
             )}
           </div>
         </CardContent>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -34,6 +34,18 @@ export const baseQuestionSchema = z.object({
   options: z.array(z.string()),
 });
 
+// The post-submission statuses a manager/admin may set. Excludes 'draft'
+// (in-progress, applicant-private) — shared by the dropdown options and the
+// updateApplicationStatus zod enum so the two never drift.
+export const MANAGEABLE_APPLICATION_STATUSES = [
+  'applied',
+  'reached_out',
+  'interview_scheduled',
+  'reviewing',
+  'accepted',
+  'rejected',
+] as const;
+
 // Human-readable labels for each application status.
 // Keyed on the generated ApplicationStatus enum for build-time exhaustiveness.
 export const APPLICATION_STATUS_LABELS: Record<

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -85,3 +85,13 @@ export type MyApplicationListItem = Prisma.ApplicationGetPayload<{
     position: { select: { id: true; title: true } };
   };
 }>;
+
+// Shared type for manager-facing position applications table rows.
+export type PositionApplicationListItem = Prisma.ApplicationGetPayload<{
+  select: {
+    id: true;
+    status: true;
+    submittedAt: true;
+    user: { select: { id: true; name: true; email: true } };
+  };
+}>;

--- a/prisma/actions/applications.ts
+++ b/prisma/actions/applications.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/prisma/client';
 
 import { getCurrentUser } from '@/lib/auth/server';
+import { MANAGEABLE_APPLICATION_STATUSES } from '@/lib/constants';
 import prisma from '@/lib/prisma';
 import { type DraftApplication } from '@/lib/types';
 import { type ResponseType, toStringArray } from '@/lib/utils';
@@ -211,4 +212,54 @@ export async function submitApplication(
   revalidatePath('/applications');
   revalidatePath('/positions');
   return updated;
+}
+
+const updateApplicationStatusSchema = z.object({
+  applicationId: z.string().min(1),
+  status: z.enum(MANAGEABLE_APPLICATION_STATUSES),
+});
+
+// Throw-only: every failure here is unexpected/impossible from a correctly-gated UI.
+// The applications page redirects unauthenticated and wrong-role users before
+// the dropdown renders, so unauthenticated calls and wrong-role calls are impossible
+// from the real UI. Forged inputs, stale ids, and DB faults all throw.
+export async function updateApplicationStatus(input: unknown): Promise<void> {
+  // getCurrentUser redirects unauthenticated callers — never returns null.
+  const currentUser = await getCurrentUser();
+
+  // Impossible from a correct UI — a failure here means malformed/forged input → throw.
+  const parsed = updateApplicationStatusSchema.safeParse(input);
+  if (!parsed.success) throw new Error('Invalid updateApplicationStatus input');
+  const { applicationId, status } = parsed.data;
+
+  // Authorization (no IDOR): scope the lookup to the application with manager filter
+  // scoped to the caller so a non-admin non-manager cannot reach this record.
+  const application = await prisma.application.findFirst({
+    where: { id: applicationId, deletedAt: null, status: { not: 'draft' } },
+    select: {
+      id: true,
+      positionId: true,
+      position: {
+        select: {
+          managers: { where: { id: currentUser.id }, select: { id: true } },
+        },
+      },
+    },
+  });
+  // Impossible from a correct UI: the list only renders submitted applications
+  // of an accessible position — a miss means a forged/stale id → throw.
+  if (!application) throw new Error('Application not found');
+
+  // Wrong role is impossible from the UI (the page redirects such users before
+  // the dropdown renders) → throw, not { error }.
+  const isManager = application.position.managers.length > 0;
+  if (!currentUser.isAdmin && !isManager)
+    throw new Error('Not authorized to manage this application');
+
+  await prisma.application.update({
+    where: { id: applicationId },
+    data: { status, updatedById: currentUser.id },
+  });
+
+  revalidatePath(`/positions/${application.positionId}/applications`);
 }

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -3,7 +3,10 @@ import 'server-only';
 import { $Enums } from '@/prisma/client';
 
 import prisma from '@/lib/prisma';
-import { type MyApplicationListItem } from '@/lib/types';
+import {
+  type MyApplicationListItem,
+  type PositionApplicationListItem,
+} from '@/lib/types';
 
 const applicationSelect = {
   id: true,
@@ -33,6 +36,23 @@ export async function getRecentMyApplications(
     select: applicationSelect,
     orderBy: { updatedAt: 'desc' },
     take,
+  });
+}
+
+const positionApplicationSelect = {
+  id: true,
+  status: true,
+  submittedAt: true,
+  user: { select: { id: true, name: true, email: true } },
+} as const;
+
+export async function getPositionApplications(
+  positionId: string,
+): Promise<PositionApplicationListItem[]> {
+  return prisma.application.findMany({
+    where: { positionId, deletedAt: null, status: { not: 'draft' } },
+    select: positionApplicationSelect,
+    orderBy: { submittedAt: 'desc' },
   });
 }
 

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -62,6 +62,17 @@ export async function getPositionForApply(
   });
 }
 
+// Minimal fetch for the applications page access check: avoids over-fetching
+// the full edit payload when only the title and manager list are needed.
+export async function getPositionAccess(
+  id: string,
+): Promise<{ id: string; title: string; managers: { id: string }[] } | null> {
+  return prisma.position.findFirst({
+    where: { id, deletedAt: null },
+    select: { id: true, title: true, managers: { select: { id: true } } },
+  });
+}
+
 export async function getPositionForEdit(
   id: string,
 ): Promise<PositionForEdit | null> {


### PR DESCRIPTION
Closes #64

## Summary

- Adds `/positions/[id]/applications` page (admin/manager-gated) showing a table of all submitted applications for a position with an inline status-update dropdown
- Adds `updateApplicationStatus` server action (throw-only contract per ENGINEERING §4) and `getPositionApplications` / `getPositionAccess` data-fetching helpers
- Adds Applications button to the position card next to Edit, visible under `showAdminActions`

## Changes

- `lib/constants.ts` — added `MANAGEABLE_APPLICATION_STATUSES` (six non-draft statuses) shared by the dropdown and the action's zod enum
- `lib/types.ts` — added `PositionApplicationListItem` (Prisma `GetPayload` type)
- `prisma/data/positions.ts` — added `getPositionAccess` (minimal fetch for the page's access check)
- `prisma/data/applications.ts` — added `getPositionApplications` (filters out drafts, orders by `submittedAt desc`)
- `prisma/actions/applications.ts` — added `updateApplicationStatus(input: unknown): Promise<void>` with auth + zod + manager/admin scoping; throw-only (no `{ error }` return)
- `components/features/application-status-select.tsx` — `'use client'` leaf: controlled select with `useTransition`, success toast, revert + generic error toast on catch
- `components/features/position-applications-table.tsx` — server component with responsive desktop table / mobile stacked cards and a designed empty state
- `app/(main)/(auth)/positions/[id]/applications/page.tsx` — server component: auth, access check, fetch, render
- `app/(main)/(auth)/positions/[id]/applications/loading.tsx` — route-level skeleton
- `components/features/position-card.tsx` — added Applications button under `showAdminActions`

## Testing plan

- [ ] As an admin, expand a position card and click **Applications** — lands on `/positions/[id]/applications`
- [ ] As a manager of the position (non-admin), navigate to `/positions/[id]/applications` — page loads correctly
- [ ] As a non-manager, non-admin user, navigate to `/positions/[id]/applications` — redirected to `/positions/[id]`
- [ ] As an unauthenticated visitor, hit `/positions/[id]/applications` — redirected to login
- [ ] Visit `/positions/[id]/applications` for a non-existent or soft-deleted position — redirected to `/positions`
- [ ] Table shows one row per submitted application; draft applications do not appear
- [ ] Each row shows applicant name (email beneath when name exists), submitted date, and a status dropdown
- [ ] A position with no submitted applications shows the empty state (Inbox icon + "No applications yet")
- [ ] Resize to 375 px — rows render as stacked cards, no horizontal overflow; resize to 1280 px — table view
- [ ] Header shows the correct pluralized count ("1 application" / "N applications"); count line absent when zero
- [ ] Change a row's status (e.g. Applied → Reviewing) — spinner shows, then success toast "Status updated to Reviewing"; value persists after page refresh
- [ ] The dropdown offers only the six non-draft statuses; Draft is not an option
- [ ] Open the same position in two tabs, change status in one, refresh the other — other reflects the new status
- [ ] Force an invalid `status` via devtools — generic "Something went wrong" toast; dropdown reverts; no internals shown
- [ ] Force a DB error and trigger a status change — generic "Something went wrong" toast; dropdown reverts; error does not reach the global boundary
- [ ] Throttle network and reload — `loading.tsx` skeleton appears before content

## Automated checks

- [x] `npm run prettier:check` — clean
- [x] `npm run eslint:check` — clean
- [x] `npm run tsc:check` — clean

## Notes

No schema migration required — the existing `Application` model covers all fields. The action is intentionally throw-only (no `{ error }` return) because the page gate redirects unauthenticated and wrong-role users before the dropdown ever renders, making every action-level failure path unexpected/impossible from a correctly-rendered UI (per ENGINEERING §4).
