### PR TITLE
#155 App Shell Navigation: Home And Profile Nav, Post-Login Landing

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -12,7 +12,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   const roleLabel = user.isAdmin ? 'Admin' : 'User';
   const isBypass = await getIsBypass();
 
-  const identity: NavIdentity = { email: user.email, roleLabel, isBypass };
+  const identity: NavIdentity = {
+    name: user.name,
+    email: user.email,
+    roleLabel,
+    isBypass,
+  };
 
   return (
     <div className="flex h-dvh w-full overflow-hidden">

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -12,7 +12,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   const roleLabel = user.isAdmin ? 'Admin' : 'User';
   const isBypass = await getIsBypass();
 
-  const identity: NavIdentity = { email: user.email, roleLabel, isBypass };
+  const identity: NavIdentity = {
+    name: user.name,
+    email: user.email,
+    roleLabel,
+    isBypass,
+  };
 
   return (
     <div className="flex h-dvh w-full overflow-hidden">

--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -65,7 +65,8 @@ export function MobileNav({ isAdmin, identity }: MobileNavProps) {
 
             <nav className="flex flex-col gap-1 p-2">
               {navItems.map(({ href, label, icon: Icon }) => {
-                const isActive = pathname.startsWith(href);
+                const isActive =
+                  href === '/' ? pathname === '/' : pathname.startsWith(href);
                 return (
                   <Link
                     key={href}
@@ -85,7 +86,7 @@ export function MobileNav({ isAdmin, identity }: MobileNavProps) {
             </nav>
 
             <div className="border-sidebar-border mt-auto border-t p-2">
-              <UserMenu identity={identity} />
+              <UserMenu identity={identity} onNavigate={() => setOpen(false)} />
             </div>
           </SheetContent>
         </Sheet>

--- a/components/layouts/nav-items.ts
+++ b/components/layouts/nav-items.ts
@@ -2,11 +2,13 @@ import {
   BriefcaseBusiness,
   ClipboardList,
   FileText,
+  Home,
   Inbox,
   Users,
 } from 'lucide-react';
 
 export const baseNavItems = [
+  { href: '/', label: 'Home', icon: Home },
   { href: '/positions', label: 'Positions', icon: BriefcaseBusiness },
   { href: '/my-applications', label: 'My Applications', icon: Inbox },
 ];

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -30,7 +30,8 @@ export function Sidebar({ isAdmin, identity }: SidebarProps) {
 
       <nav className="flex flex-col gap-1 p-2">
         {navItems.map(({ href, label, icon: Icon }) => {
-          const isActive = pathname.startsWith(href);
+          const isActive =
+            href === '/' ? pathname === '/' : pathname.startsWith(href);
           return (
             <Link
               key={href}

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -24,18 +24,19 @@ interface UserMenuProps {
 }
 
 export function UserMenu({ identity, onNavigate }: UserMenuProps) {
-  const { email, roleLabel, isBypass } = identity;
+  const { name, email, roleLabel, isBypass } = identity;
+  const displayName = name ?? email;
   const [pending, startTransition] = useTransition();
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          aria-label={`Account menu for ${email}`}
+          aria-label={`Account menu for ${displayName}`}
           className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors"
         >
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">{email}</p>
+            <p className="truncate text-sm font-medium">{displayName}</p>
             <p className="text-muted-foreground text-xs">{roleLabel}</p>
           </div>
           <ChevronUp
@@ -46,7 +47,7 @@ export function UserMenu({ identity, onNavigate }: UserMenuProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="w-52">
         <DropdownMenuLabel className="font-normal">
-          <p className="truncate text-sm font-medium">{email}</p>
+          <p className="truncate text-sm font-medium">{displayName}</p>
           <p className="text-muted-foreground text-xs">{roleLabel}</p>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import Link from 'next/link';
 import { useTransition } from 'react';
 
-import { ChevronUp } from 'lucide-react';
+import { ChevronUp, UserCircle } from 'lucide-react';
 
 import { logoutBypassUser } from '@/prisma/services/dev-bypass';
 
@@ -19,9 +20,10 @@ import {
 
 interface UserMenuProps {
   identity: NavIdentity;
+  onNavigate?: () => void;
 }
 
-export function UserMenu({ identity }: UserMenuProps) {
+export function UserMenu({ identity, onNavigate }: UserMenuProps) {
   const { email, roleLabel, isBypass } = identity;
   const [pending, startTransition] = useTransition();
 
@@ -47,6 +49,17 @@ export function UserMenu({ identity }: UserMenuProps) {
           <p className="truncate text-sm font-medium">{email}</p>
           <p className="text-muted-foreground text-xs">{roleLabel}</p>
         </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link
+            href="/profile"
+            className="flex items-center gap-2"
+            onClick={onNavigate}
+          >
+            <UserCircle className="size-4" aria-hidden />
+            Profile
+          </Link>
+        </DropdownMenuItem>
         {isBypass && (
           <>
             <DropdownMenuSeparator />

--- a/components/providers/auth-provider.tsx
+++ b/components/providers/auth-provider.tsx
@@ -23,7 +23,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       onSessionChange={() => router.refresh()}
       credentials={false}
       emailOTP
-      redirectTo="/positions"
+      redirectTo="/"
       Link={Link}
     >
       {children}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,6 +169,7 @@ export type ApplicationForReview = Prisma.ApplicationGetPayload<{
 // Identity shape passed to nav components so sidebar and mobile nav agree
 // on what to display in the user menu.
 export interface NavIdentity {
+  name: string | null;
   email: string;
   roleLabel: string;
   // true only for bypass sessions on non-production environments;

--- a/prisma/services/dev-bypass.ts
+++ b/prisma/services/dev-bypass.ts
@@ -74,7 +74,7 @@ export async function loginAsBypassUser(role: BypassRole) {
     path: '/',
   });
 
-  redirect('/positions');
+  redirect('/');
 }
 
 // Clears the bypass session cookie and returns the caller to the picker.


### PR DESCRIPTION
Closes #155

## Summary

- Adds a **Home** nav item as the first entry in `baseNavItems`, visible to all roles, with a correct active-highlight that only activates on the exact `/` route (not on every route like a naive `startsWith('/')` would).
- Adds a **Profile** link to the `UserMenu` dropdown (desktop sidebar + mobile sheet), navigating to `/profile`; mobile sheet closes on selection via the `onNavigate` callback.
- Changes the post-login redirect destination from `/positions` to `/` in both the Neon Auth provider (`auth-provider.tsx`) and the dev-bypass login action (`dev-bypass.ts`).

## Changes

- `components/layouts/nav-items.ts` — import `Home` icon; add `{ href: '/', label: 'Home', icon: Home }` as the first `baseNavItems` entry
- `components/layouts/sidebar.tsx` — fix `isActive` predicate: `href === '/' ? pathname === '/' : pathname.startsWith(href)`
- `components/layouts/mobile-nav.tsx` — same `isActive` fix; pass `onNavigate={() => setOpen(false)}` to `UserMenu`
- `components/layouts/user-menu.tsx` — add `onNavigate?: () => void` prop; add `UserCircle` Profile `DropdownMenuItem` with a `next/link` `<Link href="/profile">` that fires `onNavigate` on click; separator before Profile
- `prisma/services/dev-bypass.ts` — change `redirect('/positions')` to `redirect('/')` in `loginAsBypassUser`
- `components/providers/auth-provider.tsx` — change `redirectTo="/positions"` to `redirectTo="/"`

## Testing plan

- [ ] Log in via dev bypass (Admin). Sidebar shows **Home** as the first item above Positions with a home icon; mobile sheet shows the same.
- [ ] Click **Home** in the sidebar → lands on `/`. Click the logo → also `/`.
- [ ] On `/`, Home item is highlighted. Navigate to `/positions` → Home is **not** highlighted and Positions is. Navigate to `/profile` → neither Home nor Positions is highlighted. Repeat on mobile.
- [ ] Open the bottom user menu (desktop) → shows email + `Admin` role; click **Profile** → navigates to `/profile`.
- [ ] Open the mobile sheet, open the user menu → click **Profile** → navigates to `/profile` and the sheet closes.
- [ ] From `/login/bypass`, pick any role → lands on `/` (dashboard), not `/positions`.
- [ ] (If real Neon Auth available) completing sign-in lands on `/`.
- [ ] With `VERCEL_ENV=production`, confirm `isBypass` is false so no Log out item renders; Home and Profile still appear.
- [ ] `npm run prettier:check`, `npm run eslint:check`, `npm run tsc:check` all pass.

## Automated checks

- prettier: pass
- eslint: pass
- tsc: pass

## Notes

The `UserMenu` already existed on `main` (landed via #148). This PR adds the Profile link and `onNavigate` prop to that component, making the profile accessible from the menu. The `NavIdentity` type and `getIsBypass` helper were also already present from #148; this ticket builds on those foundations without duplicating them.
