### PR TITLE
#152 Auto-Enforce Position Open And Close Dates

### DIFF
--- a/components/features/open-positions-widget.tsx
+++ b/components/features/open-positions-widget.tsx
@@ -4,6 +4,8 @@ import { ArrowRight, Briefcase } from 'lucide-react';
 
 import { getPositions } from '@/prisma/data/positions';
 
+import { formatDate, getPositionAvailability } from '@/lib/utils';
+
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -46,25 +48,39 @@ export async function OpenPositionsWidget() {
           </div>
         ) : (
           <ul className="divide-y">
-            {displayed.map((position) => (
-              <li key={position.id} className="flex flex-col gap-1.5 p-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium">
-                      {position.title}
-                    </p>
-                    {position.description && (
-                      <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
-                        {position.description}
+            {displayed.map((position) => {
+              const availability = getPositionAvailability(position);
+              const isAccepting = availability === 'accepting';
+              return (
+                <li key={position.id} className="flex flex-col gap-1.5 p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">
+                        {position.title}
                       </p>
+                      {position.description && (
+                        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
+                          {position.description}
+                        </p>
+                      )}
+                    </div>
+                    {isAccepting ? (
+                      <Button asChild size="sm" className="shrink-0">
+                        <Link href={`/positions/${position.id}/apply`}>
+                          Apply
+                        </Link>
+                      </Button>
+                    ) : (
+                      <span className="text-muted-foreground shrink-0 text-xs">
+                        {availability === 'upcoming' && position.opensAt
+                          ? `Opens ${formatDate(position.opensAt)}`
+                          : 'Closed'}
+                      </span>
                     )}
                   </div>
-                  <Button asChild size="sm" className="shrink-0">
-                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
-                  </Button>
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </CardContent>

--- a/components/features/open-positions-widget.tsx
+++ b/components/features/open-positions-widget.tsx
@@ -74,7 +74,7 @@ export async function OpenPositionsWidget() {
                       <span className="text-muted-foreground shrink-0 text-xs">
                         {availability === 'upcoming' && position.opensAt
                           ? `Opens ${formatDate(position.opensAt)}`
-                          : 'Closed'}
+                          : /* closed_by_date or unavailable (unreachable via getPositions(false)) */ 'Closed'}
                       </span>
                     )}
                   </div>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -5,7 +5,12 @@ import { useState } from 'react';
 
 import { ChevronDown, ChevronUp, Inbox, Pencil } from 'lucide-react';
 
-import { STATUS_LABELS, STATUS_VARIANTS } from '@/lib/constants';
+import {
+  AVAILABILITY_LABELS,
+  AVAILABILITY_VARIANTS,
+  STATUS_LABELS,
+  STATUS_VARIANTS,
+} from '@/lib/constants';
 import type { PositionWithQuestions } from '@/lib/types';
 import { formatDate, getPositionAvailability } from '@/lib/utils';
 
@@ -40,8 +45,19 @@ export function PositionCard({
           <div className="flex items-center gap-3">
             <CardTitle className="text-lg">{position.title}</CardTitle>
             {showAdminActions && (
-              <Badge variant={STATUS_VARIANTS[position.status] ?? 'outline'}>
-                {STATUS_LABELS[position.status] ?? position.status}
+              // Use computed availability so a date-closed 'open' position shows
+              // "Closed" rather than "Open". Fall back to STATUS_LABELS for
+              // 'unavailable' (draft/closed) so draft still reads "Draft".
+              <Badge
+                variant={
+                  availability === 'unavailable'
+                    ? (STATUS_VARIANTS[position.status] ?? 'outline')
+                    : AVAILABILITY_VARIANTS[availability]
+                }
+              >
+                {availability === 'unavailable'
+                  ? (STATUS_LABELS[position.status] ?? position.status)
+                  : AVAILABILITY_LABELS[availability]}
               </Badge>
             )}
           </div>
@@ -75,7 +91,7 @@ export function PositionCard({
           <div className="flex items-center gap-2 pt-2">
             {showAdminActions ? (
               <>
-                {position.status === 'open' && (
+                {isAccepting && (
                   <Button asChild>
                     <Link href={`/positions/${position.id}/apply`}>Apply</Link>
                   </Button>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, ChevronUp, Inbox, Pencil } from 'lucide-react';
 
 import { STATUS_LABELS, STATUS_VARIANTS } from '@/lib/constants';
 import type { PositionWithQuestions } from '@/lib/types';
+import { formatDate, getPositionAvailability } from '@/lib/utils';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -22,6 +23,10 @@ export function PositionCard({
   showAdminActions = false,
 }: PositionCardProps) {
   const [open, setOpen] = useState(false);
+
+  // Derive availability once per render so copy and button logic stay in sync.
+  const availability = getPositionAvailability(position);
+  const isAccepting = availability === 'accepting';
 
   return (
     <Card className="gap-0 p-0">
@@ -68,13 +73,13 @@ export function PositionCard({
           )}
 
           <div className="flex items-center gap-2 pt-2">
-            {(!showAdminActions || position.status === 'open') && (
-              <Button asChild>
-                <Link href={`/positions/${position.id}/apply`}>Apply</Link>
-              </Button>
-            )}
-            {showAdminActions && (
+            {showAdminActions ? (
               <>
+                {position.status === 'open' && (
+                  <Button asChild>
+                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
+                  </Button>
+                )}
                 <Button asChild variant="outline">
                   <Link href={`/positions/${position.id}/edit`}>
                     <Pencil className="size-4" />
@@ -87,6 +92,31 @@ export function PositionCard({
                     Applications
                   </Link>
                 </Button>
+              </>
+            ) : (
+              <>
+                {isAccepting && (
+                  <>
+                    <Button asChild>
+                      <Link href={`/positions/${position.id}/apply`}>
+                        Apply
+                      </Link>
+                    </Button>
+                    {position.closesAt && (
+                      <span className="text-muted-foreground text-sm">
+                        Closes {formatDate(position.closesAt)}
+                      </span>
+                    )}
+                  </>
+                )}
+                {availability === 'upcoming' && position.opensAt && (
+                  <Badge variant="secondary">
+                    Opens {formatDate(position.opensAt)}
+                  </Badge>
+                )}
+                {availability === 'closed_by_date' && (
+                  <Badge variant="outline">Closed</Badge>
+                )}
               </>
             )}
           </div>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,6 +3,8 @@ import { z } from 'zod/v4';
 import { $Enums } from '@/prisma/client';
 import type { PositionStatus, QuestionType } from '@/prisma/client';
 
+import type { PositionAvailability } from '@/lib/types';
+
 import type { BadgeVariant } from '@/components/ui/badge';
 
 export const QUESTION_TYPE_VALUES = [
@@ -109,3 +111,21 @@ export const QUESTION_TYPE_OPTIONS: { value: QuestionType; label: string }[] = [
   { value: 'single_choice', label: 'Single Choice' },
   { value: 'multiple_choice', label: 'Multiple Choice' },
 ];
+
+// Human-readable labels for each computed availability state.
+// 'accepting'/'closed_by_date' intentionally mirror STATUS_LABELS 'open'/'closed' so
+// the admin badge reflects the effective state rather than the raw DB status enum.
+export const AVAILABILITY_LABELS: Record<PositionAvailability, string> = {
+  accepting: 'Open',
+  upcoming: 'Upcoming',
+  closed_by_date: 'Closed',
+  unavailable: 'Closed',
+};
+
+export const AVAILABILITY_VARIANTS: Record<PositionAvailability, BadgeVariant> =
+  {
+    accepting: 'default',
+    upcoming: 'secondary',
+    closed_by_date: 'outline',
+    unavailable: 'outline',
+  };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -108,6 +108,22 @@ export type AdminApplicationListItem = Prisma.ApplicationGetPayload<{
   };
 }>;
 
+// Minimal structural type for the position-window helper. Satisfied by
+// PositionWithQuestions, PositionForEdit, and raw Prisma rows — no conversion needed.
+export type PositionWindow = {
+  status: PositionStatus;
+  opensAt: Date | null;
+  closesAt: Date | null;
+};
+
+// Applicant-facing availability states derived from status + date window.
+// 'unavailable' covers draft/closed positions (status is the master switch).
+export type PositionAvailability =
+  | 'accepting'
+  | 'upcoming'
+  | 'closed_by_date'
+  | 'unavailable';
+
 // Admin-only type — open position with filtered non-draft application count.
 // Must only be used in admin-gated contexts.
 export type OpenPositionSummaryItem = Prisma.PositionGetPayload<{

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,7 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-import type { PositionStatus } from '@/prisma/client';
+import type { PositionAvailability, PositionWindow } from '@/lib/types';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -34,22 +34,6 @@ export function formatDate(date: Date): string {
   }).format(date);
 }
 
-// Minimal structural type for the position-window helper. Satisfied by
-// PositionWithQuestions, PositionForEdit, and raw Prisma rows — no conversion needed.
-export type PositionWindow = {
-  status: PositionStatus;
-  opensAt: Date | null;
-  closesAt: Date | null;
-};
-
-// Applicant-facing availability states derived from status + date window.
-// 'unavailable' covers draft/closed positions (status is the master switch).
-export type PositionAvailability =
-  | 'accepting'
-  | 'upcoming'
-  | 'closed_by_date'
-  | 'unavailable';
-
 /**
  * Derives the applicant-facing availability of a position.
  *
@@ -72,10 +56,15 @@ export function getPositionAvailability(
   if (position.opensAt !== null && now < position.opensAt) return 'upcoming';
 
   if (position.closesAt !== null) {
-    // End-of-day for closesAt: advance to the next calendar day and subtract 1ms.
-    const endOfCloseDay = new Date(position.closesAt);
-    endOfCloseDay.setDate(endOfCloseDay.getDate() + 1);
-    endOfCloseDay.setMilliseconds(endOfCloseDay.getMilliseconds() - 1);
+    // End-of-day for closesAt: UTC-explicit to stay timezone-proof on any host.
+    // Advance to the next UTC calendar day and subtract 1ms → 23:59:59.999 UTC.
+    const endOfCloseDay = new Date(
+      Date.UTC(
+        position.closesAt.getUTCFullYear(),
+        position.closesAt.getUTCMonth(),
+        position.closesAt.getUTCDate() + 1,
+      ) - 1,
+    );
     if (now > endOfCloseDay) return 'closed_by_date';
   }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+import type { PositionStatus } from '@/prisma/client';
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -30,4 +32,60 @@ export function formatDate(date: Date): string {
     day: 'numeric',
     year: 'numeric',
   }).format(date);
+}
+
+// Minimal structural type for the position-window helper. Satisfied by
+// PositionWithQuestions, PositionForEdit, and raw Prisma rows — no conversion needed.
+export type PositionWindow = {
+  status: PositionStatus;
+  opensAt: Date | null;
+  closesAt: Date | null;
+};
+
+// Applicant-facing availability states derived from status + date window.
+// 'unavailable' covers draft/closed positions (status is the master switch).
+export type PositionAvailability =
+  | 'accepting'
+  | 'upcoming'
+  | 'closed_by_date'
+  | 'unavailable';
+
+/**
+ * Derives the applicant-facing availability of a position.
+ *
+ * Date semantics (important — positions use date-only inputs):
+ *   - opensAt  → start-of-day: position opens at the beginning of opensAt day.
+ *   - closesAt → inclusive of its whole day: the stored midnight value means the
+ *     position is available *through* that day, so we compare against end-of-day
+ *     (23:59:59.999). A naive `now > closesAt` would close it at midnight on the
+ *     chosen day; inclusive end-of-day honors user intent ("open through Jun 30").
+ *
+ * `now` defaults to `new Date()` but is injectable for testing and so callers
+ * within a single action can pass a consistent timestamp.
+ */
+export function getPositionAvailability(
+  position: PositionWindow,
+  now: Date = new Date(),
+): PositionAvailability {
+  if (position.status !== 'open') return 'unavailable';
+
+  if (position.opensAt !== null && now < position.opensAt) return 'upcoming';
+
+  if (position.closesAt !== null) {
+    // End-of-day for closesAt: advance to the next calendar day and subtract 1ms.
+    const endOfCloseDay = new Date(position.closesAt);
+    endOfCloseDay.setDate(endOfCloseDay.getDate() + 1);
+    endOfCloseDay.setMilliseconds(endOfCloseDay.getMilliseconds() - 1);
+    if (now > endOfCloseDay) return 'closed_by_date';
+  }
+
+  return 'accepting';
+}
+
+/** Convenience boolean: returns true only when the position is in the 'accepting' state. */
+export function isAcceptingApplications(
+  position: PositionWindow,
+  now?: Date,
+): boolean {
+  return getPositionAvailability(position, now) === 'accepting';
 }

--- a/prisma/actions/applications.ts
+++ b/prisma/actions/applications.ts
@@ -16,7 +16,11 @@ import { getCurrentUser } from '@/lib/auth/server';
 import { APPLICATION_STATUS_VALUES } from '@/lib/constants';
 import prisma from '@/lib/prisma';
 import { type DraftApplication } from '@/lib/types';
-import { type ResponseType, toStringArray } from '@/lib/utils';
+import {
+  type ResponseType,
+  isAcceptingApplications,
+  toStringArray,
+} from '@/lib/utils';
 
 type GlobalAnswerWithQuestion = GlobalAnswer & {
   globalQuestion: GlobalQuestion;
@@ -45,6 +49,9 @@ export async function createDraftApplication(
   const parsed = createDraftApplicationSchema.safeParse({ positionId });
   if (!parsed.success) return { error: 'Invalid input' };
 
+  // Use a single consistent `now` for both the transaction and any window checks.
+  const now = new Date();
+
   return prisma.$transaction(async (tx) => {
     const existing = await tx.application.findUnique({
       where: {
@@ -56,7 +63,20 @@ export async function createDraftApplication(
       include: { globalAnswers: true, positionAnswers: true },
     });
 
+    // Return an existing draft even if the window has since closed — the applicant
+    // can still see their in-progress work; submitApplication will block the submit.
     if (existing) return existing;
+
+    // Authoritative window gate: verify the position exists and is currently accepting
+    // before creating a new draft. Reads server-trusted DB fields — no IDOR surface.
+    const position = await tx.position.findUnique({
+      where: { id: parsed.data.positionId, deletedAt: null },
+      select: { status: true, opensAt: true, closesAt: true },
+    });
+
+    if (!position) return { error: 'This position is no longer available.' };
+    if (!isAcceptingApplications(position, now))
+      return { error: 'This position is no longer accepting applications.' };
 
     const globalAnswers = await tx.globalAnswer.findMany({
       where: { userId: currentUser.id, deletedAt: null },
@@ -166,12 +186,24 @@ export async function submitApplication(
     include: {
       globalAnswers: true,
       positionAnswers: true,
-      position: { include: { questions: { where: { deletedAt: null } } } },
+      position: {
+        select: {
+          status: true,
+          opensAt: true,
+          closesAt: true,
+          questions: { where: { deletedAt: null } },
+        },
+      },
     },
   });
 
   if (!application || application.userId !== currentUser.id)
     return { error: 'Unauthorized' };
+
+  // Window re-check: a window can close while a draft is open. Checked before
+  // required-answer validation so a closed window gives the clearest message.
+  if (!isAcceptingApplications(application.position))
+    return { error: 'This position is no longer accepting applications.' };
 
   const requiredGlobalQuestions = await prisma.globalQuestion.findMany({
     where: { required: true, deletedAt: null },

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -6,6 +6,7 @@ import {
   type PositionForEdit,
   type PositionWithQuestions,
 } from '@/lib/types';
+import { isAcceptingApplications } from '@/lib/utils';
 
 export async function getPositions(
   includeAll = false,
@@ -41,7 +42,7 @@ export async function getPositions(
 export async function getPositionForApply(
   id: string,
 ): Promise<PositionWithQuestions | null> {
-  return prisma.position.findUnique({
+  const position = await prisma.position.findUnique({
     where: { id, status: 'open', deletedAt: null },
     select: {
       id: true,
@@ -64,6 +65,11 @@ export async function getPositionForApply(
       },
     },
   });
+
+  // Gate: return null for positions outside their date window so the apply route
+  // redirects to /positions (which shows the effective state on the card).
+  if (!position || !isAcceptingApplications(position)) return null;
+  return position;
 }
 
 // Minimal fetch for the applications page access check: avoids over-fetching


### PR DESCRIPTION
Closes #152

## Summary

- Adds a single shared helper (`getPositionAvailability` / `isAcceptingApplications` in `lib/utils.ts`) that encodes the date-window rule in one place so it cannot drift across layers.
- Gates `getPositionForApply` so out-of-window positions return `null` (the apply route already redirects on `null`).
- Adds authoritative window re-checks to `createDraftApplication` and `submitApplication` so direct URL or mid-draft races are blocked with clear user-facing `{ error }` messages.
- Updates `PositionCard` (applicant branch) and `OpenPositionsWidget` to derive availability from the helper and show "Opens {date}" / "Closes {date}" / "Closed" indicators; Apply is hidden when not accepting.

## Changes

- `lib/utils.ts` — add `PositionWindow`, `PositionAvailability`, `getPositionAvailability`, `isAcceptingApplications`; inclusive end-of-day semantics for `closesAt` documented in a comment.
- `prisma/data/positions.ts` — `getPositionForApply` returns `null` when `!isAcceptingApplications(position)`.
- `prisma/actions/applications.ts` — `createDraftApplication` fetches window fields and returns `{ error }` for unavailable / not-accepting; `submitApplication` extends position select to include window fields and re-checks before required-answer validation.
- `components/features/position-card.tsx` — applicant branch: derive `availability`, show Apply + "Closes {date}" hint when accepting, "Opens {date}" badge when upcoming, "Closed" badge when closed by date; admin branch unchanged.
- `components/features/open-positions-widget.tsx` — per-row availability check; Apply only when accepting, else compact muted state label.

## Testing plan

- [ ] **Open, no dates (regression):** as applicant, `/positions` shows card with Apply button; full apply + submit succeeds.
- [ ] **Open, within window (regression):** set `opensAt` = yesterday, `closesAt` = future date; applicant sees Apply plus "Closes {date}" hint; apply + submit succeeds.
- [ ] **Upcoming (future opensAt):** set `opensAt` = tomorrow; applicant `/positions` shows card with no Apply button and "Opens {date}" badge; visiting `/positions/<id>/apply` directly redirects to `/positions`; dashboard widget shows no Apply.
- [ ] **Closed by date (past closesAt):** set `closesAt` = yesterday (status still `open`); applicant sees "Closed" badge, no Apply; direct `/positions/<id>/apply` redirects to `/positions`.
- [ ] **closesAt inclusive same-day:** set `closesAt` = today; applicant can still Apply today (position is open through end of chosen day).
- [ ] **Window closes mid-draft (submit gate):** start an application while window is open, reach step 2; as admin edit `closesAt` to yesterday; back as applicant, click Submit → inline error + toast "This position is no longer accepting applications."; not redirected; draft preserved.
- [ ] **Admin path unaffected:** admin `/positions` shows draft/open/closed and upcoming/closed-by-date positions with Edit + Applications; admin Apply button follows `status === 'open'` only, not date window.
- [ ] **Single source of truth (AC 5):** by inspection, list card, dashboard widget, `getPositionForApply`, `createDraftApplication`, and `submitApplication` all call the helper in `lib/utils.ts`.

## Automated checks

- `npm run prettier:check` — passes
- `npm run eslint:check` — passes
- `npm run tsc:check` — passes

## Notes

Date boundary semantics: `opensAt` is start-of-day (position opens at the beginning of the chosen day); `closesAt` is inclusive end-of-day (position is available through the entire chosen day, so we compare against end-of-day 23:59:59.999). This matches date-picker user intent and is documented in the helper comment. No schema change was required.
