### PR TITLE
#156 Favicon Missing On Unauthenticated Routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -20,5 +20,10 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+  // Exclude Next internals and public metadata/icon assets so the
+  // file-convention favicon (/icon.svg) and apple-touch icon (/apple-icon)
+  // load on unauthenticated routes instead of being redirected to login.
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|icon.svg|apple-icon|sitemap.xml|robots.txt).*)',
+  ],
 };


### PR DESCRIPTION
Closes #156

## Summary

- The favicon was absent on unauthenticated routes (`/login`, `/login/bypass`) because the middleware matcher let `/icon.svg` and `/apple-icon` pass through `middleware()`, causing those asset requests to be redirected to the login flow on a fresh session.
- Broadened the negative-lookahead in the `matcher` to also exclude `icon.svg`, `apple-icon`, `sitemap.xml`, and `robots.txt` — the standard Next.js file-convention metadata routes — so the browser can fetch them unauthenticated.
- All real page routes remain fully auth-gated; only the public icon/metadata assets are allowed through without authentication.

## Changes

- `middleware.ts` — adds `icon.svg|apple-icon|sitemap.xml|robots.txt` to the matcher's negative-lookahead exclusion list.

## Testing plan

- [ ] Run a production build: `npm run build && npm run start`. Open a fresh incognito window with DevTools → Network (cache disabled). Load `http://localhost:3000/login`. Confirm `GET /icon.svg` returns **200** with `content-type: image/svg+xml` and the Aplio favicon renders in the browser tab (not a redirect to a login page).
- [ ] Same test for `http://localhost:3000/login/bypass` — favicon renders and `/icon.svg` is 200.
- [ ] Directly request `/apple-icon` while unauthenticated; confirm **200** with `content-type: image/png` (180x180), not a redirect.
- [ ] In the same fresh session, navigate to a protected page (e.g. `/positions`). Confirm you are still redirected to the login flow — auth gating is intact.
- [ ] Log in (dev bypass: click a role on `/login/bypass`). Load an authenticated route and confirm the favicon and apple-touch icon still render (no regression).
- [ ] (Dev-mode check) Run `npm run dev`. With no `dev-bypass-user-id` cookie, load `/login` — favicon should now render in dev mode too, because the middleware bypass also no longer intercepts the icon routes.

## Automated checks

- `npm run prettier:check` — pass (middleware.ts formatted; other pre-existing warnings are unchanged).
- `npm run eslint:check` — pass.
- `npm run tsc:check` — pass.

## Notes

`sitemap.xml` and `robots.txt` are added defensively so a future `app/sitemap.ts` / `app/robots.ts` is not silently auth-gated. They are harmless if the files do not exist. As noted in the plan, a strictly minimal diff could drop these two and keep only `icon.svg|apple-icon` — call it out in review if preferred.
