### PR TITLE
#173 Fix Neon Preview Branch Workflow: db_url_with_pooler Empty In v6

### DIFF
--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -9,7 +9,7 @@
 #
 # Neon parent branch assumption: the project's default branch (main/prod).
 # To use a non-default parent, set NEON_PARENT_BRANCH_ID as a repo secret/variable;
-# the create-branch step passes it as parent_id and omits the input when the secret
+# the create-branch step passes it as parent_branch and omits the input when the secret
 # is empty so the action falls back to the project default.
 
 name: Neon Preview Branch
@@ -76,7 +76,7 @@ jobs:
       - name: Create or reuse Neon branch
         id: create_branch
         if: steps.check_neon.outputs.has_neon == 'true'
-        # @v6 — current major; outputs: db_url (direct/unpooled), db_url_with_pooler (pooled)
+        # @v6 — current major; outputs: db_url (direct/unpooled). db_url_with_pooler is empty in v6.
         uses: neondatabase/create-branch-action@v6
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
@@ -87,18 +87,17 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
           # Optional: override the parent branch. When NEON_PARENT_BRANCH_ID is empty
           # the action falls back to the project default branch.
-          parent_id: ${{ secrets.NEON_PARENT_BRANCH_ID }}
+          parent_branch: ${{ secrets.NEON_PARENT_BRANCH_ID }}
 
-      # Mask both URLs so they never appear in subsequent log lines.
+      # Mask the URL so it never appears in subsequent log lines.
       # Note: ::add-mask:: only redacts output printed *after* this step — it cannot
       # retroactively scrub log lines the create-branch action emitted during its own
       # execution. The Neon action masks internally; this step guards any downstream
-      # shell steps that echo the URLs.
-      - name: Mask Neon connection strings
+      # shell steps that echo the URL.
+      - name: Mask Neon connection string
         if: steps.check_neon.outputs.has_neon == 'true'
         run: |
           echo "::add-mask::${{ steps.create_branch.outputs.db_url }}"
-          echo "::add-mask::${{ steps.create_branch.outputs.db_url_with_pooler }}"
 
       - name: Apply migrations
         if: steps.check_neon.outputs.has_neon == 'true'
@@ -127,7 +126,8 @@ jobs:
           fi
 
       - name: Set Vercel preview DATABASE_URL
-        # Uses the pooled URL — the runtime app uses the connection pooler.
+        # Uses the direct URL from db_url — v6 does not populate db_url_with_pooler.
+        # The Prisma datasource has no directUrl split, so the direct endpoint is fine.
         # Endpoint: POST /v10/projects/{id}/env (Vercel REST API)
         # Scoped to target=preview + gitBranch=<head_ref> so only this PR's preview
         # deployment sees the branch DB; production is never touched.
@@ -136,9 +136,14 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          POOLED_URL: ${{ steps.create_branch.outputs.db_url_with_pooler }}
+          BRANCH_URL: ${{ steps.create_branch.outputs.db_url }}
           GIT_BRANCH: ${{ github.head_ref }}
         run: |
+          if [ -z "$BRANCH_URL" ]; then
+            echo "::error::db_url output from create-branch-action is empty; cannot set Vercel DATABASE_URL."
+            exit 1
+          fi
+
           # Look up any existing branch-scoped DATABASE_URL to avoid duplicates.
           # jq @uri performs RFC-3986 percent-encoding without requiring Python.
           EXISTING_ID=$(curl -sf \
@@ -153,14 +158,14 @@ jobs:
               -H "Authorization: Bearer $VERCEL_TOKEN" \
               -H "Content-Type: application/json" \
               "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env/$EXISTING_ID?teamId=$VERCEL_ORG_ID" \
-              -d "{\"value\":\"$POOLED_URL\"}")
+              -d "{\"value\":\"$BRANCH_URL\"}")
           else
             # Create a new branch-scoped preview env var.
             HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
               -H "Authorization: Bearer $VERCEL_TOKEN" \
               -H "Content-Type: application/json" \
               "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID" \
