### PR TITLE
#148 Bypass Logout And Real-Auth Login On Dev Deployments

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,7 +1,6 @@
-import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
-import { getCurrentUser } from '@/lib/auth/server';
+import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
 import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
@@ -11,12 +10,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   const user = await getCurrentUser();
 
   const roleLabel = user.isAdmin ? 'Admin' : 'User';
-
-  // isBypass is true only when a bypass cookie is present on a non-prod environment.
-  // It gates the Log out control in the user menu (real-auth sign-out is out of scope).
-  const isBypass =
-    process.env.VERCEL_ENV !== 'production' &&
-    Boolean((await cookies()).get('dev-bypass-user-id')?.value);
+  const isBypass = await getIsBypass();
 
   const identity: NavIdentity = { email: user.email, roleLabel, isBypass };
 

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,8 @@
+import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
 import { getCurrentUser } from '@/lib/auth/server';
+import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
 import { Sidebar } from '@/components/layouts/sidebar';
@@ -8,11 +10,21 @@ import { Sidebar } from '@/components/layouts/sidebar';
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const user = await getCurrentUser();
 
+  const roleLabel = user.isAdmin ? 'Admin' : 'User';
+
+  // isBypass is true only when a bypass cookie is present on a non-prod environment.
+  // It gates the Log out control in the user menu (real-auth sign-out is out of scope).
+  const isBypass =
+    process.env.VERCEL_ENV !== 'production' &&
+    Boolean((await cookies()).get('dev-bypass-user-id')?.value);
+
+  const identity: NavIdentity = { email: user.email, roleLabel, isBypass };
+
   return (
     <div className="flex h-dvh w-full overflow-hidden">
-      <Sidebar isAdmin={user.isAdmin} />
+      <Sidebar isAdmin={user.isAdmin} identity={identity} />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <MobileNav isAdmin={user.isAdmin} />
+        <MobileNav isAdmin={user.isAdmin} identity={identity} />
         <main className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 p-6">{children}</div>
         </main>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,7 +1,6 @@
-import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
-import { getCurrentUser } from '@/lib/auth/server';
+import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
 import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
@@ -11,12 +10,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   const user = await getCurrentUser();
 
   const roleLabel = user.isAdmin ? 'Admin' : 'User';
-
-  // isBypass is true only when a bypass cookie is present on a non-prod environment.
-  // It gates the Log out control in the user menu (real-auth sign-out is out of scope).
-  const isBypass =
-    process.env.VERCEL_ENV !== 'production' &&
-    Boolean((await cookies()).get('dev-bypass-user-id')?.value);
+  const isBypass = await getIsBypass();
 
   const identity: NavIdentity = { email: user.email, roleLabel, isBypass };
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,6 +1,8 @@
+import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
 import { getCurrentUser } from '@/lib/auth/server';
+import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
 import { Sidebar } from '@/components/layouts/sidebar';
@@ -8,11 +10,21 @@ import { Sidebar } from '@/components/layouts/sidebar';
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const user = await getCurrentUser();
 
+  const roleLabel = user.isAdmin ? 'Admin' : 'User';
+
+  // isBypass is true only when a bypass cookie is present on a non-prod environment.
+  // It gates the Log out control in the user menu (real-auth sign-out is out of scope).
+  const isBypass =
+    process.env.VERCEL_ENV !== 'production' &&
+    Boolean((await cookies()).get('dev-bypass-user-id')?.value);
+
+  const identity: NavIdentity = { email: user.email, roleLabel, isBypass };
+
   return (
     <div className="flex h-dvh w-full overflow-hidden">
-      <Sidebar isAdmin={user.isAdmin} />
+      <Sidebar isAdmin={user.isAdmin} identity={identity} />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <MobileNav isAdmin={user.isAdmin} />
+        <MobileNav isAdmin={user.isAdmin} identity={identity} />
         <main className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 p-6">{children}</div>
         </main>

--- a/app/login/bypass/page.tsx
+++ b/app/login/bypass/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { loginAsBypassUser } from '@/prisma/services/dev-bypass';
 
 import { Button } from '@/components/ui/button';
@@ -28,6 +30,14 @@ export default function BypassLoginPage() {
               Position Manager
             </Button>
           </form>
+        </div>
+        <div className="border-border flex flex-col items-center gap-2 border-t pt-4">
+          <p className="text-muted-foreground text-xs">
+            Or sign in with a real account to test production-style auth.
+          </p>
+          <Button variant="ghost" className="w-full" asChild>
+            <Link href="/login">Sign in with real auth</Link>
+          </Button>
         </div>
       </div>
     </div>

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -7,17 +7,20 @@ import { useState } from 'react';
 
 import { Menu } from 'lucide-react';
 
+import type { NavIdentity } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 import { adminNavItems, baseNavItems } from '@/components/layouts/nav-items';
+import { UserMenu } from '@/components/layouts/user-menu';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 
 interface MobileNavProps {
   isAdmin: boolean;
+  identity: NavIdentity;
 }
 
-export function MobileNav({ isAdmin }: MobileNavProps) {
+export function MobileNav({ isAdmin, identity }: MobileNavProps) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const navItems = isAdmin ? [...baseNavItems, ...adminNavItems] : baseNavItems;
@@ -39,7 +42,7 @@ export function MobileNav({ isAdmin }: MobileNavProps) {
           >
             <Menu className="size-5" />
           </Button>
-          <SheetContent side="left">
+          <SheetContent side="left" className="flex flex-col p-0">
             <div className="border-sidebar-border flex h-14 items-center border-b px-4">
               <SheetTitle asChild>
                 <Link
@@ -80,6 +83,10 @@ export function MobileNav({ isAdmin }: MobileNavProps) {
                 );
               })}
             </nav>
+
+            <div className="border-sidebar-border mt-auto border-t p-2">
+              <UserMenu identity={identity} />
+            </div>
           </SheetContent>
         </Sheet>
       </div>

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -4,15 +4,18 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+import type { NavIdentity } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 import { adminNavItems, baseNavItems } from '@/components/layouts/nav-items';
+import { UserMenu } from '@/components/layouts/user-menu';
 
 interface SidebarProps {
   isAdmin: boolean;
+  identity: NavIdentity;
 }
 
-export function Sidebar({ isAdmin }: SidebarProps) {
+export function Sidebar({ isAdmin, identity }: SidebarProps) {
   const pathname = usePathname();
   const navItems = isAdmin ? [...baseNavItems, ...adminNavItems] : baseNavItems;
 
@@ -43,6 +46,10 @@ export function Sidebar({ isAdmin }: SidebarProps) {
           );
         })}
       </nav>
+
+      <div className="border-sidebar-border mt-auto border-t p-2">
+        <UserMenu identity={identity} />
+      </div>
     </aside>
   );
 }

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { ChevronUp } from 'lucide-react';
+
+import { logoutBypassUser } from '@/prisma/services/dev-bypass';
+
+import type { NavIdentity } from '@/lib/types';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface UserMenuProps {
+  identity: NavIdentity;
+}
+
+export function UserMenu({ identity }: UserMenuProps) {
+  const { email, roleLabel, isBypass } = identity;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={`Account menu for ${email}`}
+          className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{email}</p>
+            <p className="text-muted-foreground text-xs">{roleLabel}</p>
+          </div>
+          <ChevronUp
+            className="text-muted-foreground size-4 shrink-0"
+            aria-hidden
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" className="w-52">
+        <DropdownMenuLabel className="font-normal">
+          <p className="truncate text-sm font-medium">{email}</p>
+          <p className="text-muted-foreground text-xs">{roleLabel}</p>
+        </DropdownMenuLabel>
+        {isBypass && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <form action={logoutBypassUser}>
+                <button
+                  type="submit"
+                  className="text-destructive w-full cursor-pointer text-left text-sm"
+                >
+                  Log out
+                </button>
+              </form>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTransition } from 'react';
+
 import { ChevronUp } from 'lucide-react';
 
 import { logoutBypassUser } from '@/prisma/services/dev-bypass';
@@ -21,6 +23,7 @@ interface UserMenuProps {
 
 export function UserMenu({ identity }: UserMenuProps) {
   const { email, roleLabel, isBypass } = identity;
+  const [pending, startTransition] = useTransition();
 
   return (
     <DropdownMenu>
@@ -47,15 +50,12 @@ export function UserMenu({ identity }: UserMenuProps) {
         {isBypass && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <form action={logoutBypassUser}>
-                <button
-                  type="submit"
-                  className="text-destructive w-full cursor-pointer text-left text-sm"
-                >
-                  Log out
-                </button>
-              </form>
+            <DropdownMenuItem
+              disabled={pending}
+              onSelect={() => startTransition(() => logoutBypassUser())}
+              className="text-destructive cursor-pointer text-sm"
+            >
+              Log out
             </DropdownMenuItem>
           </>
         )}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -15,6 +15,13 @@ async function resolveRealUser() {
   return prisma.user.findUnique({ where: { neonAuthId: session.user.id } });
 }
 
+// Returns true only when a bypass cookie is present on a non-production environment.
+// Extracted so layouts share a single definition; called after getCurrentUser() resolves.
+export async function getIsBypass(): Promise<boolean> {
+  if (process.env.VERCEL_ENV === 'production') return false;
+  return Boolean((await cookies()).get('dev-bypass-user-id')?.value);
+}
+
 // React.cache deduplicates calls within a single server render pass,
 // avoiding a redundant DB round-trip when layout and page both call getCurrentUser().
 export const getCurrentUser = cache(async function getCurrentUser() {

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -7,6 +7,14 @@ import prisma from '@/lib/prisma';
 
 export const authServer = createAuthServer();
 
+// Resolve a real Neon Auth session to a database user.
+// Returns null when no valid session exists.
+async function resolveRealUser() {
+  const { data: session } = await authServer.getSession();
+  if (!session?.user) return null;
+  return prisma.user.findUnique({ where: { neonAuthId: session.user.id } });
+}
+
 // React.cache deduplicates calls within a single server render pass,
 // avoiding a redundant DB round-trip when layout and page both call getCurrentUser().
 export const getCurrentUser = cache(async function getCurrentUser() {
@@ -14,23 +22,22 @@ export const getCurrentUser = cache(async function getCurrentUser() {
     const cookieStore = await cookies();
     const bypassUserId = cookieStore.get('dev-bypass-user-id')?.value;
 
-    if (!bypassUserId) redirect('/login/bypass');
+    if (bypassUserId) {
+      const user = await prisma.user.findUnique({
+        where: { id: bypassUserId },
+      });
+      // Valid bypass session — use it.
+      if (user) return user;
+      // Stale/invalid bypass cookie — fall through to real auth rather than dead-ending.
+    }
 
-    const user = await prisma.user.findUnique({ where: { id: bypassUserId } });
+    const realUser = await resolveRealUser();
+    if (realUser) return realUser;
 
-    if (!user) redirect('/login/bypass');
-
-    return user;
+    redirect('/login/bypass');
   }
 
-  const { data: session } = await authServer.getSession();
-  if (!session?.user) redirect('/login');
-
-  const user = await prisma.user.findUnique({
-    where: { neonAuthId: session.user.id },
-  });
-
-  if (!user) redirect('/login');
-
-  return user;
+  const realUser = await resolveRealUser();
+  if (realUser) return realUser;
+  redirect('/login');
 });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,3 +149,13 @@ export type ApplicationForReview = Prisma.ApplicationGetPayload<{
     };
   };
 }>;
+
+// Identity shape passed to nav components so sidebar and mobile nav agree
+// on what to display in the user menu.
+export interface NavIdentity {
+  email: string;
+  roleLabel: string;
+  // true only for bypass sessions on non-production environments;
+  // gates the Log out control which is bypass-only (real-auth sign-out is out of scope).
+  isBypass: boolean;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,15 +3,18 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const isBypassActive = process.env.VERCEL_ENV !== 'production';
 
-function bypassMiddleware(request: NextRequest): NextResponse {
+async function bypassMiddleware(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
 
-  if (pathname === '/login/bypass') return NextResponse.next();
+  // Both auth entry points are always reachable on dev so testers can switch modes.
+  if (pathname === '/login/bypass' || pathname === '/login')
+    return NextResponse.next();
 
-  const cookie = request.cookies.get('dev-bypass-user-id');
-  if (cookie) return NextResponse.next();
+  // A picked bypass role short-circuits real-auth checks.
+  if (request.cookies.get('dev-bypass-user-id')) return NextResponse.next();
 
-  return NextResponse.redirect(new URL('/login/bypass', request.url));
+  // No bypass cookie — honour a real Neon Auth session; redirect the rest to the picker.
+  return neonAuthMiddleware({ loginUrl: '/login/bypass' })(request);
 }
 
 export default function middleware(request: NextRequest) {

--- a/prisma/services/dev-bypass.ts
+++ b/prisma/services/dev-bypass.ts
@@ -76,3 +76,14 @@ export async function loginAsBypassUser(role: BypassRole) {
 
   redirect('/positions');
 }
+
+// Clears the bypass session cookie and returns the caller to the picker.
+// Hard no-op in production — the cookie and this action are dev-only (ENGINEERING §3).
+export async function logoutBypassUser() {
+  if (process.env.VERCEL_ENV === 'production') return;
+
+  const cookieStore = await cookies();
+  cookieStore.delete('dev-bypass-user-id');
+
+  redirect('/login/bypass');
+}


### PR DESCRIPTION
Closes #148

## Summary

- Makes auth resolution additive on non-prod: bypass cookie wins if present, otherwise falls back to a real Neon Auth session, then redirects to `/login/bypass` only when neither is present.
- Adds `logoutBypassUser` server action (env-gated no-op in production) that clears the bypass cookie and redirects to `/login/bypass`.
- Adds a `UserMenu` client component in the sidebar and mobile nav showing the current identity (email + role), with a conditional Log out button shown only for bypass sessions.
- Adds a "Sign in with real auth" link on the `/login/bypass` page so both auth paths are reachable from one place.

## Changes

- `lib/types.ts` — add `NavIdentity` interface
- `lib/auth/server.ts` — extract `resolveRealUser()` helper; non-prod branch tries bypass cookie first, then real session, then redirects; production branch unchanged
- `middleware.ts` — non-prod branch allows `/login` and `/login/bypass` through, short-circuits on bypass cookie, otherwise delegates to `neonAuthMiddleware({ loginUrl: '/login/bypass' })`
- `prisma/services/dev-bypass.ts` — add env-gated `logoutBypassUser()` action
- `app/login/bypass/page.tsx` — add "Sign in with real auth" link to `/login`
- `components/layouts/user-menu.tsx` — new `'use client'` component using `dropdown-menu`; shows email/role, conditional Log out form action
- `app/(main)/layout.tsx` and `app/(app)/layout.tsx` — compute `isBypass` and `roleLabel`, pass `identity: NavIdentity` to `Sidebar` and `MobileNav`
- `components/layouts/sidebar.tsx` — accept `identity`, render `UserMenu` pinned to the sidebar bottom
- `components/layouts/mobile-nav.tsx` — accept `identity`, render `UserMenu` in the sheet footer

## Testing plan

- [ ] Visit any protected route while logged out — redirected to `/login/bypass`
- [ ] Click **Admin** on the bypass login page — lands in the app; sidebar shows `bypass-admin@example.com` / `Admin`
- [ ] Open the user menu in the sidebar — shows email and role; **Log out** is visible
- [ ] Click **Log out** — redirected to `/login/bypass`; pick **Applicant** — lands in the app as the applicant; sidebar shows applicant email and `User`
- [ ] Resize to mobile — open the sheet; same identity and Log out button are visible; Log out redirects to `/login/bypass`
- [ ] On `/login/bypass` click **Sign in with real auth** — navigates to `/login` (Neon Auth `AuthView` renders)
- [ ] Complete the real Neon Auth OTP flow with a real account — land in the app as that user; **no Log out** button visible in the menu (bypass-only)
- [ ] With a real session active, pick a bypass role from `/login/bypass` — app shows the bypass identity and Log out; after logout, app falls back to the real session automatically
- [ ] While fully logged out, hitting a protected route redirects to `/login/bypass`; both `/login` and `/login/bypass` are reachable directly
- [ ] With `VERCEL_ENV=production`: role buttons on `/login/bypass` are no-ops; no Log out item renders; unauthenticated traffic routes through real Neon Auth to `/login`
- [ ] `npm run prettier:check`, `npm run eslint:check`, `npm run tsc:check` all pass

## Automated checks

All three pre-push checks pass: prettier, eslint (0 warnings), and tsc (0 errors).

## Notes

The `app/(app)/layout.tsx` file (separate from `app/(main)/layout.tsx`) also needed the identity prop plumbing — it was found during the TypeScript check. Both layout files now pass identity to `Sidebar` and `MobileNav`.

The `neonAuthMiddleware` return type is `Promise<NextResponse>`, so `bypassMiddleware` is now `async` to satisfy the type checker while keeping the composition pattern identical to the production branch.
