### PR TITLE
#176 Fix Positions List Visibility For Applicants And Admins

### DIFF
--- a/app/(main)/(auth)/positions/page.tsx
+++ b/app/(main)/(auth)/positions/page.tsx
@@ -1,10 +1,7 @@
 import { Briefcase } from 'lucide-react';
 
 import { getManagedPositionIds } from '@/prisma/data/managers';
-import {
-  getAdminPositions,
-  getPositions,
-} from '@/prisma/data/positions';
+import { getAdminPositions, getPositions } from '@/prisma/data/positions';
 
 import { getCurrentUser } from '@/lib/auth/server';
 import type { PositionWithQuestions } from '@/lib/types';

--- a/app/(main)/(auth)/positions/page.tsx
+++ b/app/(main)/(auth)/positions/page.tsx
@@ -1,9 +1,13 @@
 import { Briefcase } from 'lucide-react';
 
 import { getManagedPositionIds } from '@/prisma/data/managers';
-import { getPositions } from '@/prisma/data/positions';
+import {
+  getAdminPositions,
+  getPositions,
+} from '@/prisma/data/positions';
 
 import { getCurrentUser } from '@/lib/auth/server';
+import type { PositionWithQuestions } from '@/lib/types';
 
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
@@ -12,17 +16,18 @@ import { EmptyState } from '@/components/ui/empty-state';
 
 export default async function PositionsPage() {
   const user = await getCurrentUser();
-  const positions = await getPositions({
-    isAdmin: user.isAdmin,
-    userId: user.id,
-  });
 
+  let positions: PositionWithQuestions[];
   let managedIds: Set<string>;
+
   if (user.isAdmin) {
+    positions = await getAdminPositions();
     managedIds = new Set(positions.map((p) => p.id));
   } else {
+    positions = await getPositions({ isAdmin: false, userId: user.id });
     managedIds = await getManagedPositionIds(user.id);
   }
+
   const canCreate = user.isAdmin || managedIds.size > 0;
 
   return (
@@ -39,11 +44,19 @@ export default async function PositionsPage() {
       {positions.length === 0 ? (
         <EmptyState
           icon={Briefcase}
-          title={canCreate ? 'No positions yet' : 'No open positions'}
+          title={
+            user.isAdmin
+              ? 'No active positions.'
+              : canCreate
+                ? 'No positions yet'
+                : 'No open positions'
+          }
           description={
-            canCreate
-              ? 'Create your first position to start accepting applications.'
-              : 'There are no open positions right now. Check back soon.'
+            user.isAdmin
+              ? 'Open, draft, recently closed, and in-review positions appear here.'
+              : canCreate
+                ? 'Create your first position to start accepting applications.'
+                : 'There are no open positions right now. Check back soon.'
           }
           action={canCreate ? <PositionCreateDialog /> : undefined}
         />

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -110,6 +110,18 @@ export const REVIEWER_APPLICATION_STATUSES = [
 export const REVIEWER_APPLICATION_STATUS_OPTIONS =
   APPLICATION_STATUS_OPTIONS.filter((o) => o.value !== 'draft');
 
+// Submitted-but-not-concluded application statuses. Excludes 'draft' (unsubmitted,
+// applicant-owned), 'accepted'/'rejected' (terminal), and 'withdrawn' (resolved).
+// Used by the admin positions query to keep a closed position visible only while
+// it still has work in progress. Positive 'in' list so future enum values are
+// excluded by default until deliberately added — safer for a visibility metric.
+export const UNRESOLVED_APPLICATION_STATUSES = [
+  'applied',
+  'reached_out',
+  'interview_scheduled',
+  'reviewing',
+] as const satisfies $Enums.ApplicationStatus[];
+
 export const STATUS_OPTIONS: { value: PositionStatus; label: string }[] = [
   { value: 'draft', label: 'Draft' },
   { value: 'open', label: 'Open' },

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { UNRESOLVED_APPLICATION_STATUSES } from '@/lib/constants';
 import prisma from '@/lib/prisma';
 import {
   type OpenPositionSummaryItem,
@@ -7,6 +8,29 @@ import {
   type PositionWithQuestions,
 } from '@/lib/types';
 import { isAcceptingApplications } from '@/lib/utils';
+
+// Shared select shape for PositionWithQuestions queries — extracted once so
+// every function returns the same type without duplicating the object literal.
+const positionWithQuestionsSelect = {
+  id: true,
+  title: true,
+  status: true,
+  description: true,
+  opensAt: true,
+  closesAt: true,
+  questions: {
+    where: { deletedAt: null },
+    orderBy: { order: 'asc' },
+    select: {
+      id: true,
+      label: true,
+      type: true,
+      required: true,
+      options: true,
+      order: true,
+    },
+  },
+} as const;
 
 // Manager-aware positions query.
 // Admin: all non-deleted positions.
@@ -26,26 +50,7 @@ export async function getPositions({
           deletedAt: null,
           OR: [{ status: 'open' }, { managers: { some: { id: userId } } }],
         },
-    select: {
-      id: true,
-      title: true,
-      status: true,
-      description: true,
-      opensAt: true,
-      closesAt: true,
-      questions: {
-        where: { deletedAt: null },
-        orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          label: true,
-          type: true,
-          required: true,
-          options: true,
-          order: true,
-        },
-      },
-    },
+    select: positionWithQuestionsSelect,
     orderBy: { title: 'asc' },
   });
 }
@@ -55,26 +60,45 @@ export async function getPositions({
 export async function getOpenPositions(): Promise<PositionWithQuestions[]> {
   return prisma.position.findMany({
     where: { status: 'open', deletedAt: null },
-    select: {
-      id: true,
-      title: true,
-      status: true,
-      description: true,
-      opensAt: true,
-      closesAt: true,
-      questions: {
-        where: { deletedAt: null },
-        orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          label: true,
-          type: true,
-          required: true,
-          options: true,
-          order: true,
+    select: positionWithQuestionsSelect,
+    orderBy: { title: 'asc' },
+  });
+}
+
+// Admin-only: returns all positions still worth an admin's attention.
+// A position is included when any of these hold:
+//   - status is 'open' or 'draft' (always show)
+//   - status is 'closed' and closesAt is within the last 30 days
+//   - status is 'closed' and closesAt is null, but updatedAt is within the last 30 days
+//   - status is 'closed' with at least one unresolved applicant
+// Fully-resolved closed positions (closed >30 days ago, no pending work) are hidden.
+// Returns cross-position data — must only be called from an admin-gated context.
+export async function getAdminPositions(): Promise<PositionWithQuestions[]> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 30);
+
+  return prisma.position.findMany({
+    where: {
+      deletedAt: null,
+      OR: [
+        { status: { in: ['open', 'draft'] } },
+        // Recently closed via explicit close date
+        { status: 'closed', closesAt: { gte: cutoff } },
+        // Recently closed fallback when closesAt is null — use updatedAt recency
+        { status: 'closed', closesAt: null, updatedAt: { gte: cutoff } },
+        // Closed but still has unresolved applicants (work in progress)
+        {
+          status: 'closed',
+          applications: {
+            some: {
+              deletedAt: null,
+              status: { in: [...UNRESOLVED_APPLICATION_STATUSES] },
+            },
+          },
         },
-      },
+      ],
     },
+    select: positionWithQuestionsSelect,
     orderBy: { title: 'asc' },
   });
 }
@@ -84,26 +108,7 @@ export async function getPositionForApply(
 ): Promise<PositionWithQuestions | null> {
   const position = await prisma.position.findUnique({
     where: { id, status: 'open', deletedAt: null },
-    select: {
-      id: true,
-      title: true,
-      status: true,
-      description: true,
-      opensAt: true,
-      closesAt: true,
-      questions: {
-        where: { deletedAt: null },
-        orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          label: true,
-          type: true,
-          required: true,
-          options: true,
-          order: true,
-        },
-      },
-    },
+    select: positionWithQuestionsSelect,
   });
 
   // Gate: return null for positions outside their date window so the apply route


### PR DESCRIPTION
Closes #176

## Summary

- Replace `getPositions(bool)` with two focused functions: `getOpenPositions()` for applicants and `getAdminPositions()` for admins
- Admin view now shows only relevant positions: open/draft always, closed within the last 30 days (via `closesAt` or `updatedAt` fallback), and closed positions with at least one unresolved applicant
- Add `UNRESOLVED_APPLICATION_STATUSES` constant to `lib/constants.ts` defining the four submitted-but-not-concluded statuses (`applied`, `reached_out`, `interview_scheduled`, `reviewing`)

## Changes

- `prisma/data/positions.ts` — extract shared `positionWithQuestionsSelect` const; add `getOpenPositions()` and `getAdminPositions()`; remove `getPositions()`; simplify `getPositionForApply` to reuse the shared select
- `lib/constants.ts` — add `UNRESOLVED_APPLICATION_STATUSES` (positive `in` list typed against generated enum, so future statuses are excluded by default)
- `app/(main)/(auth)/positions/page.tsx` — branch on role to call the correct query; update empty-state copy for both branches
- `components/features/open-positions-widget.tsx` — migrate from removed `getPositions(false)` to `getOpenPositions()`

## Testing plan

- [ ] Seed data with: an open position, a draft position, a closed position closed <30 days ago with no unresolved apps, a closed position closed >30 days ago with only `accepted`/`rejected`/`withdrawn` apps, a closed position closed >30 days ago with one `reviewing` app, and a closed position with `closesAt = null`
- [ ] As applicant: visit `/positions` and confirm only `status: 'open'` positions appear (title asc), with no draft or closed positions and no "Recently Closed" section
- [ ] As applicant: with no open positions confirm the designed empty state renders ("No open positions right now." / "Check back soon for new opportunities.")
- [ ] As applicant: open dashboard and confirm the Open Positions widget still shows only open positions (unchanged behaviour)
- [ ] As admin: visit `/positions` and confirm all open and draft positions appear
- [ ] As admin: confirm the closed position closed <30 days ago is shown
- [ ] As admin: confirm the closed position closed >30 days ago with only `accepted`/`rejected`/`withdrawn` apps is hidden
- [ ] As admin: confirm the closed position closed >30 days ago with a `reviewing` app is shown
- [ ] As admin: confirm the `closesAt = null` closed position appears only when its `updatedAt` is within the last 30 days (or it has an unresolved app)
- [ ] As admin: with no relevant positions confirm the admin empty state renders ("No active positions." / "Open, draft, recently closed, and in-review positions appear here.")
- [ ] Apply gate regression: navigate to `/positions/[id]/apply` for a `status: 'closed'` position — confirm it returns null and redirects to `/positions`

## Automated checks

- [x] `npm run prettier:check` — pass
- [x] `npm run eslint:check` — pass
- [x] `npm run tsc:check` — pass

## Notes

The `withdrawn` application status (required for the `UNRESOLVED_APPLICATION_STATUSES` filter) was introduced in #151 and is present in `main`. The `getAdminPositions` query uses a positive `in` list for the unresolved-applicants filter so any future enum value is excluded by default until deliberately added — safer for a visibility metric than a `notIn` list that grows silently.
