### PR TITLE
#179 Fix Table Header Row Highlight Overflowing Rounded Container Corners

### DIFF
--- a/components/features/my-applications-table.tsx
+++ b/components/features/my-applications-table.tsx
@@ -41,7 +41,8 @@ export function MyApplicationsTable({
     );
 
   return (
-    <Card className="gap-0 p-0">
+    // overflow-hidden clips the header hover highlight to the card's rounded corners
+    <Card className="gap-0 overflow-hidden p-0">
       {/* Desktop table — hidden on mobile */}
       <div className="hidden md:block">
         <Table>

--- a/components/features/my-applications-widget.tsx
+++ b/components/features/my-applications-widget.tsx
@@ -67,7 +67,8 @@ export async function MyApplicationsWidget({
   const summary = buildCountsSummary(counts);
 
   return (
-    <Card className="gap-0 p-0">
+    // overflow-hidden clips the header hover highlight to the card's rounded corners
+    <Card className="gap-0 overflow-hidden p-0">
       <CardHeader className="border-b p-4">
         <div className="flex items-center justify-between">
           <div>

--- a/components/features/position-applications-table.tsx
+++ b/components/features/position-applications-table.tsx
@@ -32,7 +32,8 @@ export function PositionApplicationsTable({
     );
 
   return (
-    <Card className="gap-0 p-0">
+    // overflow-hidden clips the header hover highlight to the card's rounded corners
+    <Card className="gap-0 overflow-hidden p-0">
       {/* Desktop table — hidden on mobile */}
       <div className="hidden md:block">
         <Table>

--- a/components/features/recent-applications.tsx
+++ b/components/features/recent-applications.tsx
@@ -22,7 +22,8 @@ export async function RecentApplications() {
   const applications = await getRecentApplications();
 
   return (
-    <Card className="gap-0 p-0">
+    // overflow-hidden clips the header hover highlight to the card's rounded corners
+    <Card className="gap-0 overflow-hidden p-0">
       <CardHeader className="border-b p-4">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-semibold">


### PR DESCRIPTION
Closes #179

## Summary

- Pure CSS/Tailwind fix: adds `overflow-hidden` to four table-bearing `Card` wrappers so row hover backgrounds are clipped to the card's rounded corners
- Follows the established pattern already used in `applications-table.tsx` (the reference implementation)
- No data, server actions, schema, auth, or logic changes

## Changes

- `components/features/position-applications-table.tsx` — `Card className` changed from `"gap-0 p-0"` to `"gap-0 overflow-hidden p-0"`
- `components/features/my-applications-table.tsx` — same change
- `components/features/recent-applications.tsx` — same change (fixes bottom-corner bleed on last row hover)
- `components/features/my-applications-widget.tsx` — same change (fixes bottom-corner bleed on last row hover)
- `components/features/applications-table.tsx` — no change (already correct; serves as reference)
- `components/ui/table.tsx` — no change (shared primitive untouched)

## Testing plan

- [ ] **Admin applications list** (`/applications`): hover the header row and the last data row — card corners remain rounded at all four corners in both light and dark mode (this is the reference; should already be correct)
- [ ] **Position applications table** (e.g. a position's applications view): hover the header row — top-left and top-right card corners stay rounded (previously squared on hover); hover the last row — bottom corners stay rounded; verify in both themes
- [ ] **My applications table** (`/my-applications`) with at least one application: hover header row and last row — all corners stay rounded in both themes
- [ ] **Dashboard "Recent Applications" widget**: hover the last data row — bottom card corners stay rounded in both themes (header row sits under a `CardHeader`, so check bottom corners specifically)
- [ ] **Dashboard "My Applications" widget**: same check as above
- [ ] **Horizontal scroll regression**: narrow browser or use a wide table to trigger horizontal scroll — table scrolls correctly and card corners remain rounded while scrolled
- [ ] **Empty states**: view surfaces with zero applications — empty-state card renders unchanged
- [ ] **Mobile (375px)**: stacked mobile layouts render correctly with rounded card corners and no hover-rectangle bleed on first/last stacked rows
- [ ] **Gates**: `npm run prettier:check`, `npm run eslint:check`, `npm run tsc:check` all pass

## Automated checks

- prettier: pass
- eslint: pass
- tsc: pass

## Notes

`overflow-hidden` on the outer `Card` (which owns the `rounded-xl` radius) is the correct clipping point. The inner shadcn `Table` wrapper retains `overflow-x-auto`, so horizontal scrolling continues to work inside the clipped rounded box. Per-cell `rounded-tl-*/rounded-tr-*` was considered and rejected: it only fixes top corners and misses the bottom-corner bleed on the last row hover.
