### PR TITLE
#79 Position Manager Role

### DIFF
--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -4,10 +4,10 @@ import {
   getApplications,
   getReviewablePositions,
 } from '@/prisma/data/applications';
+import { isManager } from '@/prisma/data/managers';
 
 import { getCurrentUser } from '@/lib/auth/server';
 import { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
-import prisma from '@/lib/prisma';
 import type {
   ApplicationFilters,
   ApplicationSort,
@@ -34,10 +34,8 @@ export default async function ApplicationsPage({
   // Authorization guard: admins pass; managers pass only while they have ≥1 position.
   // Regular applicants are redirected to home — the (auth) layout is not sufficient.
   if (!user.isAdmin) {
-    const managed = await prisma.position.count({
-      where: { managers: { some: { id: user.id } }, deletedAt: null },
-    });
-    if (managed === 0) redirect('/');
+    const managed = await isManager(user.id);
+    if (!managed) redirect('/');
   }
 
   const sp = await searchParams;

--- a/app/(main)/(auth)/layout.tsx
+++ b/app/(main)/(auth)/layout.tsx
@@ -1,10 +1,10 @@
 import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 
+import { isManager } from '@/prisma/data/managers';
 import { getProfileCompleteness } from '@/prisma/data/profile';
 
 import { getCurrentUser } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
 
 export default async function AuthGateLayout({
   children,
@@ -15,10 +15,7 @@ export default async function AuthGateLayout({
 
   if (user.isAdmin) return <>{children}</>;
 
-  const managedCount = await prisma.position.count({
-    where: { managers: { some: { id: user.id } }, deletedAt: null },
-  });
-  if (managedCount > 0) return <>{children}</>;
+  if (await isManager(user.id)) return <>{children}</>;
 
   const { complete } = await getProfileCompleteness(user.id);
   if (!complete) redirect('/profile');

--- a/app/(main)/(auth)/page.tsx
+++ b/app/(main)/(auth)/page.tsx
@@ -8,5 +8,8 @@ export default async function Home() {
 
   if (user.isAdmin) return <AdminDashboard />;
 
+  // Managers intentionally use UserDashboard — they are also regular users who can apply.
+  // A bespoke manager dashboard (managed-position pipeline) belongs to the Applications
+  // hub (#150) and would duplicate that work here.
   return <UserDashboard userId={user.id} userName={user.name} />;
 }

--- a/app/(main)/(auth)/positions/[id]/edit/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/edit/page.tsx
@@ -28,8 +28,11 @@ export default async function EditPositionPage({
 
   // Access check: admins always have access; managers are confirmed after the DB fetch
   // because the manager list is part of the position record.
-  const isManager = position.managers.some((m) => m.id === user.id);
-  if (!user.isAdmin && !isManager) redirect(`/positions/${id}`);
+  const isPositionManager = position.managers.some((m) => m.id === user.id);
+  if (!user.isAdmin && !isPositionManager) redirect(`/positions/${id}`);
+
+  // canManage: admin always; managers confirmed above via the position record.
+  const canManage = user.isAdmin || isPositionManager;
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6">
@@ -60,11 +63,11 @@ export default async function EditPositionPage({
           />
         }
         managersContent={
-          user.isAdmin ? (
+          canManage ? (
             <PositionManagersSection
               positionId={position.id}
               initialManagers={position.managers}
-              isAdmin={user.isAdmin}
+              canManage={canManage}
             />
           ) : null
         }

--- a/app/(main)/(auth)/positions/page.tsx
+++ b/app/(main)/(auth)/positions/page.tsx
@@ -1,16 +1,21 @@
+import { Briefcase } from 'lucide-react';
+
 import { getManagedPositionIds } from '@/prisma/data/managers';
 import { getPositions } from '@/prisma/data/positions';
+
 import { getCurrentUser } from '@/lib/auth/server';
 
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
 import { PageHeader } from '@/components/layouts/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Briefcase } from 'lucide-react';
 
 export default async function PositionsPage() {
   const user = await getCurrentUser();
-  const positions = await getPositions({ isAdmin: user.isAdmin, userId: user.id });
+  const positions = await getPositions({
+    isAdmin: user.isAdmin,
+    userId: user.id,
+  });
 
   let managedIds: Set<string>;
   if (user.isAdmin) {

--- a/app/(main)/(auth)/positions/page.tsx
+++ b/app/(main)/(auth)/positions/page.tsx
@@ -1,6 +1,7 @@
 import { getManagedPositionIds } from '@/prisma/data/managers';
 import { getPositions } from '@/prisma/data/positions';
 import { getCurrentUser } from '@/lib/auth/server';
+
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
 import { PageHeader } from '@/components/layouts/page-header';

--- a/app/(main)/(auth)/positions/page.tsx
+++ b/app/(main)/(auth)/positions/page.tsx
@@ -1,40 +1,45 @@
-import { Briefcase } from 'lucide-react';
-
+import { getManagedPositionIds } from '@/prisma/data/managers';
 import { getPositions } from '@/prisma/data/positions';
-
 import { getCurrentUser } from '@/lib/auth/server';
-
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
 import { PageHeader } from '@/components/layouts/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Briefcase } from 'lucide-react';
 
 export default async function PositionsPage() {
   const user = await getCurrentUser();
-  const positions = await getPositions(user.isAdmin);
+  const positions = await getPositions({ isAdmin: user.isAdmin, userId: user.id });
+
+  let managedIds: Set<string>;
+  if (user.isAdmin) {
+    managedIds = new Set(positions.map((p) => p.id));
+  } else {
+    managedIds = await getManagedPositionIds(user.id);
+  }
+  const canCreate = user.isAdmin || managedIds.size > 0;
 
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
-        title={user.isAdmin ? 'Positions' : 'Open Positions'}
+        title={canCreate ? 'Positions' : 'Open Positions'}
         description={
-          user.isAdmin
+          canCreate
             ? 'Create, edit, and review applications for every position.'
             : 'Browse and apply to open positions.'
         }
-        actions={user.isAdmin ? <PositionCreateDialog /> : undefined}
+        actions={canCreate ? <PositionCreateDialog /> : undefined}
       />
-
       {positions.length === 0 ? (
         <EmptyState
           icon={Briefcase}
-          title={user.isAdmin ? 'No positions yet' : 'No open positions'}
+          title={canCreate ? 'No positions yet' : 'No open positions'}
           description={
-            user.isAdmin
+            canCreate
               ? 'Create your first position to start accepting applications.'
               : 'There are no open positions right now. Check back soon.'
           }
-          action={user.isAdmin ? <PositionCreateDialog /> : undefined}
+          action={canCreate ? <PositionCreateDialog /> : undefined}
         />
       ) : (
         <div className="grid items-start gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -42,7 +47,7 @@ export default async function PositionsPage() {
             <PositionCard
               key={position.id}
               position={position}
-              showAdminActions={user.isAdmin}
+              canManage={managedIds.has(position.id)}
             />
           ))}
         </div>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 
+import { isManager } from '@/prisma/data/managers';
+
 import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
 import type { NavIdentity } from '@/lib/types';
 
 import { MobileNav } from '@/components/layouts/mobile-nav';
@@ -10,7 +11,11 @@ import { Sidebar } from '@/components/layouts/sidebar';
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const user = await getCurrentUser();
 
-  const roleLabel = user.isAdmin ? 'Admin' : 'User';
+  // Admins always see reviewer nav; check manager status only for non-admins.
+  const userIsManager = user.isAdmin ? false : await isManager(user.id);
+  const canReviewApplications = user.isAdmin || userIsManager;
+
+  const roleLabel = user.isAdmin ? 'Admin' : userIsManager ? 'Manager' : 'User';
   const isBypass = await getIsBypass();
 
   const identity: NavIdentity = {
@@ -19,13 +24,6 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     roleLabel,
     isBypass,
   };
-
-  // Admins always see reviewer nav; managers see it only while they manage ≥1 position.
-  const canReviewApplications =
-    user.isAdmin ||
-    (await prisma.position.count({
-      where: { managers: { some: { id: user.id } }, deletedAt: null },
-    })) > 0;
 
   return (
     <div className="flex h-dvh w-full overflow-hidden">

--- a/components/features/open-positions-widget.tsx
+++ b/components/features/open-positions-widget.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 import { ArrowRight, Briefcase } from 'lucide-react';
 
-import { getPositions } from '@/prisma/data/positions';
+import { getOpenPositions } from '@/prisma/data/positions';
 
 import { formatDate, getPositionAvailability } from '@/lib/utils';
 
@@ -10,9 +10,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export async function OpenPositionsWidget() {
-  // Reuse getPositions(false) — returns only open positions. Slight over-fetch
-  // of questions fields is acceptable to reuse the shared type (ENGINEERING §2).
-  const positions = await getPositions(false);
+  // getOpenPositions returns only open positions; does not surface a manager's
+  // draft/closed positions in this "Open Positions" widget context.
+  const positions = await getOpenPositions();
   const displayed = positions.slice(0, 5);
 
   return (
@@ -74,7 +74,7 @@ export async function OpenPositionsWidget() {
                       <span className="text-muted-foreground shrink-0 text-xs">
                         {availability === 'upcoming' && position.opensAt
                           ? `Opens ${formatDate(position.opensAt)}`
-                          : /* closed_by_date or unavailable (unreachable via getPositions(false)) */ 'Closed'}
+                          : /* closed_by_date or unavailable (unreachable via getOpenPositions) */ 'Closed'}
                       </span>
                     )}
                   </div>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -15,12 +15,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 interface PositionCardProps {
   position: PositionWithQuestions;
-  showAdminActions?: boolean;
+  canManage?: boolean;
 }
 
 export function PositionCard({
   position,
-  showAdminActions = false,
+  canManage = false,
 }: PositionCardProps) {
   const [open, setOpen] = useState(false);
 
@@ -39,7 +39,7 @@ export function PositionCard({
         >
           <div className="flex items-center gap-3">
             <CardTitle className="text-lg">{position.title}</CardTitle>
-            {showAdminActions && <PositionStatusBadge position={position} />}
+            {canManage && <PositionStatusBadge position={position} />}
           </div>
           {open ? (
             <ChevronUp className="text-muted-foreground size-5 shrink-0" />
@@ -69,7 +69,7 @@ export function PositionCard({
           )}
 
           <div className="flex items-center gap-2 pt-2">
-            {showAdminActions ? (
+            {canManage ? (
               <>
                 {isAccepting && (
                   <Button asChild>

--- a/components/features/position-managers-section.tsx
+++ b/components/features/position-managers-section.tsx
@@ -28,13 +28,13 @@ interface UserResult {
 interface PositionManagersSectionProps {
   positionId: string;
   initialManagers: PositionManager[];
-  isAdmin: boolean;
+  canManage: boolean;
 }
 
 export function PositionManagersSection({
   positionId,
   initialManagers,
-  isAdmin,
+  canManage,
 }: PositionManagersSectionProps) {
   const [managers, setManagers] = useState<PositionManager[]>(initialManagers);
   const [query, setQuery] = useState('');
@@ -124,7 +124,7 @@ export function PositionManagersSection({
                   </p>
                 )}
               </div>
-              {isAdmin && (
+              {canManage && (
                 <Button
                   variant="ghost"
                   size="icon"
@@ -144,7 +144,7 @@ export function PositionManagersSection({
         </ul>
       )}
 
-      {isAdmin && (
+      {canManage && (
         <div className="flex flex-col gap-2">
           <Label htmlFor="manager-search">Add Manager</Label>
           <div className="relative">

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -80,7 +80,7 @@ export async function updatePosition(
   const { id, title, description, status, opensAt, closesAt } = parsed.data;
 
   const hasAccess = await checkPositionAccess(id, user.id, user.isAdmin);
-  if (!hasAccess) return { error: 'Unauthorized' };
+  if (!hasAccess) throw new Error('Forbidden');
 
   await prisma.position.update({
     where: { id },
@@ -135,7 +135,7 @@ export async function addPositionManager(
     user.id,
     user.isAdmin,
   );
-  if (!hasAccess) return { error: 'Unauthorized' };
+  if (!hasAccess) throw new Error('Forbidden');
 
   await prisma.position.update({
     where: { id: positionId },
@@ -160,7 +160,7 @@ export async function removePositionManager(
     user.id,
     user.isAdmin,
   );
-  if (!hasAccess) return { error: 'Unauthorized' };
+  if (!hasAccess) throw new Error('Forbidden');
 
   await prisma.position.update({
     where: { id: positionId },

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -4,6 +4,8 @@ import { revalidatePath } from 'next/cache';
 
 import { z } from 'zod/v4';
 
+import { checkPositionAccess } from '@/prisma/data/managers';
+
 import { getCurrentUser } from '@/lib/auth/server';
 import prisma from '@/lib/prisma';
 
@@ -30,12 +32,12 @@ const deletePositionSchema = z.object({ id: z.string().min(1) });
 
 const addPositionManagerSchema = z.object({
   positionId: z.string().min(1),
-  userId: z.string().min(1),
+  userId: z.string().cuid(),
 });
 
 const removePositionManagerSchema = z.object({
   positionId: z.string().min(1),
-  userId: z.string().min(1),
+  userId: z.string().cuid(),
 });
 
 export async function createPosition(
@@ -77,15 +79,8 @@ export async function updatePosition(
 
   const { id, title, description, status, opensAt, closesAt } = parsed.data;
 
-  const position = await prisma.position.findFirst({
-    where: { id, deletedAt: null },
-    include: { managers: { where: { id: user.id } } },
-  });
-
-  if (!position) return { error: 'Position not found' };
-
-  const isPositionManager = position.managers.length > 0;
-  if (!user.isAdmin && !isPositionManager) return { error: 'Unauthorized' };
+  const hasAccess = await checkPositionAccess(id, user.id, user.isAdmin);
+  if (!hasAccess) return { error: 'Unauthorized' };
 
   await prisma.position.update({
     where: { id },
@@ -135,17 +130,12 @@ export async function addPositionManager(
 
   const { positionId, userId } = parsed.data;
 
-  // Fetch position and check if the caller manages it (admin or manager-of-this-position).
-  const position = await prisma.position.findFirst({
-    where: { id: positionId, deletedAt: null },
-    select: {
-      id: true,
-      managers: { where: { id: user.id }, select: { id: true } },
-    },
-  });
-  if (!position) return { error: 'Not found' };
-  if (!user.isAdmin && position.managers.length === 0)
-    return { error: 'Unauthorized' };
+  const hasAccess = await checkPositionAccess(
+    positionId,
+    user.id,
+    user.isAdmin,
+  );
+  if (!hasAccess) return { error: 'Unauthorized' };
 
   await prisma.position.update({
     where: { id: positionId },
@@ -165,17 +155,12 @@ export async function removePositionManager(
 
   const { positionId, userId } = parsed.data;
 
-  // Fetch position and check if the caller manages it (admin or manager-of-this-position).
-  const position = await prisma.position.findFirst({
-    where: { id: positionId, deletedAt: null },
-    select: {
-      id: true,
-      managers: { where: { id: user.id }, select: { id: true } },
-    },
-  });
-  if (!position) return { error: 'Not found' };
-  if (!user.isAdmin && position.managers.length === 0)
-    return { error: 'Unauthorized' };
+  const hasAccess = await checkPositionAccess(
+    positionId,
+    user.id,
+    user.isAdmin,
+  );
+  if (!hasAccess) return { error: 'Unauthorized' };
 
   await prisma.position.update({
     where: { id: positionId },

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -144,6 +144,7 @@ export async function addPositionManager(
 
   const exists = await prisma.position.findFirst({
     where: { id: positionId, deletedAt: null },
+    select: { id: true },
   });
   if (!exists) notFound();
 
@@ -174,6 +175,7 @@ export async function removePositionManager(
 
   const exists = await prisma.position.findFirst({
     where: { id: positionId, deletedAt: null },
+    select: { id: true },
   });
   if (!exists) notFound();
 

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { notFound } from 'next/navigation';
 
 import { z } from 'zod/v4';
 
@@ -141,6 +142,11 @@ export async function addPositionManager(
 
   const { positionId, userId } = parsed.data;
 
+  const exists = await prisma.position.findFirst({
+    where: { id: positionId, deletedAt: null },
+  });
+  if (!exists) notFound();
+
   const hasAccess = await checkPositionAccess(
     positionId,
     user.id,
@@ -165,6 +171,11 @@ export async function removePositionManager(
   if (!parsed.success) return { error: 'Invalid input' };
 
   const { positionId, userId } = parsed.data;
+
+  const exists = await prisma.position.findFirst({
+    where: { id: positionId, deletedAt: null },
+  });
+  if (!exists) notFound();
 
   const hasAccess = await checkPositionAccess(
     positionId,

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -42,13 +42,13 @@ export async function createPosition(
   input: unknown,
 ): Promise<{ id: string } | { error: string }> {
   const user = await getCurrentUser();
-  if (!user.isAdmin) return { error: 'Unauthorized' };
 
   const parsed = createPositionSchema.safeParse(input);
   if (!parsed.success) return { error: 'Invalid input' };
 
   const { title, description, status, opensAt, closesAt } = parsed.data;
 
+  // Creator is auto-assigned as a manager so they can immediately edit the position.
   const position = await prisma.position.create({
     data: {
       title,
@@ -58,6 +58,7 @@ export async function createPosition(
       closesAt: closesAt ? new Date(closesAt) : null,
       createdById: user.id,
       updatedById: user.id,
+      managers: { connect: { id: user.id } },
     },
     select: { id: true },
   });
@@ -83,8 +84,8 @@ export async function updatePosition(
 
   if (!position) return { error: 'Position not found' };
 
-  const isManager = position.managers.length > 0;
-  if (!user.isAdmin && !isManager) return { error: 'Unauthorized' };
+  const isPositionManager = position.managers.length > 0;
+  if (!user.isAdmin && !isPositionManager) return { error: 'Unauthorized' };
 
   await prisma.position.update({
     where: { id },
@@ -128,18 +129,23 @@ export async function addPositionManager(
   input: unknown,
 ): Promise<void | { error: string }> {
   const user = await getCurrentUser();
-  if (!user.isAdmin) return { error: 'Unauthorized' };
 
   const parsed = addPositionManagerSchema.safeParse(input);
   if (!parsed.success) return { error: 'Invalid input' };
 
   const { positionId, userId } = parsed.data;
 
-  const addPosition = await prisma.position.findFirst({
+  // Fetch position and check if the caller manages it (admin or manager-of-this-position).
+  const position = await prisma.position.findFirst({
     where: { id: positionId, deletedAt: null },
-    select: { id: true },
+    select: {
+      id: true,
+      managers: { where: { id: user.id }, select: { id: true } },
+    },
   });
-  if (!addPosition) return { error: 'Not found' };
+  if (!position) return { error: 'Not found' };
+  if (!user.isAdmin && position.managers.length === 0)
+    return { error: 'Unauthorized' };
 
   await prisma.position.update({
     where: { id: positionId },
@@ -153,18 +159,23 @@ export async function removePositionManager(
   input: unknown,
 ): Promise<void | { error: string }> {
   const user = await getCurrentUser();
-  if (!user.isAdmin) return { error: 'Unauthorized' };
 
   const parsed = removePositionManagerSchema.safeParse(input);
   if (!parsed.success) return { error: 'Invalid input' };
 
   const { positionId, userId } = parsed.data;
 
-  const removePosition = await prisma.position.findFirst({
+  // Fetch position and check if the caller manages it (admin or manager-of-this-position).
+  const position = await prisma.position.findFirst({
     where: { id: positionId, deletedAt: null },
-    select: { id: true },
+    select: {
+      id: true,
+      managers: { where: { id: user.id }, select: { id: true } },
+    },
   });
-  if (!removePosition) return { error: 'Not found' };
+  if (!position) return { error: 'Not found' };
+  if (!user.isAdmin && position.managers.length === 0)
+    return { error: 'Unauthorized' };
 
   await prisma.position.update({
     where: { id: positionId },
@@ -176,9 +187,12 @@ export async function removePositionManager(
 
 const searchUsersSchema = z.object({ query: z.string().max(200) });
 
+// Authenticated directory lookup used to assign position managers.
+// Intentionally exposes name+email to any logged-in user — only id/displayName/email
+// are returned (no sensitive/internal fields). Capped at 10 results.
 export async function searchUsers(input: unknown) {
-  const user = await getCurrentUser();
-  if (!user.isAdmin) return [];
+  // getCurrentUser redirects if unauthenticated; no further role check needed.
+  await getCurrentUser();
 
   const parsed = searchUsersSchema.safeParse(input);
   if (!parsed.success) return [];

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -79,6 +79,14 @@ export async function updatePosition(
 
   const { id, title, description, status, opensAt, closesAt } = parsed.data;
 
+  // Stale-link guard: a manager navigating to a deleted position should get an
+  // actionable message, not a generic error toast (ENGINEERING §4 gray-area rule).
+  const exists = await prisma.position.findFirst({
+    where: { id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!exists) return { error: 'Position no longer exists' };
+
   const hasAccess = await checkPositionAccess(id, user.id, user.isAdmin);
   if (!hasAccess) throw new Error('Forbidden');
 

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import { z } from 'zod/v4';
 
-import { checkPositionAccess } from '@/prisma/data/managers';
+import { checkPositionAccess, isManager } from '@/prisma/data/managers';
 
 import { getCurrentUser } from '@/lib/auth/server';
 import prisma from '@/lib/prisma';
@@ -44,6 +44,9 @@ export async function createPosition(
   input: unknown,
 ): Promise<{ id: string } | { error: string }> {
   const user = await getCurrentUser();
+
+  const allowed = user.isAdmin || (await isManager(user.id));
+  if (!allowed) return { error: 'Unauthorized' };
 
   const parsed = createPositionSchema.safeParse(input);
   if (!parsed.success) return { error: 'Invalid input' };

--- a/prisma/actions/position-question-actions.ts
+++ b/prisma/actions/position-question-actions.ts
@@ -53,7 +53,7 @@ export async function createPositionQuestion(
     user.id,
     user.isAdmin,
   );
-  if (!hasAccess) return { error: 'Unauthorized' };
+  if (!hasAccess) throw new Error('Forbidden');
 
   const created = await prisma.$transaction(async (tx) => {
     const maxOrder = await tx.positionQuestion.aggregate({
@@ -96,7 +96,7 @@ export async function updatePositionQuestion(
     user.id,
     user.isAdmin,
   );
-  if (!hasAccess) return { error: 'Unauthorized' };
+  if (!hasAccess) throw new Error('Forbidden');
 
   // Scope the write to positionId to prevent IDOR across positions
   const result = await prisma.positionQuestion.updateMany({
@@ -124,7 +124,7 @@ export async function deletePositionQuestion(
     user.id,
     user.isAdmin,
   );
-  if (!hasAccess) return { error: 'Unauthorized' };
+  if (!hasAccess) throw new Error('Forbidden');
 
   // Scope the write to positionId to prevent IDOR across positions
   const result = await prisma.positionQuestion.updateMany({

--- a/prisma/actions/position-question-actions.ts
+++ b/prisma/actions/position-question-actions.ts
@@ -4,6 +4,8 @@ import { revalidatePath } from 'next/cache';
 
 import { z } from 'zod/v4';
 
+import { checkPositionAccess } from '@/prisma/data/managers';
+
 import { getCurrentUser } from '@/lib/auth/server';
 import prisma from '@/lib/prisma';
 
@@ -36,21 +38,6 @@ const deletePositionQuestionSchema = z.object({
   positionId: z.string().min(1),
 });
 
-async function checkAccess(
-  positionId: string,
-  userId: string,
-  isAdmin: boolean,
-): Promise<boolean> {
-  if (isAdmin) return true;
-
-  const position = await prisma.position.findFirst({
-    where: { id: positionId, deletedAt: null },
-    include: { managers: { where: { id: userId } } },
-  });
-
-  return (position?.managers.length ?? 0) > 0;
-}
-
 export async function createPositionQuestion(
   input: unknown,
 ): Promise<{ id: string; order: number } | { error: string }> {
@@ -61,7 +48,11 @@ export async function createPositionQuestion(
 
   const { positionId, label, type, required, options } = parsed.data;
 
-  const hasAccess = await checkAccess(positionId, user.id, user.isAdmin);
+  const hasAccess = await checkPositionAccess(
+    positionId,
+    user.id,
+    user.isAdmin,
+  );
   if (!hasAccess) return { error: 'Unauthorized' };
 
   const created = await prisma.$transaction(async (tx) => {
@@ -100,7 +91,11 @@ export async function updatePositionQuestion(
 
   const { id, positionId, label, type, required, options } = parsed.data;
 
-  const hasAccess = await checkAccess(positionId, user.id, user.isAdmin);
+  const hasAccess = await checkPositionAccess(
+    positionId,
+    user.id,
+    user.isAdmin,
+  );
   if (!hasAccess) return { error: 'Unauthorized' };
 
   // Scope the write to positionId to prevent IDOR across positions
@@ -124,7 +119,11 @@ export async function deletePositionQuestion(
 
   const { id, positionId } = parsed.data;
 
-  const hasAccess = await checkAccess(positionId, user.id, user.isAdmin);
+  const hasAccess = await checkPositionAccess(
+    positionId,
+    user.id,
+    user.isAdmin,
+  );
   if (!hasAccess) return { error: 'Unauthorized' };
 
   // Scope the write to positionId to prevent IDOR across positions

--- a/prisma/data/managers.ts
+++ b/prisma/data/managers.ts
@@ -12,3 +12,32 @@ export async function isManager(userId: string): Promise<boolean> {
   });
   return count > 0;
 }
+
+// Returns the set of position IDs managed by the given user (non-deleted only).
+// Admins should pass the full positions list instead of calling this function.
+export async function getManagedPositionIds(
+  userId: string,
+): Promise<Set<string>> {
+  const managed = await prisma.position.findMany({
+    where: { managers: { some: { id: userId } }, deletedAt: null },
+    select: { id: true },
+  });
+  return new Set(managed.map((p) => p.id));
+}
+
+// Returns true if the user is an admin or a manager of the given position.
+// Used as the shared authorization guard across position actions.
+export async function checkPositionAccess(
+  positionId: string,
+  userId: string,
+  isAdmin: boolean,
+): Promise<boolean> {
+  if (isAdmin) return true;
+
+  const position = await prisma.position.findFirst({
+    where: { id: positionId, deletedAt: null },
+    select: { managers: { where: { id: userId }, select: { id: true } } },
+  });
+
+  return (position?.managers.length ?? 0) > 0;
+}

--- a/prisma/data/managers.ts
+++ b/prisma/data/managers.ts
@@ -1,0 +1,14 @@
+import 'server-only';
+
+import prisma from '@/lib/prisma';
+
+// Single source of truth for global manager detection.
+// Returns true if the user manages at least one non-deleted position.
+// Per-position checks use position.managers.some(m => m.id === userId)
+// against an already-fetched list; this function is for nav/dashboard routing only.
+export async function isManager(userId: string): Promise<boolean> {
+  const count = await prisma.position.count({
+    where: { managers: { some: { id: userId } }, deletedAt: null },
+  });
+  return count > 0;
+}

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -8,13 +8,53 @@ import {
 } from '@/lib/types';
 import { isAcceptingApplications } from '@/lib/utils';
 
-export async function getPositions(
-  includeAll = false,
-): Promise<PositionWithQuestions[]> {
+// Manager-aware positions query.
+// Admin: all non-deleted positions.
+// Non-admin: open positions ∪ positions the user manages (including drafts).
+// A plain applicant (manages nothing) collapses to open-only — same as before.
+export async function getPositions({
+  isAdmin,
+  userId,
+}: {
+  isAdmin: boolean;
+  userId: string;
+}): Promise<PositionWithQuestions[]> {
   return prisma.position.findMany({
-    where: includeAll
+    where: isAdmin
       ? { deletedAt: null }
-      : { status: 'open', deletedAt: null },
+      : {
+          deletedAt: null,
+          OR: [{ status: 'open' }, { managers: { some: { id: userId } } }],
+        },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      description: true,
+      opensAt: true,
+      closesAt: true,
+      questions: {
+        where: { deletedAt: null },
+        orderBy: { order: 'asc' },
+        select: {
+          id: true,
+          label: true,
+          type: true,
+          required: true,
+          options: true,
+          order: true,
+        },
+      },
+    },
+    orderBy: { title: 'asc' },
+  });
+}
+
+// Open-only positions for widgets (e.g. dashboard) that must not surface
+// a manager's draft/closed positions in an "Open Positions" context.
+export async function getOpenPositions(): Promise<PositionWithQuestions[]> {
+  return prisma.position.findMany({
+    where: { status: 'open', deletedAt: null },
     select: {
       id: true,
       title: true,


### PR DESCRIPTION
Closes #79

## Summary

- Introduces the manager role tier by threading "is this user a manager?" through all previously admin-only surfaces — nav, positions list, create, edit page, and manager assignment actions
- No schema changes: manager status is fully derived from the existing `Position.managers` many-to-many relation
- Admins are unaffected; regular applicants are unaffected

## Changes

- **`prisma/data/managers.ts`** (new): `isManager(userId)` — single source of truth for global manager detection, extracted from the auth-gate layout's inline count
- **`app/(main)/(auth)/layout.tsx`**: refactored to call `isManager()` instead of inlining the prisma count (behavior identical)
- **`prisma/data/positions.ts`**: `getPositions` is now manager-aware (`{ isAdmin, userId }` signature); added `getOpenPositions()` for widgets that must not surface managed drafts
- **`components/features/open-positions-widget.tsx`**: updated to call `getOpenPositions()`
- **`prisma/actions/position-actions.ts`**:
  - `createPosition`: drops `isAdmin` gate; auto-assigns creator as a manager via `managers: { connect: { id: user.id } }`
  - `addPositionManager` / `removePositionManager`: authorize admin-or-manager-of-this-position
  - `searchUsers`: drops admin gate (authenticated only), with security note
- **`components/layouts/nav-items.ts`**: split `adminNavItems` into `reviewerNavItems` (Applications) + `adminOnlyNavItems` (Users, Global Questions)
- **`app/(main)/layout.tsx`**: computes `userIsManager` via `isManager()`, passes `canReviewApplications` to nav, sets `roleLabel` to Admin/Manager/User
- **`app/(main)/(auth)/positions/page.tsx`**: fetches manager-aware positions, computes `canCreate` and per-card `canManage` via a managed-ids Set (no N+1)
- **`components/features/position-card.tsx`**: renames `showAdminActions` → `canManage`
- **`app/(main)/(auth)/positions/[id]/edit/page.tsx`**: renders Managers tab for `canManage` (admin or manager-of-this-position)
- **`components/features/position-managers-section.tsx`**: renames `isAdmin` prop → `canManage`
- **`app/(main)/(auth)/page.tsx`**: documents that managers intentionally use `UserDashboard`

## Testing plan

Setup: use the dev bypass picker (`/login/bypass`). It provides admin, applicant, and position-manager identities. As admin, also create a second open position not managed by the bypass manager.

**Navigation / role gating**
- [ ] Log in as applicant. Sidebar shows only Positions + My Applications. Manually visit `/users`, `/global-questions`, `/applications/<any id>` — expect redirect/not-found. User menu shows role "User".
- [ ] Log in as manager. Sidebar shows Positions, My Applications, Applications — and NOT Users or Global Questions. User menu shows role "Manager". Visit `/users` and `/global-questions` directly → redirected to `/`.
- [ ] Log in as admin. Sidebar unchanged: Positions, My Applications, Applications, Users, Global Questions.
- [ ] Repeat the manager sidebar check at mobile width (< md) via the hamburger Sheet — same items, no Users/Global Questions.

**Positions list scoping**
- [ ] As manager, open `/positions`. Title is "Positions", "New Position" button is present, managed "Bypass Position" card shows Edit + Applications, and any other open positions show Apply (not Edit). A managed draft appears with Edit/Applications even though it's a draft.
- [ ] As applicant, open `/positions`. Title is "Open Positions", no New Position button, only open positions, Apply only (no Edit/Applications).
- [ ] As admin, open `/positions`. Unchanged: all positions, admin actions on each, New Position button.

**Create + auto-assignment**
- [ ] As manager, click New Position, fill title + status, Create. Expect a "Position created" toast and redirect to that position's `/edit`. Confirm you can open the edit page (auto-assigned). Open the Managers tab → your account is listed as a manager.
- [ ] As applicant, confirm there is no create button.

**Edit / questions / managers (own position)**
- [ ] As manager, on your managed position's edit page: change a detail and save → "saved" toast persists on reload. Add a position question → it appears. Open the Managers tab → search a user by name/email, Add them (toast "Manager added"), then Remove them (toast "Manager removed").
- [ ] As manager, try to open the edit page of a position you do NOT manage → redirected to that position's view (no edit access).

**Applications (own position)**
- [ ] As manager, from your managed position card click Applications → see the per-position table. Open an application detail (`/applications/<id>`) → change its status (toast "Status updated"), reload to confirm persistence.
- [ ] As manager, open `/applications/<id>` for an application on a position you do NOT manage → "Page not found" (no leak).

**States & a11y**
- [ ] Manager with zero open positions and zero managed positions → muted empty line, no crash.
- [ ] Operate the Managers tab search + add/remove entirely by keyboard (Tab to input, type, Tab to a result, Enter to add; Tab to remove, Enter); visible focus rings throughout.
- [ ] Verify both light and dark themes render the manager sidebar and positions list correctly (design tokens, no hardcoded colors).

## Automated checks

- `npm run tsc:check` — passes
- `npm run eslint:check` — passes
- `npm run prettier:check` — passes

## Notes

- A manager who removes themselves from a position's manager list will be redirected out of the edit page on the next render — this is intentional and consistent with the access model.
- The manager dashboard is intentionally the UserDashboard; a bespoke manager pipeline view belongs to the Applications hub (#150).
- The `/users` Manager badge mentioned in the ticket spec depends on #77 (User Management) and is out of scope for this ticket.
