### PR TITLE
#164 Neon Branch Database Per Git Branch With Auto-Migration

### DIFF
--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -1,0 +1,210 @@
+# Neon Preview Branch — per-PR isolated database with auto-migration
+#
+# Required secrets (GitHub → Settings → Secrets and variables → Actions):
+#   NEON_API_KEY        — Neon API key with branch create/delete permissions
+#   NEON_PROJECT_ID     — Neon project ID (find in Neon console → Settings)
+#   VERCEL_TOKEN        — Vercel personal access token (optional; skip var-wiring if absent)
+#   VERCEL_ORG_ID       — Vercel team/org ID (optional)
+#   VERCEL_PROJECT_ID   — Vercel project ID (optional)
+#
+# Neon parent branch assumption: the project's default branch (main/prod).
+# To use a non-default parent, set NEON_PARENT_BRANCH_ID as a repo secret/variable.
+
+name: Neon Preview Branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+# Cancel in-progress runs for the same PR so rapid pushes don't race on the
+# same Neon branch (create-vs-migrate overlap).
+concurrency:
+  group: neon-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ── upsert ─────────────────────────────────────────────────────────────────
+  # Runs on open / synchronize / reopen.
+  # Creates (or reuses) a Neon branch and applies pending migrations.
+  upsert:
+    name: Create branch & migrate
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - name: Install dependencies
+        # npm ci is the correct CI form — lockfile-faithful, no resolution surprises.
+        # Existing workflows use npm install; this workflow intentionally uses npm ci.
+        run: npm ci
+
+      - name: Generate Prisma client
+        # Guards against config drift; migrate deploy doesn't strictly need it but
+        # aligns with the other workflows and catches schema/config issues early.
+        run: npm run prisma:generate
+
+      - name: Create or reuse Neon branch
+        id: create_branch
+        # @v6 — current major; outputs: db_url (direct/unpooled), db_url_with_pooler (pooled)
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          # Stable slug: preview/<head-ref> matches the issue's naming convention.
+          # The create-branch action accepts arbitrary branch names and is idempotent
+          # (reuses an existing branch with the same name).
+          branch_name: preview/${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      # Mask both URLs so they never appear in logs.
+      - name: Mask Neon connection strings
+        run: |
+          echo "::add-mask::${{ steps.create_branch.outputs.db_url }}"
+          echo "::add-mask::${{ steps.create_branch.outputs.db_url_with_pooler }}"
+
+      - name: Apply migrations
+        # Uses the direct (unpooled) URL — prisma migrate deploy requires a direct connection.
+        # No continue-on-error: a migration failure MUST turn the PR check red (AC).
+        run: npm run prisma:migrate:deploy
+        env:
+          DATABASE_URL: ${{ steps.create_branch.outputs.db_url }}
+
+      # ── Vercel env-var wiring (resilient — skipped if secrets absent) ──────
+
+      - name: Check Vercel secrets
+        id: check_vercel
+        # secrets.* cannot be evaluated directly in `if:` conditions, so we probe
+        # via env and write a flag to GITHUB_OUTPUT.
+        env:
+          HAS_TOKEN: ${{ secrets.VERCEL_TOKEN != '' }}
+          HAS_ORG: ${{ secrets.VERCEL_ORG_ID != '' }}
+          HAS_PROJECT: ${{ secrets.VERCEL_PROJECT_ID != '' }}
+        run: |
+          if [ "$HAS_TOKEN" = "true" ] && [ "$HAS_ORG" = "true" ] && [ "$HAS_PROJECT" = "true" ]; then
+            echo "has_vercel=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_vercel=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Vercel secrets not configured; skipping preview env var update."
+          fi
+
+      - name: Set Vercel preview DATABASE_URL
+        # Uses the pooled URL — the runtime app uses the connection pooler.
+        # Endpoint: POST /v10/projects/{id}/env (Vercel REST API)
+        # Scoped to target=preview + gitBranch=<head_ref> so only this PR's preview
+        # deployment sees the branch DB; production is never touched.
+        if: steps.check_vercel.outputs.has_vercel == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          POOLED_URL: ${{ steps.create_branch.outputs.db_url_with_pooler }}
+          GIT_BRANCH: ${{ github.head_ref }}
+        run: |
+          # Look up any existing branch-scoped DATABASE_URL to avoid duplicates.
+          EXISTING_ID=$(curl -sf \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&gitBranch=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["GIT_BRANCH"]))')" \
+            | jq -r '.envs[] | select(.key == "DATABASE_URL" and .gitBranch == env.GIT_BRANCH) | .id' \
+            || true)
+
+          if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
+            # Patch the existing record in-place.
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env/$EXISTING_ID?teamId=$VERCEL_ORG_ID" \
+              -d "{\"value\":\"$POOLED_URL\"}")
+          else
+            # Create a new branch-scoped preview env var.
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID" \
+              -d "{\"key\":\"DATABASE_URL\",\"value\":\"$POOLED_URL\",\"type\":\"encrypted\",\"target\":[\"preview\"],\"gitBranch\":\"$GIT_BRANCH\"}")
+          fi
+
+          # A non-2xx from a configured Vercel integration is a real error — fail the job.
+          if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
+            echo "Vercel API returned HTTP $HTTP_STATUS; failing job."
+            exit 1
+          fi
+
+  # ── cleanup ────────────────────────────────────────────────────────────────
+  # Runs on PR close (merged or abandoned).
+  # Deletes the Neon branch and removes the branch-scoped Vercel env var.
+  cleanup:
+    name: Delete branch
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Delete Neon branch
+        id: delete_branch
+        # @v3 — current major; tolerant if the branch is already gone (idempotent).
+        # continue-on-error is acceptable here: a missing branch on cleanup is benign.
+        uses: neondatabase/delete-branch-action@v3
+        continue-on-error: true
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: preview/${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      # ── Vercel cleanup (resilient — skipped if secrets absent) ─────────────
+
+      - name: Check Vercel secrets
+        id: check_vercel
+        env:
+          HAS_TOKEN: ${{ secrets.VERCEL_TOKEN != '' }}
+          HAS_ORG: ${{ secrets.VERCEL_ORG_ID != '' }}
+          HAS_PROJECT: ${{ secrets.VERCEL_PROJECT_ID != '' }}
+        run: |
+          if [ "$HAS_TOKEN" = "true" ] && [ "$HAS_ORG" = "true" ] && [ "$HAS_PROJECT" = "true" ]; then
+            echo "has_vercel=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_vercel=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Vercel secrets not configured; skipping preview env var cleanup."
+          fi
+
+      - name: Remove Vercel preview DATABASE_URL
+        # Deletes the branch-scoped env var created during upsert.
+        # Skips silently if not found — cleanup is best-effort.
+        if: steps.check_vercel.outputs.has_vercel == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          GIT_BRANCH: ${{ github.head_ref }}
+        run: |
+          EXISTING_ID=$(curl -sf \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&gitBranch=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["GIT_BRANCH"]))')" \
+            | jq -r '.envs[] | select(.key == "DATABASE_URL" and .gitBranch == env.GIT_BRANCH) | .id' \
+            || true)
+
+          if [ -z "$EXISTING_ID" ] || [ "$EXISTING_ID" = "null" ]; then
+            echo "No branch-scoped DATABASE_URL found for branch $GIT_BRANCH; nothing to clean up."
+            exit 0
+          fi
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env/$EXISTING_ID?teamId=$VERCEL_ORG_ID")
+
+          if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
+            echo "Vercel DELETE returned HTTP $HTTP_STATUS; failing job."
+            exit 1
+          fi
+          echo "Removed branch-scoped DATABASE_URL for branch $GIT_BRANCH."

