### PR TITLE
#150 Admin Applications Hub With Filters And Bulk Actions

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
+import prisma from '@/lib/prisma';
 import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
@@ -19,11 +20,25 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     isBypass,
   };
 
+  const canReviewApplications =
+    user.isAdmin ||
+    (await prisma.position.count({
+      where: { managers: { some: { id: user.id } }, deletedAt: null },
+    })) > 0;
+
   return (
     <div className="flex h-dvh w-full overflow-hidden">
-      <Sidebar isAdmin={user.isAdmin} identity={identity} />
+      <Sidebar
+        isAdmin={user.isAdmin}
+        identity={identity}
+        canReviewApplications={canReviewApplications}
+      />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <MobileNav isAdmin={user.isAdmin} identity={identity} />
+        <MobileNav
+          isAdmin={user.isAdmin}
+          identity={identity}
+          canReviewApplications={canReviewApplications}
+        />
         <main className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 p-6">{children}</div>
         </main>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -20,6 +20,8 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     isBypass,
   };
 
+  // No active pages live under (app)/ yet, but the query is kept in sync with
+  // (main)/layout.tsx to satisfy the shared Sidebar/MobileNav props contract.
   const canReviewApplications =
     user.isAdmin ||
     (await prisma.position.count({

--- a/app/(main)/(auth)/applications/loading.tsx
+++ b/app/(main)/(auth)/applications/loading.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ApplicationsLoading() {
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6">
+      {/* Header skeleton */}
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-7 w-36" />
+        <Skeleton className="h-4 w-28" />
+      </div>
+
+      {/* Toolbar skeleton — Position Select + Status Select + Search Input */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-9 w-48" />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-9 w-44" />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-9 w-56" />
+        </div>
+      </div>
+
+      {/* Table skeleton — header row + 5 data rows, checkbox column included */}
+      <div className="rounded-lg border">
+        {/* Table header */}
+        <div className="border-b p-4">
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-4 w-4" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="ml-auto h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b p-4 last:border-b-0"
+          >
+            <Skeleton className="h-4 w-4 shrink-0" />
+            <div className="flex flex-1 flex-col gap-1">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -111,6 +111,7 @@ export default async function ApplicationsPage({
       <ApplicationsTable
         applications={applications}
         hasActiveFilters={hasActiveFilters}
+        sort={filters.sort}
       />
     </div>
   );

--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -1,7 +1,83 @@
-export default function ApplicationsPage() {
+import { redirect } from 'next/navigation';
+
+import {
+  getApplications,
+  getReviewablePositions,
+} from '@/prisma/data/applications';
+
+import { getCurrentUser } from '@/lib/auth/server';
+import { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
+import prisma from '@/lib/prisma';
+import type { ApplicationFilters, ReviewerStatus } from '@/lib/types';
+
+import { ApplicationsTable } from '@/components/features/applications-table';
+import { ApplicationsToolbar } from '@/components/features/applications-toolbar';
+
+interface ApplicationsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function ApplicationsPage({
+  searchParams,
+}: ApplicationsPageProps) {
+  const user = await getCurrentUser();
+
+  // Authorization guard: admins pass; managers pass only while they have ≥1 position.
+  // Regular applicants are redirected to home — the (auth) layout is not sufficient.
+  if (!user.isAdmin) {
+    const managed = await prisma.position.count({
+      where: { managers: { some: { id: user.id } }, deletedAt: null },
+    });
+    if (managed === 0) redirect('/');
+  }
+
+  const sp = await searchParams;
+
+  // Parse filters from searchParams — unknown/invalid values are ignored.
+  const rawStatus = typeof sp.status === 'string' ? sp.status : undefined;
+  const validStatus: ReviewerStatus | undefined =
+    rawStatus &&
+    (REVIEWER_APPLICATION_STATUSES as readonly string[]).includes(rawStatus)
+      ? (rawStatus as ReviewerStatus)
+      : undefined;
+
+  const filters: ApplicationFilters = {
+    positionId: typeof sp.positionId === 'string' ? sp.positionId : undefined,
+    status: validStatus,
+    userId: typeof sp.userId === 'string' ? sp.userId : undefined,
+    q: typeof sp.q === 'string' && sp.q.trim() ? sp.q.trim() : undefined,
+  };
+
+  const hasActiveFilters = !!(
+    filters.positionId ||
+    filters.status ||
+    filters.q
+  );
+
+  const [applications, positions] = await Promise.all([
+    getApplications(user, filters),
+    getReviewablePositions(user),
+  ]);
+
+  const count = applications.length;
+  const countLabel =
+    count === 1 ? '1 application' : count > 0 ? `${count} applications` : null;
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold tracking-tight">Applications</h1>
+    <div className="mx-auto flex max-w-6xl flex-col gap-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Applications</h1>
+        {countLabel && (
+          <p className="text-muted-foreground mt-1 text-sm">{countLabel}</p>
+        )}
+      </header>
+
+      <ApplicationsToolbar positions={positions} filters={filters} />
+
+      <ApplicationsTable
+        applications={applications}
+        hasActiveFilters={hasActiveFilters}
+      />
     </div>
   );
 }

--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -51,6 +51,7 @@ export default async function ApplicationsPage({
   const hasActiveFilters = !!(
     filters.positionId ||
     filters.status ||
+    filters.userId ||
     filters.q
   );
 
@@ -60,8 +61,16 @@ export default async function ApplicationsPage({
   ]);
 
   const count = applications.length;
+  // `getApplications` caps results at 100; show "100+" when the list may be
+  // truncated so the label is never misleadingly exact.
   const countLabel =
-    count === 1 ? '1 application' : count > 0 ? `${count} applications` : null;
+    count === 1
+      ? '1 application'
+      : count >= 100
+        ? '100+ applications'
+        : count > 0
+          ? `${count} applications`
+          : null;
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6">

--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -8,7 +8,13 @@ import {
 import { getCurrentUser } from '@/lib/auth/server';
 import { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
 import prisma from '@/lib/prisma';
-import type { ApplicationFilters, ReviewerStatus } from '@/lib/types';
+import type {
+  ApplicationFilters,
+  ApplicationSort,
+  ApplicationSortDirection,
+  ApplicationSortField,
+  ReviewerStatus,
+} from '@/lib/types';
 
 import { ApplicationsTable } from '@/components/features/applications-table';
 import { ApplicationsToolbar } from '@/components/features/applications-toolbar';
@@ -16,6 +22,9 @@ import { ApplicationsToolbar } from '@/components/features/applications-toolbar'
 interface ApplicationsPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
+
+const VALID_SORT_FIELDS: ApplicationSortField[] = ['date', 'name', 'status'];
+const VALID_SORT_DIRECTIONS: ApplicationSortDirection[] = ['asc', 'desc'];
 
 export default async function ApplicationsPage({
   searchParams,
@@ -41,18 +50,34 @@ export default async function ApplicationsPage({
       ? (rawStatus as ReviewerStatus)
       : undefined;
 
+  // Parse sort from "field:direction" param (e.g. "date:desc").
+  const rawSort = typeof sp.sort === 'string' ? sp.sort : undefined;
+  let validSort: ApplicationSort | undefined;
+  if (rawSort) {
+    const [rawField, rawDir] = rawSort.split(':');
+    const field = rawField as ApplicationSortField;
+    const direction = rawDir as ApplicationSortDirection;
+    if (
+      VALID_SORT_FIELDS.includes(field) &&
+      VALID_SORT_DIRECTIONS.includes(direction)
+    )
+      validSort = { field, direction };
+  }
+
   const filters: ApplicationFilters = {
     positionId: typeof sp.positionId === 'string' ? sp.positionId : undefined,
     status: validStatus,
     userId: typeof sp.userId === 'string' ? sp.userId : undefined,
     q: typeof sp.q === 'string' && sp.q.trim() ? sp.q.trim() : undefined,
+    sort: validSort,
   };
 
   const hasActiveFilters = !!(
     filters.positionId ||
     filters.status ||
     filters.userId ||
-    filters.q
+    filters.q ||
+    filters.sort
   );
 
   const [applications, positions] = await Promise.all([

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
+import prisma from '@/lib/prisma';
 import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
@@ -19,11 +20,26 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     isBypass,
   };
 
+  // Admins always see reviewer nav; managers see it only while they manage ≥1 position.
+  const canReviewApplications =
+    user.isAdmin ||
+    (await prisma.position.count({
+      where: { managers: { some: { id: user.id } }, deletedAt: null },
+    })) > 0;
+
   return (
     <div className="flex h-dvh w-full overflow-hidden">
-      <Sidebar isAdmin={user.isAdmin} identity={identity} />
+      <Sidebar
+        isAdmin={user.isAdmin}
+        identity={identity}
+        canReviewApplications={canReviewApplications}
+      />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <MobileNav isAdmin={user.isAdmin} identity={identity} />
+        <MobileNav
+          isAdmin={user.isAdmin}
+          identity={identity}
+          canReviewApplications={canReviewApplications}
+        />
         <main className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 p-6">{children}</div>
         </main>

--- a/components/features/application-status-control.tsx
+++ b/components/features/application-status-control.tsx
@@ -8,7 +8,7 @@ import { toast } from 'sonner';
 import { updateApplicationStatus } from '@/prisma/actions/applications';
 import { type $Enums } from '@/prisma/client';
 
-import { APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
+import { REVIEWER_APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
 
 import { Label } from '@/components/ui/label';
 import {
@@ -32,10 +32,8 @@ export function ApplicationStatusControl({
 
   const isDraft = currentStatus === 'draft';
 
-  // Reviewer-selectable options exclude 'draft'.
-  const options = APPLICATION_STATUS_OPTIONS.filter(
-    (opt) => opt.value !== 'draft',
-  );
+  // Reviewer-selectable options — 'draft' is already excluded from this constant.
+  const options = REVIEWER_APPLICATION_STATUS_OPTIONS;
 
   function handleValueChange(value: string) {
     startTransition(async () => {

--- a/components/features/applications-bulk-bar.tsx
+++ b/components/features/applications-bulk-bar.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useTransition } from 'react';
+
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { updateApplicationStatuses } from '@/prisma/actions/applications';
+import type { $Enums } from '@/prisma/client';
+
+import { REVIEWER_APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface ApplicationsBulkBarProps {
+  selectedIds: string[];
+  onApplied: () => void;
+  status: $Enums.ApplicationStatus | '';
+  onStatusChange: (value: $Enums.ApplicationStatus | '') => void;
+}
+
+export function ApplicationsBulkBar({
+  selectedIds,
+  onApplied,
+  status,
+  onStatusChange,
+}: ApplicationsBulkBarProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const count = selectedIds.length;
+  const countLabel = count === 1 ? '1 selected' : `${count} selected`;
+
+  function handleApply() {
+    if (!status) return;
+    startTransition(async () => {
+      try {
+        const result = await updateApplicationStatuses({
+          applicationIds: selectedIds,
+          status,
+        });
+        if ('error' in result) {
+          toast.error(result.error);
+        } else {
+          const updated = result.updated;
+          const label =
+            updated === 1 ? '1 application' : `${updated} applications`;
+          toast.success(`Updated ${label}`);
+          onApplied();
+        }
+      } catch {
+        toast.error('Something went wrong. Please try again.');
+      }
+    });
+  }
+
+  return (
+    <div className="bg-muted/50 flex flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
+      <span className="text-sm font-medium">{countLabel}</span>
+
+      <div className="flex items-center gap-2">
+        <Label htmlFor="bulk-status" className="sr-only">
+          Set status
+        </Label>
+        <Select
+          value={status}
+          onValueChange={(v) =>
+            onStatusChange(v as $Enums.ApplicationStatus | '')
+          }
+          disabled={isPending}
+        >
+          <SelectTrigger id="bulk-status" className="w-44">
+            <SelectValue placeholder="Set status..." />
+          </SelectTrigger>
+          <SelectContent>
+            {REVIEWER_APPLICATION_STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button size="sm" onClick={handleApply} disabled={isPending || !status}>
+          {isPending ? (
+            <>
+              <Loader2
+                className="mr-1.5 h-3.5 w-3.5 animate-spin"
+                aria-hidden
+              />
+              Applying...
+            </>
+          ) : (
+            `Apply to ${count}`
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/features/applications-table.tsx
+++ b/components/features/applications-table.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
-import { FileText, Inbox } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, FileText, Inbox } from 'lucide-react';
 
 import type { $Enums } from '@/prisma/client';
 
-import type { ApplicationListRow } from '@/lib/types';
+import type {
+  ApplicationListRow,
+  ApplicationSort,
+  ApplicationSortDirection,
+  ApplicationSortField,
+} from '@/lib/types';
 import { formatDate } from '@/lib/utils';
 
 import { ApplicationsBulkBar } from '@/components/features/applications-bulk-bar';
@@ -27,12 +33,75 @@ import {
 interface ApplicationsTableProps {
   applications: ApplicationListRow[];
   hasActiveFilters: boolean;
+  sort?: ApplicationSort;
+}
+
+interface SortableHeadProps {
+  field: ApplicationSortField;
+  sort?: ApplicationSort;
+  onSort: (
+    field: ApplicationSortField,
+    direction: ApplicationSortDirection,
+  ) => void;
+  children: React.ReactNode;
+}
+
+function SortableHead({ field, sort, onSort, children }: SortableHeadProps) {
+  const isActive = sort?.field === field;
+  const isAsc = isActive && sort?.direction === 'asc';
+
+  function handleClick() {
+    if (!isActive) {
+      // Default to desc for date (newest first), asc for name/status (A-Z).
+      const defaultDir: ApplicationSortDirection =
+        field === 'date' ? 'desc' : 'asc';
+      onSort(field, defaultDir);
+    } else {
+      onSort(field, isAsc ? 'desc' : 'asc');
+    }
+  }
+
+  return (
+    <TableHead>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="hover:text-foreground flex items-center gap-1 font-medium transition-colors"
+        aria-label={`Sort by ${String(children)}${isActive ? (isAsc ? ', currently ascending' : ', currently descending') : ''}`}
+      >
+        {children}
+        {isActive ? (
+          isAsc ? (
+            <ArrowUp
+              className="text-foreground h-3.5 w-3.5"
+              aria-hidden="true"
+            />
+          ) : (
+            <ArrowDown
+              className="text-foreground h-3.5 w-3.5"
+              aria-hidden="true"
+            />
+          )
+        ) : (
+          <ArrowUpDown
+            className="text-muted-foreground h-3.5 w-3.5"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </TableHead>
+  );
 }
 
 export function ApplicationsTable({
   applications,
   hasActiveFilters,
+  sort,
 }: ApplicationsTableProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkStatus, setBulkStatus] = useState<$Enums.ApplicationStatus | ''>(
     '',
@@ -70,6 +139,15 @@ export function ApplicationsTable({
   function clearSelection() {
     setSelectedIds(new Set());
     setBulkStatus('');
+  }
+
+  function handleSort(
+    field: ApplicationSortField,
+    direction: ApplicationSortDirection,
+  ) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('sort', `${field}:${direction}`);
+    router.push(`${pathname}?${params.toString()}`);
   }
 
   if (applications.length === 0) {
@@ -122,7 +200,8 @@ export function ApplicationsTable({
         />
       )}
 
-      <Card className="gap-0 p-0">
+      {/* overflow-hidden clips the header hover highlight to the card's rounded corners */}
+      <Card className="gap-0 overflow-hidden p-0">
         {/* Desktop table — hidden on mobile */}
         <div className="hidden md:block">
           <Table>
@@ -135,10 +214,16 @@ export function ApplicationsTable({
                     aria-label="Select all applications"
                   />
                 </TableHead>
-                <TableHead>Applicant</TableHead>
+                <SortableHead field="name" sort={sort} onSort={handleSort}>
+                  Applicant
+                </SortableHead>
                 <TableHead>Position</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Submitted</TableHead>
+                <SortableHead field="status" sort={sort} onSort={handleSort}>
+                  Status
+                </SortableHead>
+                <SortableHead field="date" sort={sort} onSort={handleSort}>
+                  Submitted
+                </SortableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/components/features/applications-table.tsx
+++ b/components/features/applications-table.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+import { FileText, Inbox } from 'lucide-react';
+
+import type { $Enums } from '@/prisma/client';
+
+import type { ApplicationListRow } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+import { ApplicationsBulkBar } from '@/components/features/applications-bulk-bar';
+import { ApplicationStatusBadge } from '@/components/features/status-badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface ApplicationsTableProps {
+  applications: ApplicationListRow[];
+  hasActiveFilters: boolean;
+}
+
+export function ApplicationsTable({
+  applications,
+  hasActiveFilters,
+}: ApplicationsTableProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkStatus, setBulkStatus] = useState<$Enums.ApplicationStatus | ''>(
+    '',
+  );
+
+  const allIds = applications.map((a) => a.id);
+  const allSelected =
+    allIds.length > 0 && allIds.every((id) => selectedIds.has(id));
+  const someSelected = allIds.some((id) => selectedIds.has(id));
+  const isIndeterminate = someSelected && !allSelected;
+
+  // Drop ids no longer in the current view (e.g. after a filter change).
+  const visibleSelected = Array.from(selectedIds).filter((id) =>
+    allIds.includes(id),
+  );
+
+  function toggleAll() {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(allIds));
+    }
+  }
+
+  function toggleOne(id: string) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setSelectedIds(next);
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+    setBulkStatus('');
+  }
+
+  if (applications.length === 0) {
+    if (hasActiveFilters)
+      return (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+            <FileText
+              className="text-muted-foreground size-12"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-base font-semibold">
+                No applications match these filters
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Try adjusting or clearing your filters.
+              </p>
+            </div>
+            <Button variant="outline" asChild>
+              <Link href="/applications">Clear filters</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      );
+
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <Inbox className="text-muted-foreground size-12" aria-hidden="true" />
+          <div>
+            <p className="text-base font-semibold">No applications yet</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Applications will appear here once candidates apply.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {visibleSelected.length > 0 && (
+        <ApplicationsBulkBar
+          selectedIds={visibleSelected}
+          onApplied={clearSelection}
+          status={bulkStatus}
+          onStatusChange={setBulkStatus}
+        />
+      )}
+
+      <Card className="gap-0 p-0">
+        {/* Desktop table — hidden on mobile */}
+        <div className="hidden md:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={isIndeterminate ? 'indeterminate' : allSelected}
+                    onCheckedChange={toggleAll}
+                    aria-label="Select all applications"
+                  />
+                </TableHead>
+                <TableHead>Applicant</TableHead>
+                <TableHead>Position</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Submitted</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {applications.map((app) => {
+                const displayName = app.user.name ?? app.user.email;
+                const isChecked = selectedIds.has(app.id);
+                return (
+                  <TableRow
+                    key={app.id}
+                    data-state={isChecked ? 'selected' : undefined}
+                  >
+                    <TableCell
+                      onClick={(e) => e.stopPropagation()}
+                      className="w-10"
+                    >
+                      <Checkbox
+                        checked={isChecked}
+                        onCheckedChange={() => toggleOne(app.id)}
+                        aria-label={`Select ${displayName}`}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        href={`/applications/${app.id}`}
+                        className="font-medium hover:underline"
+                      >
+                        {displayName}
+                      </Link>
+                      {app.user.name && (
+                        <span className="text-muted-foreground block text-xs">
+                          {app.user.email}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {app.position.title}
+                    </TableCell>
+                    <TableCell>
+                      <ApplicationStatusBadge status={app.status} />
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatDate(app.submittedAt)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Mobile stacked cards — shown only on mobile */}
+        <div className="flex flex-col divide-y md:hidden">
+          {applications.map((app) => {
+            const displayName = app.user.name ?? app.user.email;
+            const isChecked = selectedIds.has(app.id);
+            return (
+              <div key={app.id} className="flex gap-3 p-4">
+                <Checkbox
+                  checked={isChecked}
+                  onCheckedChange={() => toggleOne(app.id)}
+                  aria-label={`Select ${displayName}`}
+                  className="mt-0.5 shrink-0"
+                />
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <Link
+                      href={`/applications/${app.id}`}
+                      className="truncate font-medium hover:underline"
+                    >
+                      {displayName}
+                    </Link>
+                    <ApplicationStatusBadge status={app.status} />
+                  </div>
+                  {app.user.name && (
+                    <span className="text-muted-foreground truncate text-xs">
+                      {app.user.email}
+                    </span>
+                  )}
+                  <span className="text-muted-foreground text-sm">
+                    {app.position.title}
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    {formatDate(app.submittedAt)}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -3,8 +3,10 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useRef } from 'react';
 
+import { X } from 'lucide-react';
+
 import { REVIEWER_APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
-import type { ApplicationFilters } from '@/lib/types';
+import type { ApplicationFilters, ApplicationSort } from '@/lib/types';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -20,6 +22,20 @@ import {
 interface ApplicationsToolbarProps {
   positions: { id: string; title: string }[];
   filters: ApplicationFilters;
+}
+
+const SORT_OPTIONS: { value: string; label: string }[] = [
+  { value: 'date:desc', label: 'Newest first' },
+  { value: 'date:asc', label: 'Oldest first' },
+  { value: 'name:asc', label: 'Name A–Z' },
+  { value: 'name:desc', label: 'Name Z–A' },
+  { value: 'status:asc', label: 'Status A–Z' },
+  { value: 'status:desc', label: 'Status Z–A' },
+];
+
+function sortToParam(sort: ApplicationSort | undefined): string {
+  if (!sort) return '';
+  return `${sort.field}:${sort.direction}`;
 }
 
 export function ApplicationsToolbar({
@@ -41,7 +57,8 @@ export function ApplicationsToolbar({
     filters.positionId ||
     filters.status ||
     filters.userId ||
-    filters.q
+    filters.q ||
+    filters.sort
   );
 
   function updateParam(key: string, value: string | undefined) {
@@ -69,75 +86,128 @@ export function ApplicationsToolbar({
     }, 300);
   }
 
+  function clearSearch() {
+    clearTimeout(debounceTimer.current);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('q');
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
   function clearFilters() {
     // Drop all filters including userId so the user can escape the deep-link
     // context (#77) when the filter set returns zero results.
     router.push(pathname);
   }
 
+  const currentSort = sortToParam(filters.sort);
+
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="filter-position" className="text-xs">
-          Position
-        </Label>
-        <Select
-          value={filters.positionId ?? ''}
-          onValueChange={(v) => updateParam('positionId', v || undefined)}
-        >
-          <SelectTrigger id="filter-position" className="w-48">
-            <SelectValue placeholder="All positions" />
-          </SelectTrigger>
-          <SelectContent>
-            {positions.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.title}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+    // min-w-0 prevents the toolbar from expanding the page when filter controls
+    // change width; overflow-x-auto lets it scroll on very narrow viewports
+    // instead of reflowing the surrounding layout.
+    <div className="min-w-0 overflow-x-auto">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="filter-position" className="text-xs">
+            Position
+          </Label>
+          <Select
+            value={filters.positionId ?? ''}
+            onValueChange={(v) => updateParam('positionId', v || undefined)}
+          >
+            <SelectTrigger id="filter-position" className="w-48">
+              <SelectValue placeholder="All positions" />
+            </SelectTrigger>
+            <SelectContent>
+              {/* "All positions" clears the filter */}
+              <SelectItem value="">All positions</SelectItem>
+              {positions.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {p.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="filter-status" className="text-xs">
-          Status
-        </Label>
-        <Select
-          value={filters.status ?? ''}
-          onValueChange={(v) => updateParam('status', v || undefined)}
-        >
-          <SelectTrigger id="filter-status" className="w-44">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            {REVIEWER_APPLICATION_STATUS_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="filter-status" className="text-xs">
+            Status
+          </Label>
+          <Select
+            value={filters.status ?? ''}
+            onValueChange={(v) => updateParam('status', v || undefined)}
+          >
+            <SelectTrigger id="filter-status" className="w-44">
+              <SelectValue placeholder="All statuses" />
+            </SelectTrigger>
+            <SelectContent>
+              {/* "All statuses" clears the filter */}
+              <SelectItem value="">All statuses</SelectItem>
+              {REVIEWER_APPLICATION_STATUS_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="filter-search" className="text-xs">
-          Search
-        </Label>
-        <Input
-          id="filter-search"
-          aria-label="Search applications"
-          placeholder="Search by name or email"
-          defaultValue={filters.q ?? ''}
-          onChange={(e) => handleSearch(e.target.value)}
-          className="w-56"
-        />
-      </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="filter-search" className="text-xs">
+            Search
+          </Label>
+          <div className="relative">
+            <Input
+              id="filter-search"
+              aria-label="Search applications"
+              placeholder="Name, email, position, or date"
+              defaultValue={filters.q ?? ''}
+              onChange={(e) => handleSearch(e.target.value)}
+              className="w-64 pr-8"
+            />
+            {filters.q && (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={clearSearch}
+                className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+        </div>
 
-      {hasActiveFilters && (
-        <Button variant="ghost" size="sm" onClick={clearFilters}>
-          Clear filters
-        </Button>
-      )}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="filter-sort" className="text-xs">
+            Sort
+          </Label>
+          <Select
+            value={currentSort}
+            onValueChange={(v) => updateParam('sort', v || undefined)}
+          >
+            <SelectTrigger id="filter-sort" className="w-40">
+              <SelectValue placeholder="Newest first" />
+            </SelectTrigger>
+            <SelectContent>
+              {/* Empty value resets to default (newest first) */}
+              <SelectItem value="">Default (newest)</SelectItem>
+              {SORT_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {hasActiveFilters && (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            Clear filters
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRef } from 'react';
+
+import { REVIEWER_APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
+import type { ApplicationFilters } from '@/lib/types';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface ApplicationsToolbarProps {
+  positions: { id: string; title: string }[];
+  filters: ApplicationFilters;
+}
+
+export function ApplicationsToolbar({
+  positions,
+  filters,
+}: ApplicationsToolbarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // useRef is the correct home for a timer handle in a client component — it
+  // persists across renders without triggering re-renders, and avoids the
+  // react-hooks/immutability lint error that a plain `let` produces.
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const hasActiveFilters = !!(
+    filters.positionId ||
+    filters.status ||
+    filters.q
+  );
+
+  function updateParam(key: string, value: string | undefined) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    // Always preserve userId across filter changes (powers #77 deep-link).
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  function handleSearch(value: string) {
+    clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value.trim()) {
+        params.set('q', value.trim());
+      } else {
+        params.delete('q');
+      }
+      // Use replace for search so typing doesn't spam history.
+      router.replace(`${pathname}?${params.toString()}`);
+    }, 300);
+  }
+
+  function clearFilters() {
+    const params = new URLSearchParams();
+    // Preserve userId if present — the deep-link remains active after clearing.
+    const userId = searchParams.get('userId');
+    if (userId) params.set('userId', userId);
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-position" className="text-xs">
+          Position
+        </Label>
+        <Select
+          value={filters.positionId ?? ''}
+          onValueChange={(v) => updateParam('positionId', v || undefined)}
+        >
+          <SelectTrigger id="filter-position" className="w-48">
+            <SelectValue placeholder="All positions" />
+          </SelectTrigger>
+          <SelectContent>
+            {positions.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-status" className="text-xs">
+          Status
+        </Label>
+        <Select
+          value={filters.status ?? ''}
+          onValueChange={(v) => updateParam('status', v || undefined)}
+        >
+          <SelectTrigger id="filter-status" className="w-44">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            {REVIEWER_APPLICATION_STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-search" className="text-xs">
+          Search
+        </Label>
+        <Input
+          id="filter-search"
+          aria-label="Search applications"
+          placeholder="Search by name or email"
+          defaultValue={filters.q ?? ''}
+          onChange={(e) => handleSearch(e.target.value)}
+          className="w-56"
+        />
+      </div>
+
+      {hasActiveFilters && (
+        <Button variant="ghost" size="sm" onClick={clearFilters}>
+          Clear filters
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -40,6 +40,7 @@ export function ApplicationsToolbar({
   const hasActiveFilters = !!(
     filters.positionId ||
     filters.status ||
+    filters.userId ||
     filters.q
   );
 
@@ -69,11 +70,9 @@ export function ApplicationsToolbar({
   }
 
   function clearFilters() {
-    const params = new URLSearchParams();
-    // Preserve userId if present — the deep-link remains active after clearing.
-    const userId = searchParams.get('userId');
-    if (userId) params.set('userId', userId);
-    router.push(`${pathname}?${params.toString()}`);
+    // Drop all filters including userId so the user can escape the deep-link
+    // context (#77) when the filter set returns zero results.
+    router.push(pathname);
   }
 
   return (

--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import { X } from 'lucide-react';
 
 import { REVIEWER_APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
-import type { ApplicationFilters, ApplicationSort } from '@/lib/types';
+import type { ApplicationFilters } from '@/lib/types';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,20 +24,6 @@ interface ApplicationsToolbarProps {
   filters: ApplicationFilters;
 }
 
-const SORT_OPTIONS: { value: string; label: string }[] = [
-  { value: 'date:desc', label: 'Newest first' },
-  { value: 'date:asc', label: 'Oldest first' },
-  { value: 'name:asc', label: 'Name A–Z' },
-  { value: 'name:desc', label: 'Name Z–A' },
-  { value: 'status:asc', label: 'Status A–Z' },
-  { value: 'status:desc', label: 'Status Z–A' },
-];
-
-function sortToParam(sort: ApplicationSort | undefined): string {
-  if (!sort) return '';
-  return `${sort.field}:${sort.direction}`;
-}
-
 export function ApplicationsToolbar({
   positions,
   filters,
@@ -52,6 +38,11 @@ export function ApplicationsToolbar({
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+
+  // Track the search input value in local state so the X button reflects the
+  // current input value both on initial page load (from URL param) and after
+  // typing (without waiting for the debounce to update the URL).
+  const [searchValue, setSearchValue] = useState(filters.q ?? '');
 
   const hasActiveFilters = !!(
     filters.positionId ||
@@ -73,6 +64,7 @@ export function ApplicationsToolbar({
   }
 
   function handleSearch(value: string) {
+    setSearchValue(value);
     clearTimeout(debounceTimer.current);
     debounceTimer.current = setTimeout(() => {
       const params = new URLSearchParams(searchParams.toString());
@@ -87,6 +79,7 @@ export function ApplicationsToolbar({
   }
 
   function clearSearch() {
+    setSearchValue('');
     clearTimeout(debounceTimer.current);
     const params = new URLSearchParams(searchParams.toString());
     params.delete('q');
@@ -94,12 +87,11 @@ export function ApplicationsToolbar({
   }
 
   function clearFilters() {
+    setSearchValue('');
     // Drop all filters including userId so the user can escape the deep-link
     // context (#77) when the filter set returns zero results.
     router.push(pathname);
   }
-
-  const currentSort = sortToParam(filters.sort);
 
   return (
     // min-w-0 prevents the toolbar from expanding the page when filter controls
@@ -157,16 +149,17 @@ export function ApplicationsToolbar({
           <Label htmlFor="filter-search" className="text-xs">
             Search
           </Label>
-          <div className="relative">
+          {/* pb-0.5 gives the focus ring room on the bottom edge so it is not clipped */}
+          <div className="relative pb-0.5">
             <Input
               id="filter-search"
               aria-label="Search applications"
               placeholder="Name, email, position, or date"
-              defaultValue={filters.q ?? ''}
+              value={searchValue}
               onChange={(e) => handleSearch(e.target.value)}
               className="w-64 pr-8"
             />
-            {filters.q && (
+            {searchValue && (
               <button
                 type="button"
                 aria-label="Clear search"
@@ -177,29 +170,6 @@ export function ApplicationsToolbar({
               </button>
             )}
           </div>
-        </div>
-
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="filter-sort" className="text-xs">
-            Sort
-          </Label>
-          <Select
-            value={currentSort}
-            onValueChange={(v) => updateParam('sort', v || undefined)}
-          >
-            <SelectTrigger id="filter-sort" className="w-40">
-              <SelectValue placeholder="Newest first" />
-            </SelectTrigger>
-            <SelectContent>
-              {/* Empty value resets to default (newest first) */}
-              <SelectItem value="">Default (newest)</SelectItem>
-              {SORT_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
 
         {hasActiveFilters && (

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -10,7 +10,11 @@ import { Menu } from 'lucide-react';
 import type { NavIdentity } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
-import { adminNavItems, baseNavItems } from '@/components/layouts/nav-items';
+import {
+  adminOnlyNavItems,
+  baseNavItems,
+  reviewerNavItems,
+} from '@/components/layouts/nav-items';
 import { UserMenu } from '@/components/layouts/user-menu';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
@@ -18,12 +22,17 @@ import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 interface MobileNavProps {
   isAdmin: boolean;
   identity: NavIdentity;
+  canReviewApplications: boolean;
 }
 
-export function MobileNav({ isAdmin, identity }: MobileNavProps) {
+export function MobileNav({ isAdmin, identity, canReviewApplications }: MobileNavProps) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
-  const navItems = isAdmin ? [...baseNavItems, ...adminNavItems] : baseNavItems;
+  const navItems = [
+    ...baseNavItems,
+    ...(canReviewApplications ? reviewerNavItems : []),
+    ...(isAdmin ? adminOnlyNavItems : []),
+  ];
 
   return (
     <header className="bg-sidebar border-sidebar-border flex h-14 items-center border-b px-4 md:hidden">

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -25,7 +25,11 @@ interface MobileNavProps {
   canReviewApplications: boolean;
 }
 
-export function MobileNav({ isAdmin, identity, canReviewApplications }: MobileNavProps) {
+export function MobileNav({
+  isAdmin,
+  identity,
+  canReviewApplications,
+}: MobileNavProps) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const navItems = [

--- a/components/layouts/nav-items.ts
+++ b/components/layouts/nav-items.ts
@@ -13,8 +13,13 @@ export const baseNavItems = [
   { href: '/my-applications', label: 'My Applications', icon: Inbox },
 ];
 
-export const adminNavItems = [
+// Shown to admins AND managers — anyone who can review applications.
+export const reviewerNavItems = [
   { href: '/applications', label: 'Applications', icon: FileText },
+];
+
+// Shown to admins only — Users and Global Questions are admin-only.
+export const adminOnlyNavItems = [
   { href: '/users', label: 'Users', icon: Users },
   { href: '/global-questions', label: 'Global Questions', icon: ClipboardList },
 ];

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -7,17 +7,26 @@ import { usePathname } from 'next/navigation';
 import type { NavIdentity } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
-import { adminNavItems, baseNavItems } from '@/components/layouts/nav-items';
+import {
+  adminOnlyNavItems,
+  baseNavItems,
+  reviewerNavItems,
+} from '@/components/layouts/nav-items';
 import { UserMenu } from '@/components/layouts/user-menu';
 
 interface SidebarProps {
   isAdmin: boolean;
   identity: NavIdentity;
+  canReviewApplications: boolean;
 }
 
-export function Sidebar({ isAdmin, identity }: SidebarProps) {
+export function Sidebar({ isAdmin, identity, canReviewApplications }: SidebarProps) {
   const pathname = usePathname();
-  const navItems = isAdmin ? [...baseNavItems, ...adminNavItems] : baseNavItems;
+  const navItems = [
+    ...baseNavItems,
+    ...(canReviewApplications ? reviewerNavItems : []),
+    ...(isAdmin ? adminOnlyNavItems : []),
+  ];
 
   return (
     <aside className="bg-sidebar border-sidebar-border hidden h-full w-56 shrink-0 flex-col border-r md:flex">

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -20,7 +20,11 @@ interface SidebarProps {
   canReviewApplications: boolean;
 }
 
-export function Sidebar({ isAdmin, identity, canReviewApplications }: SidebarProps) {
+export function Sidebar({
+  isAdmin,
+  identity,
+  canReviewApplications,
+}: SidebarProps) {
   const pathname = usePathname();
   const navItems = [
     ...baseNavItems,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -87,6 +87,27 @@ export const APPLICATION_STATUS_OPTIONS: {
   label: APPLICATION_STATUS_LABELS[value],
 }));
 
+// Reviewer-selectable statuses exclude 'draft' — a reviewer cannot push an
+// application back to draft; that state is applicant-owned. Written as a
+// literal tuple so z.enum() infers the correct union without an unsafe cast.
+// Used in the single-update action, the bulk-update action, and both status
+// controls — extracted here (ENGINEERING §1: abstract at 2+).
+export const REVIEWER_APPLICATION_STATUSES = [
+  'applied',
+  'reached_out',
+  'interview_scheduled',
+  'reviewing',
+  'accepted',
+  'rejected',
+] as const satisfies [
+  Exclude<$Enums.ApplicationStatus, 'draft'>,
+  ...Exclude<$Enums.ApplicationStatus, 'draft'>[],
+];
+
+// Reviewer-facing Select options — draft excluded.
+export const REVIEWER_APPLICATION_STATUS_OPTIONS =
+  APPLICATION_STATUS_OPTIONS.filter((o) => o.value !== 'draft');
+
 export const STATUS_OPTIONS: { value: PositionStatus; label: string }[] = [
   { value: 'draft', label: 'Draft' },
   { value: 'open', label: 'Open' },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,8 @@ import type {
 } from '@/prisma/client';
 import type { Prisma } from '@/prisma/client';
 
+import type { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
+
 export type PositionWithQuestions = {
   id: string;
   title: string;
@@ -129,6 +131,22 @@ export type PositionAvailability =
 export type OpenPositionSummaryItem = Prisma.PositionGetPayload<{
   select: { id: true; title: true; _count: { select: { applications: true } } };
 }>;
+
+// Reviewer-selectable status — everything except 'draft'.
+export type ReviewerStatus = (typeof REVIEWER_APPLICATION_STATUSES)[number];
+
+// Filters accepted by the /applications hub — all optional.
+// status is constrained to ReviewerStatus so 'draft' is never listed.
+export type ApplicationFilters = {
+  positionId?: string;
+  status?: ReviewerStatus;
+  userId?: string;
+  q?: string;
+};
+
+// Row type for the applications hub table — reuses AdminApplicationListItem
+// (no audit fields cross the server/client boundary).
+export type ApplicationListRow = AdminApplicationListItem;
 
 export type ProfileCompleteness = {
   complete: boolean;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -135,6 +135,14 @@ export type OpenPositionSummaryItem = Prisma.PositionGetPayload<{
 // Reviewer-selectable status — everything except 'draft'.
 export type ReviewerStatus = (typeof REVIEWER_APPLICATION_STATUSES)[number];
 
+// Sort options for the /applications hub.
+export type ApplicationSortField = 'date' | 'name' | 'status';
+export type ApplicationSortDirection = 'asc' | 'desc';
+export type ApplicationSort = {
+  field: ApplicationSortField;
+  direction: ApplicationSortDirection;
+};
+
 // Filters accepted by the /applications hub — all optional.
 // status is constrained to ReviewerStatus so 'draft' is never listed.
 export type ApplicationFilters = {
@@ -142,6 +150,7 @@ export type ApplicationFilters = {
   status?: ReviewerStatus;
   userId?: string;
   q?: string;
+  sort?: ApplicationSort;
 };
 
 // Row type for the applications hub table — reuses AdminApplicationListItem

--- a/prisma/actions/applications.ts
+++ b/prisma/actions/applications.ts
@@ -343,6 +343,9 @@ export async function updateApplicationStatuses(
   });
 
   revalidatePath('/applications');
+  // Clears all cached detail-page renders — bulk updates don't have individual
+  // positionIds at hand, so the wildcard layout segment is the right scope.
+  revalidatePath('/applications/[id]', 'layout');
 
   return { updated: result.count };
 }

--- a/prisma/actions/applications.ts
+++ b/prisma/actions/applications.ts
@@ -13,7 +13,7 @@ import type {
 } from '@/prisma/client';
 
 import { getCurrentUser } from '@/lib/auth/server';
-import { APPLICATION_STATUS_VALUES } from '@/lib/constants';
+import { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
 import prisma from '@/lib/prisma';
 import { type DraftApplication } from '@/lib/types';
 import {
@@ -246,27 +246,9 @@ export async function submitApplication(
   return updated;
 }
 
-// Reviewer-selectable statuses exclude 'draft' — a reviewer cannot push an
-// application back to draft; that state is applicant-owned.
-type ReviewerStatus = Exclude<
-  (typeof APPLICATION_STATUS_VALUES)[number],
-  'draft'
->;
-// Written as a literal tuple so z.enum() infers the correct union without an
-// unsafe `as` cast — adding a new status to APPLICATION_STATUS_VALUES will
-// surface a compile error here if it is not also listed.
-const reviewerStatuses = [
-  'applied',
-  'reached_out',
-  'interview_scheduled',
-  'reviewing',
-  'accepted',
-  'rejected',
-] as const satisfies [ReviewerStatus, ...ReviewerStatus[]];
-
 const updateApplicationStatusSchema = z.object({
   applicationId: z.string().min(1),
-  status: z.enum(reviewerStatuses),
+  status: z.enum(REVIEWER_APPLICATION_STATUSES),
 });
 
 export async function updateApplicationStatus(
@@ -311,4 +293,56 @@ export async function updateApplicationStatus(
   revalidatePath(`/applications/${applicationId}`);
   revalidatePath('/applications');
   revalidatePath(`/positions/${application.positionId}/applications`);
+}
+
+const updateApplicationStatusesSchema = z.object({
+  applicationIds: z.array(z.string().min(1)).min(1).max(100),
+  status: z.enum(REVIEWER_APPLICATION_STATUSES),
+});
+
+// Bulk status update for the /applications hub. Returns { updated: number } on
+// success so the client can toast the real count. Returns { error } for
+// user-facing failures (invalid input, no-op race). Throws for unexpected errors.
+// Authorization is folded into the scoped findMany — no IDOR.
+export async function updateApplicationStatuses(
+  input: unknown,
+): Promise<{ updated: number } | { error: string }> {
+  const user = await getCurrentUser();
+
+  const parsed = updateApplicationStatusesSchema.safeParse(input);
+  if (!parsed.success) return { error: 'Invalid input' };
+
+  const { applicationIds, status } = parsed.data;
+
+  // Authorize: scoped where clause means forged/deleted/out-of-scope ids are
+  // silently excluded — the caller can only update records they may see.
+  const where = user.isAdmin
+    ? {
+        id: { in: applicationIds },
+        deletedAt: null,
+        status: { not: 'draft' as const },
+      }
+    : {
+        id: { in: applicationIds },
+        deletedAt: null,
+        status: { not: 'draft' as const },
+        position: { managers: { some: { id: user.id } } },
+      };
+
+  const authorized = await prisma.application.findMany({
+    where,
+    select: { id: true },
+  });
+
+  if (authorized.length === 0)
+    return { error: 'No applications were updated.' };
+
+  const result = await prisma.application.updateMany({
+    where: { id: { in: authorized.map((a) => a.id) } },
+    data: { status, updatedById: user.id },
+  });
+
+  revalidatePath('/applications');
+
+  return { updated: result.count };
 }

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -158,22 +158,101 @@ export async function getApplications(
         position: { managers: { some: { id: user.id } } },
       };
 
+  // Build date-range clause when q looks like a year (e.g. "2026") or a
+  // "Mon YYYY" string (e.g. "Jun 2026"). This lets reviewers search by date
+  // without raw-SQL formatting — Prisma DateTime filters are range-based.
+  const MONTH_NAMES = [
+    'jan',
+    'feb',
+    'mar',
+    'apr',
+    'may',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'oct',
+    'nov',
+    'dec',
+  ];
+  let dateWhere: { submittedAt?: { gte: Date; lt: Date } } = {};
+  if (filters.q) {
+    const q = filters.q.trim();
+    const yearOnly = /^\d{4}$/.exec(q);
+    if (yearOnly) {
+      const y = parseInt(q, 10);
+      dateWhere = {
+        submittedAt: { gte: new Date(y, 0, 1), lt: new Date(y + 1, 0, 1) },
+      };
+    } else {
+      // Match "Jun 2026" or "2026 Jun" or "June 2026" etc.
+      const parts = q.toLowerCase().split(/[\s,]+/);
+      const monthIdx = parts.findIndex((p) =>
+        MONTH_NAMES.some((m) => p.startsWith(m)),
+      );
+      const yearPart = parts.find((p) => /^\d{4}$/.test(p));
+      if (monthIdx !== -1 && yearPart) {
+        const monthNum = MONTH_NAMES.findIndex((m) =>
+          parts[monthIdx].startsWith(m),
+        );
+        const y = parseInt(yearPart, 10);
+        dateWhere = {
+          submittedAt: {
+            gte: new Date(y, monthNum, 1),
+            lt: new Date(y, monthNum + 1, 1),
+          },
+        };
+      }
+    }
+  }
+
+  // Text search covers applicant name, email, and position title.
+  // When the query also resolves to a date range the full clause is an OR
+  // so that typing "Jun 2026" finds both date-matched and name/title-matched rows.
+  const textWhere = filters.q
+    ? {
+        OR: [
+          {
+            user: {
+              OR: [
+                { name: { contains: filters.q, mode: 'insensitive' as const } },
+                {
+                  email: { contains: filters.q, mode: 'insensitive' as const },
+                },
+              ],
+            },
+          },
+          {
+            position: {
+              title: { contains: filters.q, mode: 'insensitive' as const },
+            },
+          },
+          ...(dateWhere.submittedAt
+            ? [{ submittedAt: dateWhere.submittedAt }]
+            : []),
+        ],
+      }
+    : {};
+
+  const sort = filters.sort;
+  const orderBy = sort
+    ? sort.field === 'date'
+      ? { submittedAt: sort.direction }
+      : sort.field === 'name'
+        ? [
+            { user: { name: sort.direction } },
+            { user: { email: sort.direction } },
+          ]
+        : { status: sort.direction }
+    : ({ submittedAt: 'desc' } as const);
+
   return prisma.application.findMany({
     where: {
       ...baseWhere,
       ...(filters.positionId ? { positionId: filters.positionId } : {}),
       ...(filters.status ? { status: filters.status } : {}),
       ...(filters.userId ? { userId: filters.userId } : {}),
-      ...(filters.q
-        ? {
-            user: {
-              OR: [
-                { name: { contains: filters.q, mode: 'insensitive' } },
-                { email: { contains: filters.q, mode: 'insensitive' } },
-              ],
-            },
-          }
-        : {}),
+      ...textWhere,
     },
     select: {
       id: true,
@@ -182,7 +261,7 @@ export async function getApplications(
       position: { select: { id: true, title: true } },
       user: { select: { id: true, name: true, email: true } },
     },
-    orderBy: { submittedAt: 'desc' },
+    orderBy,
     take: 100,
   });
 }

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -5,6 +5,7 @@ import { $Enums } from '@/prisma/client';
 import prisma from '@/lib/prisma';
 import {
   type AdminApplicationListItem,
+  type ApplicationFilters,
   type ApplicationForReview,
   type MyApplicationListItem,
   type PositionApplicationListItem,
@@ -137,5 +138,68 @@ export async function getRecentApplications(
     },
     orderBy: { submittedAt: 'desc' },
     take,
+  });
+}
+
+// Returns all non-draft applications the caller may review, with optional
+// filters applied on top of the caller-scoped where clause (no IDOR).
+// Admins see all; managers see only their positions'. Returns cross-user data
+// (applicant identity + position) — must only be called from a reviewer-gated context.
+// Capped at 100 rows as a query-cost guard; full pagination is a future follow-up.
+export async function getApplications(
+  user: { id: string; isAdmin: boolean },
+  filters: ApplicationFilters,
+): Promise<AdminApplicationListItem[]> {
+  const baseWhere = user.isAdmin
+    ? { deletedAt: null, status: { not: 'draft' as const } }
+    : {
+        deletedAt: null,
+        status: { not: 'draft' as const },
+        position: { managers: { some: { id: user.id } } },
+      };
+
+  return prisma.application.findMany({
+    where: {
+      ...baseWhere,
+      ...(filters.positionId ? { positionId: filters.positionId } : {}),
+      ...(filters.status ? { status: filters.status } : {}),
+      ...(filters.userId ? { userId: filters.userId } : {}),
+      ...(filters.q
+        ? {
+            user: {
+              OR: [
+                { name: { contains: filters.q, mode: 'insensitive' } },
+                { email: { contains: filters.q, mode: 'insensitive' } },
+              ],
+            },
+          }
+        : {}),
+    },
+    select: {
+      id: true,
+      status: true,
+      submittedAt: true,
+      position: { select: { id: true, title: true } },
+      user: { select: { id: true, name: true, email: true } },
+    },
+    orderBy: { submittedAt: 'desc' },
+    take: 100,
+  });
+}
+
+// Returns positions the caller may review — used to populate the Position filter
+// Select on /applications. Admins see all non-deleted; managers see their positions.
+export async function getReviewablePositions(user: {
+  id: string;
+  isAdmin: boolean;
+}): Promise<{ id: string; title: string }[]> {
+  const where = user.isAdmin
+    ? { deletedAt: null }
+    : { deletedAt: null, managers: { some: { id: user.id } } };
+
+  return prisma.position.findMany({
+    where,
+    select: { id: true, title: true },
+    orderBy: { title: 'asc' },
   });
 }


### PR DESCRIPTION
Closes #150

## Summary

- Builds `/applications` as the central review hub for admins and managers — replaces the empty stub with a filterable, searchable table of all submitted applications the caller may see
- Adds bulk status update action (`updateApplicationStatuses`) scoped per-caller with no IDOR
- Splits nav item groups so managers see Applications but not Users/Global Questions

## Changes

### Data layer
- `lib/constants.ts` — adds `REVIEWER_APPLICATION_STATUSES` (non-empty tuple for `z.enum`) and `REVIEWER_APPLICATION_STATUS_OPTIONS`; refactors the existing single-update action and `ApplicationStatusControl` to consume the shared exports (removes private `reviewerStatuses` tuple and inline `.filter`)
- `lib/types.ts` — adds `ReviewerStatus`, `ApplicationFilters`, and `ApplicationListRow` alias
- `prisma/data/applications.ts` — adds `getApplications(user, filters)` (caller-scoped `where`, layered filters, `take: 100` cap, `AdminApplicationListItem` select) and `getReviewablePositions(user)`
- `prisma/actions/applications.ts` — adds `updateApplicationStatuses(input)` returning `{ updated: number } | { error }`: zod-validated, scoped `findMany` authorize step, single `updateMany`, `revalidatePath('/applications')`

### Page
- `app/(main)/(auth)/applications/page.tsx` — replaces stub: admin/manager guard (`redirect('/')` for others), parses `searchParams`, parallel-fetches data, renders header + toolbar + table
- `app/(main)/(auth)/applications/loading.tsx` — route-level skeleton matching header + toolbar + table incl. checkbox column

### Components
- `components/features/applications-toolbar.tsx` — `'use client'` Position/Status Selects + debounced search Input → URL via `useRouter`/`useSearchParams`; `useRef` for the debounce timer; preserves `userId` deep-link across other filter changes
- `components/features/applications-table.tsx` — `'use client'` with `Set<string>` selection state; header select-all (indeterminate support); desktop `<Table>` + mobile stacked cards; two distinct empty states (no-data vs no-match)
- `components/features/applications-bulk-bar.tsx` — `'use client'` with `useTransition`; status Select + Apply button; toasts real updated count

### Navigation
- `components/layouts/nav-items.ts` — splits `adminNavItems` into `reviewerNavItems` (Applications) and `adminOnlyNavItems` (Users, Global Questions)
- `app/(main)/layout.tsx` and `app/(app)/layout.tsx` — compute `canReviewApplications` flag via position count query; thread it to `Sidebar` and `MobileNav`
- `components/layouts/sidebar.tsx` and `components/layouts/mobile-nav.tsx` — accept `canReviewApplications`; compose nav items accordingly

## Testing plan

- [ ] As **admin**, confirm sidebar shows Applications, Users, Global Questions
- [ ] As a **manager** (non-admin), confirm sidebar shows Applications but not Users or Global Questions; Positions and My Applications present
- [ ] As a **regular applicant**, confirm Applications is absent from nav; navigating directly to `/applications` redirects to `/`
- [ ] As admin, open `/applications`: all non-draft applications appear, newest first; count line matches row count; no draft appears
- [ ] As manager M1, open `/applications`: only P1 applications appear; Position filter lists only P1
- [ ] Type in search box → URL gains `?q=…`; list narrows to matching name/email (case-insensitive); clearing restores
- [ ] Pick position → `?positionId=…`; pick status → `?status=reviewing`; filters compose (AND); "Clear filters" resets to `/applications`
- [ ] Copy a filtered URL into a new tab → same filtered result loads (bookmarkable/shareable)
- [ ] Visit `/applications?userId={id}` → pre-filters to that applicant; changing status filter keeps `userId` in URL
- [ ] Visit `/applications?status=draft` and `?status=bogus` → treated as "All"; drafts never appear
- [ ] Tick header "select all" → all visible rows selected; tick/untick one → header shows indeterminate
- [ ] Select 2–3 rows, choose "Accepted", click Apply → pending spinner; toast "Updated N applications"; selection clears; rows show Accepted badge; reload confirms persistence
- [ ] Confirm draft is not offered in the bulk status Select
- [ ] As M1, select rows and apply a status — succeeds only for P1 applications
- [ ] Attempt to bulk-update a P1 application id as M2 (via devtools) → toast "No applications were updated."; P1 status unchanged
- [ ] Empty state (no applications seeded): "No applications yet"; with active filter yielding no results: "No applications match these filters" + Clear filters button
- [ ] Observe `loading.tsx` skeleton on throttled network — layout matches final (header, toolbar, table with checkbox column)
- [ ] Operate toolbar Selects and row checkboxes entirely by keyboard; confirm visible focus rings; applicant link opens detail view via Enter
- [ ] View at narrow (mobile) width — stacked cards, checkbox + applicant link tappable, no horizontal scroll; bulk bar remains usable

## Automated checks

All three CI checks pass on the branch:
- `npm run prettier:check` — clean
- `npm run eslint:check` — clean (0 warnings)
- `npm run tsc:check` — clean (0 errors)

## Notes

- `nuqs` is in `package.json` but has no `NuqsAdapter` wired — per the plan, plain `useRouter`/`useSearchParams` is used throughout, consistent with the rest of the codebase
- The `take: 100` cap on `getApplications` guards against an unbounded query; full pagination is a deferred follow-up
- The `(app)/layout.tsx` route group layout (no active pages, present as a variant) was also updated to pass `canReviewApplications` to avoid a TypeScript error
