### PR TITLE
#78 Dashboard / Home Page

### DIFF
--- a/app/(main)/(auth)/layout.tsx
+++ b/app/(main)/(auth)/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 
+import { getProfileCompleteness } from '@/prisma/data/profile';
+
 import { getCurrentUser } from '@/lib/auth/server';
 import prisma from '@/lib/prisma';
 
@@ -18,22 +20,8 @@ export default async function AuthGateLayout({
   });
   if (managedCount > 0) return <>{children}</>;
 
-  const requiredQuestions = await prisma.globalQuestion.findMany({
-    where: { required: true, deletedAt: null },
-    select: { id: true },
-  });
-
-  if (requiredQuestions.length > 0) {
-    const answers = await prisma.globalAnswer.findMany({
-      where: {
-        userId: user.id,
-        globalQuestionId: { in: requiredQuestions.map((q) => q.id) },
-        deletedAt: null,
-      },
-      select: { id: true },
-    });
-    if (answers.length < requiredQuestions.length) redirect('/profile');
-  }
+  const { complete } = await getProfileCompleteness(user.id);
+  if (!complete) redirect('/profile');
 
   return <>{children}</>;
 }

--- a/app/(main)/(auth)/loading.tsx
+++ b/app/(main)/(auth)/loading.tsx
@@ -1,0 +1,61 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function HomeLoading() {
+  return (
+    <div className="flex w-full flex-col gap-6">
+      {/* Heading */}
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      {/* First widget */}
+      <Card className="gap-0 p-0">
+        <CardHeader className="border-b p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-5 w-36" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="border-b px-4 py-3 last:border-0">
+              <div className="grid grid-cols-3 gap-4">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-5 w-20 rounded-md" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Second widget */}
+      <Card className="gap-0 p-0">
+        <CardHeader className="border-b p-4">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="border-b px-4 py-4 last:border-0">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex flex-1 flex-col gap-1.5">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-64" />
+                </div>
+                <Skeleton className="h-8 w-16 rounded-md" />
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(main)/(auth)/page.tsx
+++ b/app/(main)/(auth)/page.tsx
@@ -1,55 +1,12 @@
-import { Suspense } from 'react';
-
 import { getCurrentUser } from '@/lib/auth/server';
 
-import { MyApplicationsWidget } from '@/components/features/my-applications-widget';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-
-function MyApplicationsWidgetSkeleton() {
-  return (
-    <Card className="gap-0 p-0">
-      <CardHeader className="border-b p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex flex-col gap-2">
-            <Skeleton className="h-5 w-36" />
-            <Skeleton className="h-4 w-48" />
-          </div>
-          <Skeleton className="h-4 w-16" />
-        </div>
-      </CardHeader>
-      <CardContent className="p-0">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="border-b px-4 py-3 last:border-0">
-            <div className="grid grid-cols-3 gap-4">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-5 w-20 rounded-md" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  );
-}
+import { AdminDashboard } from '@/components/features/admin-dashboard';
+import { UserDashboard } from '@/components/features/user-dashboard';
 
 export default async function Home() {
   const user = await getCurrentUser();
 
-  return (
-    <div className="flex w-full flex-col gap-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Welcome to Aplio
-        </h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          Here&apos;s a summary of your applications.
-        </p>
-      </div>
+  if (user.isAdmin) return <AdminDashboard />;
 
-      <Suspense fallback={<MyApplicationsWidgetSkeleton />}>
-        <MyApplicationsWidget userId={user.id} />
-      </Suspense>
-    </div>
-  );
+  return <UserDashboard userId={user.id} userName={user.name} />;
 }

--- a/components/features/admin-dashboard.tsx
+++ b/components/features/admin-dashboard.tsx
@@ -1,0 +1,106 @@
+import { Suspense } from 'react';
+
+import { OpenPositionsSummary } from '@/components/features/open-positions-summary';
+import { PipelineSummary } from '@/components/features/pipeline-summary';
+import { RecentApplications } from '@/components/features/recent-applications';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+function PipelineSummarySkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Card key={i} className="p-4">
+          <CardContent className="p-0">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="mt-2 h-8 w-12" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function RecentApplicationsSkeleton() {
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="border-b px-4 py-4 last:border-0">
+            <div className="hidden grid-cols-4 gap-4 md:grid">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-5 w-20 rounded-md" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <div className="flex flex-col gap-2 md:hidden">
+              <div className="flex items-center justify-between gap-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-5 w-20 rounded-md" />
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function OpenPositionsSummarySkeleton() {
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between border-b px-4 py-3 last:border-0"
+          >
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AdminDashboard() {
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Overview of applications across all positions.
+        </p>
+      </div>
+
+      <Suspense fallback={<PipelineSummarySkeleton />}>
+        <PipelineSummary />
+      </Suspense>
+
+      <Suspense fallback={<RecentApplicationsSkeleton />}>
+        <RecentApplications />
+      </Suspense>
+
+      <Suspense fallback={<OpenPositionsSummarySkeleton />}>
+        <OpenPositionsSummary />
+      </Suspense>
+    </div>
+  );
+}

--- a/components/features/open-positions-summary.tsx
+++ b/components/features/open-positions-summary.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+
+import { ArrowRight, Briefcase } from 'lucide-react';
+
+import { getOpenPositionsSummary } from '@/prisma/data/positions';
+
+import { type OpenPositionSummaryItem } from '@/lib/types';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export async function OpenPositionsSummary() {
+  const positions = await getOpenPositionsSummary();
+
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold">
+            Open Positions
+          </CardTitle>
+          <Link
+            href="/positions"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
+          >
+            View all
+            <ArrowRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {positions.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <Briefcase
+              className="text-muted-foreground size-10"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-sm font-medium">No open positions</p>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                Create a position to start accepting applications.
+              </p>
+            </div>
+            <Link
+              href="/positions"
+              className="text-primary text-sm font-medium hover:underline"
+            >
+              Manage positions
+            </Link>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {positions.map((position) => (
+              <PositionRow key={position.id} position={position} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PositionRow({ position }: { position: OpenPositionSummaryItem }) {
+  const count = position._count.applications;
+  const applicantLabel = `${count} ${count === 1 ? 'applicant' : 'applicants'}`;
+
+  return (
+    <li className="flex items-center justify-between gap-4 px-4 py-3">
+      <Link href="/positions" className="text-sm font-medium hover:underline">
+        {position.title}
+      </Link>
+      <span className="text-muted-foreground shrink-0 text-sm">
+        {applicantLabel}
+      </span>
+    </li>
+  );
+}

--- a/components/features/open-positions-widget.tsx
+++ b/components/features/open-positions-widget.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+
+import { ArrowRight, Briefcase } from 'lucide-react';
+
+import { getPositions } from '@/prisma/data/positions';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export async function OpenPositionsWidget() {
+  // Reuse getPositions(false) — returns only open positions. Slight over-fetch
+  // of questions fields is acceptable to reuse the shared type (ENGINEERING §2).
+  const positions = await getPositions(false);
+  const displayed = positions.slice(0, 5);
+
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold">
+            Open Positions
+          </CardTitle>
+          <Link
+            href="/positions"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
+          >
+            View all
+            <ArrowRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {displayed.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-center">
+            <Briefcase
+              className="text-muted-foreground size-10"
+              aria-hidden="true"
+            />
+            <p className="text-muted-foreground text-sm">
+              No open positions right now.
+            </p>
+            <p className="text-muted-foreground text-xs">
+              Check back soon for new opportunities.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {displayed.map((position) => (
+              <li key={position.id} className="flex flex-col gap-1.5 p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {position.title}
+                    </p>
+                    {position.description && (
+                      <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
+                        {position.description}
+                      </p>
+                    )}
+                  </div>
+                  <Button asChild size="sm" className="shrink-0">
+                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/pipeline-summary.tsx
+++ b/components/features/pipeline-summary.tsx
@@ -1,0 +1,73 @@
+import { $Enums } from '@/prisma/client';
+import { getApplicationStatusCounts } from '@/prisma/data/applications';
+
+import {
+  APPLICATION_STATUS_BADGE_VARIANT,
+  APPLICATION_STATUS_LABELS,
+} from '@/lib/constants';
+
+import { Card, CardContent } from '@/components/ui/card';
+
+// Statuses surfaced in the pipeline summary (excludes draft).
+const PIPELINE_STATUSES = [
+  $Enums.ApplicationStatus.applied,
+  $Enums.ApplicationStatus.reached_out,
+  $Enums.ApplicationStatus.interview_scheduled,
+  $Enums.ApplicationStatus.reviewing,
+  $Enums.ApplicationStatus.accepted,
+  $Enums.ApplicationStatus.rejected,
+] as const;
+
+// Map badge variant to a design-token dot color for stat card accents.
+const BADGE_VARIANT_TO_DOT: Record<string, string> = {
+  info: 'bg-info',
+  warning: 'bg-warning',
+  success: 'bg-success',
+  destructive: 'bg-destructive',
+  secondary: 'bg-muted-foreground',
+  default: 'bg-primary',
+  outline: 'bg-border',
+};
+
+export async function PipelineSummary() {
+  const counts = await getApplicationStatusCounts();
+
+  const total = PIPELINE_STATUSES.reduce((sum, s) => sum + (counts[s] ?? 0), 0);
+
+  return (
+    <section aria-label="Pipeline summary">
+      {total === 0 && (
+        <p className="text-muted-foreground mb-4 text-sm">
+          No applications submitted yet.
+        </p>
+      )}
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+        {PIPELINE_STATUSES.map((status) => {
+          const count = counts[status] ?? 0;
+          const variant = APPLICATION_STATUS_BADGE_VARIANT[status];
+          const dotClass =
+            BADGE_VARIANT_TO_DOT[variant] ?? 'bg-muted-foreground';
+
+          return (
+            <Card key={status} className="p-4">
+              <CardContent className="p-0">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={`size-2 shrink-0 rounded-full ${dotClass}`}
+                    aria-hidden="true"
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    {APPLICATION_STATUS_LABELS[status]}
+                  </p>
+                </div>
+                <p className="mt-2 text-2xl font-semibold tabular-nums">
+                  {count}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/features/profile-completeness-banner.tsx
+++ b/components/features/profile-completeness-banner.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+
+import { CircleAlert } from 'lucide-react';
+
+import { getProfileCompleteness } from '@/prisma/data/profile';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface ProfileCompletenessBannerProps {
+  userId: string;
+}
+
+export async function ProfileCompletenessBanner({
+  userId,
+}: ProfileCompletenessBannerProps) {
+  const { complete, missingCount } = await getProfileCompleteness(userId);
+
+  if (complete) return null;
+
+  const questionWord = missingCount === 1 ? 'question' : 'questions';
+
+  return (
+    <Card className="border-warning bg-warning/5">
+      <CardContent className="flex items-start gap-3 p-4">
+        <CircleAlert
+          className="text-warning mt-0.5 size-5 shrink-0"
+          aria-hidden="true"
+        />
+        <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold">Complete your profile</p>
+            <p className="text-muted-foreground mt-0.5 text-sm">
+              {missingCount > 0
+                ? `You have ${missingCount} required ${questionWord} left to answer.`
+                : 'Finish your profile so you’re ready to apply to open positions.'}
+            </p>
+          </div>
+          <Button asChild size="sm" className="shrink-0">
+            <Link href="/profile">Complete profile</Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/profile-completeness-banner.tsx
+++ b/components/features/profile-completeness-banner.tsx
@@ -31,9 +31,7 @@ export async function ProfileCompletenessBanner({
           <div>
             <p className="text-sm font-semibold">Complete your profile</p>
             <p className="text-muted-foreground mt-0.5 text-sm">
-              {missingCount > 0
-                ? `You have ${missingCount} required ${questionWord} left to answer.`
-                : 'Finish your profile so you’re ready to apply to open positions.'}
+              {`You have ${missingCount} required ${questionWord} left to answer.`}
             </p>
           </div>
           <Button asChild size="sm" className="shrink-0">

--- a/components/features/recent-applications.tsx
+++ b/components/features/recent-applications.tsx
@@ -1,0 +1,139 @@
+import Link from 'next/link';
+
+import { ArrowRight, Inbox } from 'lucide-react';
+
+import { getRecentApplications } from '@/prisma/data/applications';
+
+import { type AdminApplicationListItem } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+import { ApplicationStatusBadge } from '@/components/features/status-badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+export async function RecentApplications() {
+  const applications = await getRecentApplications();
+
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold">
+            Recent Applications
+          </CardTitle>
+          <Link
+            href="/applications"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
+          >
+            View all
+            <ArrowRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {applications.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <Inbox
+              className="text-muted-foreground size-10"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-sm font-medium">No applications yet</p>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                Submissions across all positions will appear here.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Desktop table */}
+            <div className="hidden md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Applicant</TableHead>
+                    <TableHead>Position</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Applied</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {applications.map((app) => (
+                    <ApplicationRow key={app.id} app={app} />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Mobile stacked cards */}
+            <div className="flex flex-col divide-y md:hidden">
+              {applications.map((app) => (
+                <ApplicationCard key={app.id} app={app} />
+              ))}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ApplicationRow({ app }: { app: AdminApplicationListItem }) {
+  const applicantLabel = app.user.name ?? app.user.email;
+
+  return (
+    <TableRow>
+      <TableCell>
+        <Link
+          href={`/applications/${app.id}`}
+          className="font-medium hover:underline"
+        >
+          {applicantLabel}
+        </Link>
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {app.position.title}
+      </TableCell>
+      <TableCell>
+        <ApplicationStatusBadge status={app.status} />
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {formatDate(app.submittedAt)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function ApplicationCard({ app }: { app: AdminApplicationListItem }) {
+  const applicantLabel = app.user.name ?? app.user.email;
+
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          href={`/applications/${app.id}`}
+          className="font-medium hover:underline"
+        >
+          {applicantLabel}
+        </Link>
+        <ApplicationStatusBadge status={app.status} />
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-muted-foreground text-sm">
+          {app.position.title}
+        </span>
+        <span className="text-muted-foreground text-sm">
+          {formatDate(app.submittedAt)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/features/user-dashboard.tsx
+++ b/components/features/user-dashboard.tsx
@@ -1,0 +1,93 @@
+import { Suspense } from 'react';
+
+import { MyApplicationsWidget } from '@/components/features/my-applications-widget';
+import { OpenPositionsWidget } from '@/components/features/open-positions-widget';
+import { ProfileCompletenessBanner } from '@/components/features/profile-completeness-banner';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface UserDashboardProps {
+  userId: string;
+  userName: string | null;
+}
+
+function MyApplicationsWidgetSkeleton() {
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="border-b px-4 py-3 last:border-0">
+            <div className="grid grid-cols-3 gap-4">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-5 w-20 rounded-md" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function OpenPositionsWidgetSkeleton() {
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="border-b px-4 py-4 last:border-0">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-1 flex-col gap-1.5">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-64" />
+              </div>
+              <Skeleton className="h-8 w-16 rounded-md" />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function UserDashboard({ userId, userName }: UserDashboardProps) {
+  const firstName = userName?.split(' ')[0];
+  const heading = firstName ? `Welcome back, ${firstName}` : 'Welcome to Aplio';
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{heading}</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Here&apos;s a summary of your applications.
+        </p>
+      </div>
+
+      <Suspense fallback={null}>
+        <ProfileCompletenessBanner userId={userId} />
+      </Suspense>
+
+      <Suspense fallback={<MyApplicationsWidgetSkeleton />}>
+        <MyApplicationsWidget userId={userId} />
+      </Suspense>
+
+      <Suspense fallback={<OpenPositionsWidgetSkeleton />}>
+        <OpenPositionsWidget />
+      </Suspense>
+    </div>
+  );
+}

--- a/components/features/user-dashboard.tsx
+++ b/components/features/user-dashboard.tsx
@@ -77,7 +77,8 @@ export function UserDashboard({ userId, userName }: UserDashboardProps) {
         </p>
       </div>
 
-      <Suspense fallback={null}>
+      {/* Fixed-height placeholder prevents CLS when the banner resolves and is present. */}
+      <Suspense fallback={<div className="h-[68px]" />}>
         <ProfileCompletenessBanner userId={userId} />
       </Suspense>
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -95,3 +95,21 @@ export type PositionApplicationListItem = Prisma.ApplicationGetPayload<{
     user: { select: { id: true; name: true; email: true } };
   };
 }>;
+
+// Admin-only type — exposes applicant identity (name/email) and position.
+// Must only be used in admin-gated contexts; never serialize to non-admin clients.
+export type AdminApplicationListItem = Prisma.ApplicationGetPayload<{
+  select: {
+    id: true;
+    status: true;
+    submittedAt: true;
+    position: { select: { id: true; title: true } };
+    user: { select: { id: true; name: true; email: true } };
+  };
+}>;
+
+// Admin-only type — open position with filtered non-draft application count.
+// Must only be used in admin-gated contexts.
+export type OpenPositionSummaryItem = Prisma.PositionGetPayload<{
+  select: { id: true; title: true; _count: { select: { applications: true } } };
+}>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -113,3 +113,9 @@ export type AdminApplicationListItem = Prisma.ApplicationGetPayload<{
 export type OpenPositionSummaryItem = Prisma.PositionGetPayload<{
   select: { id: true; title: true; _count: { select: { applications: true } } };
 }>;
+
+export type ProfileCompleteness = {
+  complete: boolean;
+  missingCount: number;
+  requiredCount: number;
+};

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -4,6 +4,7 @@ import { $Enums } from '@/prisma/client';
 
 import prisma from '@/lib/prisma';
 import {
+  type AdminApplicationListItem,
   type MyApplicationListItem,
   type PositionApplicationListItem,
 } from '@/lib/types';
@@ -66,4 +67,37 @@ export async function getMyApplicationStatusCounts(
   });
 
   return Object.fromEntries(rows.map((r) => [r.status, r._count]));
+}
+
+// Admin-only: returns application counts grouped by status across all positions.
+// Returns cross-user data — must only be called from an admin-gated context.
+export async function getApplicationStatusCounts(): Promise<
+  Partial<Record<$Enums.ApplicationStatus, number>>
+> {
+  const rows = await prisma.application.groupBy({
+    by: ['status'],
+    where: { deletedAt: null },
+    _count: true,
+  });
+
+  return Object.fromEntries(rows.map((r) => [r.status, r._count]));
+}
+
+// Admin-only: returns the most recent non-draft applications across all positions.
+// Returns cross-user data (applicant name/email) — must only be called from an admin-gated context.
+export async function getRecentApplications(
+  take = 10,
+): Promise<AdminApplicationListItem[]> {
+  return prisma.application.findMany({
+    where: { deletedAt: null, status: { not: 'draft' } },
+    select: {
+      id: true,
+      status: true,
+      submittedAt: true,
+      position: { select: { id: true, title: true } },
+      user: { select: { id: true, name: true, email: true } },
+    },
+    orderBy: { submittedAt: 'desc' },
+    take,
+  });
 }

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -1,7 +1,11 @@
 import 'server-only';
 
 import prisma from '@/lib/prisma';
-import { type PositionForEdit, type PositionWithQuestions } from '@/lib/types';
+import {
+  type OpenPositionSummaryItem,
+  type PositionForEdit,
+  type PositionWithQuestions,
+} from '@/lib/types';
 
 export async function getPositions(
   includeAll = false,
@@ -70,6 +74,28 @@ export async function getPositionAccess(
   return prisma.position.findFirst({
     where: { id, deletedAt: null },
     select: { id: true, title: true, managers: { select: { id: true } } },
+  });
+}
+
+// Admin-only: open positions with filtered non-draft application counts in a single query.
+// Returns cross-position data — must only be called from an admin-gated context.
+export async function getOpenPositionsSummary(): Promise<
+  OpenPositionSummaryItem[]
+> {
+  return prisma.position.findMany({
+    where: { status: 'open', deletedAt: null },
+    select: {
+      id: true,
+      title: true,
+      _count: {
+        select: {
+          applications: {
+            where: { deletedAt: null, status: { not: 'draft' } },
+          },
+        },
+      },
+    },
+    orderBy: { title: 'asc' },
   });
 }
 

--- a/prisma/data/profile.ts
+++ b/prisma/data/profile.ts
@@ -18,3 +18,35 @@ export async function getProfileData(
     answer: answers[0] ?? null,
   }));
 }
+
+export type ProfileCompleteness = {
+  complete: boolean;
+  missingCount: number;
+  requiredCount: number;
+};
+
+export async function getProfileCompleteness(
+  userId: string,
+): Promise<ProfileCompleteness> {
+  const requiredQuestions = await prisma.globalQuestion.findMany({
+    where: { required: true, deletedAt: null },
+    select: { id: true },
+  });
+
+  const requiredCount = requiredQuestions.length;
+
+  if (requiredCount === 0)
+    return { complete: true, missingCount: 0, requiredCount: 0 };
+
+  const answers = await prisma.globalAnswer.findMany({
+    where: {
+      userId,
+      globalQuestionId: { in: requiredQuestions.map((q) => q.id) },
+      deletedAt: null,
+    },
+    select: { id: true },
+  });
+
+  const missingCount = requiredCount - answers.length;
+  return { complete: missingCount === 0, missingCount, requiredCount };
+}

--- a/prisma/data/profile.ts
+++ b/prisma/data/profile.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
 
 import prisma from '@/lib/prisma';
+import { type ProfileCompleteness } from '@/lib/types';
 
 export async function getProfileData(
   userId: string,
@@ -18,12 +19,6 @@ export async function getProfileData(
     answer: answers[0] ?? null,
   }));
 }
-
-export type ProfileCompleteness = {
-  complete: boolean;
-  missingCount: number;
-  requiredCount: number;
-};
 
 export async function getProfileCompleteness(
   userId: string,


### PR DESCRIPTION
Closes #78

## Summary

- Implements a role-aware dashboard at `/` that dispatches to `UserDashboard` or `AdminDashboard` based on `user.isAdmin`
- User dashboard: personalized greeting, profile-completeness warning banner, My Applications widget, and Open Positions widget — each in independent `<Suspense>` boundaries
- Admin dashboard: pipeline stat-card grid (6 statuses, DB-aggregated), recent applications table with mobile stacked cards, and open positions summary with per-position applicant counts

## Changes

- `lib/types.ts` — added `AdminApplicationListItem` and `OpenPositionSummaryItem` Prisma payload types
- `prisma/data/applications.ts` — added `getApplicationStatusCounts()` (admin `groupBy`) and `getRecentApplications()` (admin top-10 non-draft)
- `prisma/data/positions.ts` — added `getOpenPositionsSummary()` (open positions with filtered `_count` in one query)
- `prisma/data/profile.ts` — added `getProfileCompleteness(userId)` and `ProfileCompleteness` type; refactored `app/(main)/(auth)/layout.tsx` to use it (single source of truth)
- `components/features/profile-completeness-banner.tsx` — warning banner, renders `null` when profile is complete
- `components/features/open-positions-widget.tsx` — user open-positions widget with empty state
- `components/features/pipeline-summary.tsx` — admin stat-card grid (6 pipeline statuses, zero-state handled)
- `components/features/recent-applications.tsx` — admin recent-applications card with desktop table and mobile stacked layout, empty state
- `components/features/open-positions-summary.tsx` — admin open positions list with per-position applicant counts, empty state
- `components/features/user-dashboard.tsx` — composes user sections with per-section `<Suspense>` and skeletons
- `components/features/admin-dashboard.tsx` — composes admin sections with per-section `<Suspense>` and skeletons
- `app/(main)/(auth)/page.tsx` — slim dispatcher on `user.isAdmin`
- `app/(main)/(auth)/loading.tsx` — route-level loading skeleton

## Testing plan

- [ ] Sign in as a **manager with an incomplete profile** → home shows the **"Complete your profile"** warning banner; clicking "Complete profile" navigates to `/profile`; My Applications and Open Positions widgets render below
- [ ] Answer all required questions for that user, return to `/` → **banner is gone**; widgets still render
- [ ] Sign in as a **regular user with a complete profile** → no banner; My Applications widget shows up to 5 newest applications with status badges and dates; "View all" → `/my-applications`
- [ ] With no applications for the user → My Applications empty state renders ("You haven't started any applications yet" + Browse positions link)
- [ ] Open Positions widget: with open positions → titles, descriptions, Apply CTAs (→ `/positions/[id]/apply`) and "View all" → `/positions`; with no open positions → empty state renders
- [ ] Sign in as an **admin** → home shows Dashboard heading, Pipeline summary stat cards for all 6 statuses (applied → rejected), Recent Applications table with "View all" → `/applications`, Open Positions summary with per-position applicant counts and "View all" → `/positions`
- [ ] With zero submitted applications → all pipeline cards show `0` + "No applications submitted yet." note; Recent Applications empty state renders
- [ ] Hard-refresh `/` → route-level and per-section skeletons appear, then resolve without layout shift
- [ ] At **375px** — stat cards reflow to 2-up, table rows become stacked cards, nothing overflows
- [ ] At **768px** — stat cards reflow to 3-up
- [ ] At **1280px** — stat cards show full 6-up row
- [ ] Tab through the page — banner CTA, "View all" links, and table row links are keyboard-reachable with visible focus rings; headings are hierarchical (h1 → section CardTitles)
- [ ] Toggle **dark mode** → all surfaces, status dot accents, and the warning banner render correctly
- [ ] `npm run prettier:check && npm run eslint:check && npm run tsc:check` all pass

## Automated checks

- `tsc:check` — pass
- `eslint:check` — pass
- `prettier:check` — pass

## Notes

- Admin Recent Applications rows link to `/applications/[id]`; that detail route does not exist yet (blocked by #75, #64, #43) — links are intentionally forward-pointing and harmless until clicked
- Draft applications are excluded from admin counts/recent list; the user widget's own draft handling is unchanged