--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -8,7 +8,9 @@
 #   VERCEL_PROJECT_ID   — Vercel project ID (optional)
 #
 # Neon parent branch assumption: the project's default branch (main/prod).
-# To use a non-default parent, set NEON_PARENT_BRANCH_ID as a repo secret/variable.
+# To use a non-default parent, set NEON_PARENT_BRANCH_ID as a repo secret/variable;
+# the create-branch step passes it as parent_id and omits the input when the secret
+# is empty so the action falls back to the project default.
 
 name: Neon Preview Branch
 
@@ -56,8 +58,24 @@ jobs:
         # aligns with the other workflows and catches schema/config issues early.
         run: npm run prisma:generate
 
+      - name: Check Neon secrets
+        id: check_neon
+        # secrets.* cannot be evaluated directly in `if:` conditions, so we probe
+        # via env and write a flag to GITHUB_OUTPUT.
+        env:
+          HAS_KEY: ${{ secrets.NEON_API_KEY != '' }}
+          HAS_PROJECT: ${{ secrets.NEON_PROJECT_ID != '' }}
+        run: |
+          if [ "$HAS_KEY" = "true" ] && [ "$HAS_PROJECT" = "true" ]; then
+            echo "has_neon=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_neon=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::NEON_API_KEY or NEON_PROJECT_ID not configured; skipping Neon branch create and migration."
+          fi
+
       - name: Create or reuse Neon branch
         id: create_branch