-              -d "{\"key\":\"DATABASE_URL\",\"value\":\"$POOLED_URL\",\"type\":\"encrypted\",\"target\":[\"preview\"],\"gitBranch\":\"$GIT_BRANCH\"}")
+              -d "{\"key\":\"DATABASE_URL\",\"value\":\"$BRANCH_URL\",\"type\":\"encrypted\",\"target\":[\"preview\"],\"gitBranch\":\"$GIT_BRANCH\"}")
           fi
 
           # A non-2xx from a configured Vercel integration is a real error — fail the job.


### PR DESCRIPTION
Closes #173

## Summary

- `create-branch-action@v6` leaves `db_url_with_pooler` empty; the workflow was passing that empty value as `DATABASE_URL` to Vercel, silently breaking all preview deployments.
- Switches the Vercel env-var step to source from `db_url` (direct/unpooled), which v6 does populate. The Prisma datasource has no `directUrl` split so the direct endpoint is sufficient for both migrations and runtime.
- Adds an explicit early-exit guard (`exit 1`) when `db_url` is empty so future regressions fail loudly rather than silently.
- Renames `parent_id:` to `parent_branch:` (the v6 input name) and drops the now-spurious mask line for the empty pooler URL.

## Changes

- `.github/workflows/neon-preview-branch.yml`
  - Header comment: `parent_id` -> `parent_branch` (line 12)
  - `Create or reuse Neon branch` step comment: documents that `db_url_with_pooler` is empty in v6
  - `parent_id:` input renamed to `parent_branch:`
  - `Mask Neon connection strings` step renamed to `Mask Neon connection string` (singular); removed the `db_url_with_pooler` mask line (masking an empty string produces its own warning)
  - `Set Vercel preview DATABASE_URL` step: `POOLED_URL` env var renamed to `BRANCH_URL`, sourced from `db_url`; updated step comment; added empty-guard before first `curl`; replaced all `$POOLED_URL` references with `$BRANCH_URL`

## Testing plan

Static checks (diff review):

- [ ] Confirm no remaining occurrences of `db_url_with_pooler` (functional) or `POOLED_URL` anywhere in the file — only the two explanatory comments documenting v6 behavior remain.
- [ ] Confirm `parent_branch:` appears exactly once (the create step) and `parent_id:` no longer appears anywhere in the file.
- [ ] Confirm the mask step is named `Mask Neon connection string` (singular) and contains a single `::add-mask::` line for `db_url`.
- [ ] Confirm the Vercel step defines `BRANCH_URL: ${{ steps.create_branch.outputs.db_url }}` and the guard `if [ -z "$BRANCH_URL" ]; then … exit 1` precedes the first `curl`.

Live validation (requires Neon + Vercel secrets):

- [ ] Push a commit to an open PR; confirm the `Neon Preview Branch → Create branch & migrate` run shows no `Can't add secret mask for empty string` warning and no `Unexpected input(s) 'parent_id'` warning.
- [ ] Confirm `Set Vercel preview DATABASE_URL` step succeeds (HTTP 2xx) and the guard did not trip.
- [ ] In Vercel -> Project -> Settings -> Environment Variables, confirm a non-empty `DATABASE_URL` exists scoped to `Preview` + the PR's branch.
- [ ] Confirm the PR's Vercel preview deployment builds and boots without a DB-connection failure.
- [ ] Close/merge the PR and confirm the cleanup job still removes the branch-scoped `DATABASE_URL` (regression check that the cleanup job was unaffected).

## Automated checks

This PR contains only a GitHub Actions YAML change (no TypeScript/JavaScript). The standard `prettier:check`, `eslint:check`, and `tsc:check` workflows do not cover YAML and will pass trivially.

## Notes

The `cleanup` job was confirmed unaffected — it references neither `db_url_with_pooler` nor `POOLED_URL`. No Prisma schema changes. No application code changes.