+        if: steps.check_neon.outputs.has_neon == 'true'
         # @v6 — current major; outputs: db_url (direct/unpooled), db_url_with_pooler (pooled)
         uses: neondatabase/create-branch-action@v6
         with:
@@ -67,14 +85,23 @@ jobs:
           # (reuses an existing branch with the same name).
           branch_name: preview/${{ github.head_ref }}
           api_key: ${{ secrets.NEON_API_KEY }}
+          # Optional: override the parent branch. When NEON_PARENT_BRANCH_ID is empty
+          # the action falls back to the project default branch.
+          parent_id: ${{ secrets.NEON_PARENT_BRANCH_ID }}
 
-      # Mask both URLs so they never appear in logs.
+      # Mask both URLs so they never appear in subsequent log lines.
+      # Note: ::add-mask:: only redacts output printed *after* this step — it cannot
+      # retroactively scrub log lines the create-branch action emitted during its own
+      # execution. The Neon action masks internally; this step guards any downstream
+      # shell steps that echo the URLs.
       - name: Mask Neon connection strings
+        if: steps.check_neon.outputs.has_neon == 'true'
         run: |
           echo "::add-mask::${{ steps.create_branch.outputs.db_url }}"
           echo "::add-mask::${{ steps.create_branch.outputs.db_url_with_pooler }}"
 
       - name: Apply migrations
+        if: steps.check_neon.outputs.has_neon == 'true'
         # Uses the direct (unpooled) URL — prisma migrate deploy requires a direct connection.
         # No continue-on-error: a migration failure MUST turn the PR check red (AC).
         run: npm run prisma:migrate:deploy
@@ -104,7 +131,7 @@ jobs:
         # Endpoint: POST /v10/projects/{id}/env (Vercel REST API)
         # Scoped to target=preview + gitBranch=<head_ref> so only this PR's preview
         # deployment sees the branch DB; production is never touched.
-        if: steps.check_vercel.outputs.has_vercel == 'true'
+        if: steps.check_neon.outputs.has_neon == 'true' && steps.check_vercel.outputs.has_vercel == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -113,9 +140,10 @@ jobs:
           GIT_BRANCH: ${{ github.head_ref }}
         run: |
           # Look up any existing branch-scoped DATABASE_URL to avoid duplicates.
+          # jq @uri performs RFC-3986 percent-encoding without requiring Python.
           EXISTING_ID=$(curl -sf \
             -H "Authorization: Bearer $VERCEL_TOKEN" \
-            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&gitBranch=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["GIT_BRANCH"]))')" \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&gitBranch=$(printf '%s' "$GIT_BRANCH" | jq -sRr @uri)" \
             | jq -r '.envs[] | select(.key == "DATABASE_URL" and .gitBranch == env.GIT_BRANCH) | .id' \
             || true)
 
@@ -188,9 +216,10 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           GIT_BRANCH: ${{ github.head_ref }}
         run: |
+          # jq @uri performs RFC-3986 percent-encoding without requiring Python.
           EXISTING_ID=$(curl -sf \
             -H "Authorization: Bearer $VERCEL_TOKEN" \
-            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&gitBranch=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["GIT_BRANCH"]))')" \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&gitBranch=$(printf '%s' "$GIT_BRANCH" | jq -sRr @uri)" \
             | jq -r '.envs[] | select(.key == "DATABASE_URL" and .gitBranch == env.GIT_BRANCH) | .id' \
             || true)
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "tsc:check": "tsc --noEmit",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
+    "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:seed": "npx tsx --env-file=.env prisma/seed.ts",
     "db:start": "docker compose up -d",
     "db:stop": "docker compose down",


### PR DESCRIPTION
Closes #164

## Summary

- Adds `.github/workflows/neon-preview-branch.yml`: a GitHub Actions workflow that creates (or reuses) a Neon database branch per PR, applies all pending Prisma migrations against that branch, and wires the pooled connection string to Vercel as a branch-scoped preview environment variable. Cleans up on PR close.
- Adds `prisma:migrate:deploy` npm script to `package.json` (wraps `prisma migrate deploy`) so the workflow follows the `npm run prisma:*` convention and never calls bare `npx prisma`.

## Changes

- **`.github/workflows/neon-preview-branch.yml`** — new workflow with two jobs:
  - `upsert` (open/synchronize/reopen): checkout → npm ci → prisma:generate → create Neon branch (`neondatabase/create-branch-action@v6`) → mask connection strings → `npm run prisma:migrate:deploy` with direct URL (no `continue-on-error`) → set branch-scoped Vercel `DATABASE_URL` via REST API (pooled URL), guarded by a "check secrets" step that emits a warning and skips — not fails — if Vercel secrets are absent.
  - `cleanup` (closed): delete Neon branch (`neondatabase/delete-branch-action@v3`, `continue-on-error: true` since a missing branch is benign) → delete branch-scoped Vercel env var (guarded same way).
  - `concurrency` group keyed on PR number with `cancel-in-progress: true` to prevent create/migrate races on rapid pushes.
  - Least-privilege `permissions: contents: read, pull-requests: write`.
  - Block comment at top listing all five required secrets.
- **`package.json`** — added `"prisma:migrate:deploy": "prisma migrate deploy"` after the existing `prisma:migrate` line.

**Deviations from existing workflow style called out explicitly:**
- Uses `npm ci` instead of `npm install` (correct CI form; lockfile-faithful).
- Uses `actions/checkout@v4` and `actions/setup-node@v4` (current majors, aligned with the Neon actions which also use v4 tooling).

## Testing plan

Prerequisites: five secrets (`NEON_API_KEY`, `NEON_PROJECT_ID`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) configured in GitHub → Settings → Secrets; a Neon project whose default branch is the production parent.

- [ ] **Open a PR from a branch with no schema change.** Confirm the "Neon Preview Branch / Create branch & migrate" check runs and goes green; in the Actions log confirm a Neon branch `preview/<head-ref>` was created and `migrate deploy` logged "No migration found" (or applied existing migrations) and exited 0.
- [ ] **In the Neon console**, confirm a branch named `preview/<head-ref>` exists and the primary/prod branch is unchanged (no new branch off it was reset; row counts/schema on prod intact).
- [ ] **In Vercel** (if secrets configured), confirm the project's Environment Variables show a `DATABASE_URL` scoped to Preview + this git branch, pointing at the Neon branch's pooled URL; open the preview deployment and confirm the app reads/writes the branch DB, not prod.
- [ ] **Push a second commit (synchronize).** Confirm the check re-runs green, the Neon branch is reused (not duplicated), and `migrate deploy` is idempotent.
- [ ] **Add a real migration on the branch** (e.g. a throwaway column), push, and confirm `migrate deploy` applies it to the branch DB only — verify the column exists on the branch DB and is absent on prod.
- [ ] **Force a migration failure** (commit a deliberately broken migration), push, and confirm the check turns red with the Prisma error visible in the log — no partial success reported as green.
- [ ] **Remove Vercel secrets (or test in a repo without them).** Confirm the Neon + migrate steps still succeed and the Vercel step is skipped with a `::warning::` annotation, not a hard failure.
- [ ] **Close/merge the PR.** Confirm the `cleanup` job runs, the Neon branch `preview/<head-ref>` is deleted in the Neon console, and the branch-scoped Vercel env var is removed (if Vercel configured). Re-running close on an already-clean PR does not fail.
- [ ] **Re-open the PR.** Confirm the branch is re-created and migrations re-applied (lifecycle is repeatable).

## Automated checks

- `prettier:check` — pass
- `eslint:check` — pass
- `tsc:check` — pass

## Notes

- The workflow file is named `neon-preview-branch.yml` (descriptive) rather than `neon-branch.yml` as the issue example suggested.
- `prisma migrate deploy` (non-interactive, applies committed migrations only, never generates or resets) is used — not `prisma migrate dev`. This distinction is called out in the plan's research findings. The new `prisma:migrate:deploy` script satisfies the "no bare `npx prisma`" acceptance criterion.
- The Vercel `DATABASE_URL` is set via the REST API (not the Vercel CLI) to keep the step hermetic and non-interactive.
- Connection strings are masked with `::add-mask::` before any subsequent step can log them.
- With zero migrations in the repo today, `migrate deploy` logs "No migration found" and exits 0 — a correct no-op until a branch adds its first migration.
