### PR TITLE
#181 Add Static Privacy Policy And Terms Of Service Pages

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
 import prisma from '@/lib/prisma';
 import type { NavIdentity } from '@/lib/types';
 
+import { AppFooter } from '@/components/layouts/app-footer';
 import { MobileNav } from '@/components/layouts/mobile-nav';
 import { Sidebar } from '@/components/layouts/sidebar';
 
@@ -43,6 +44,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         />
         <main className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 p-6">{children}</div>
+          <AppFooter />
         </main>
       </div>
     </div>

--- a/app/(legal)/layout.tsx
+++ b/app/(legal)/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+// Public layout — no getCurrentUser, no auth gate, no app chrome.
+// Mirrors app/login/layout.tsx as the precedent for public-only routes.
+export default function LegalLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-background min-h-dvh">
+      <main className="mx-auto max-w-3xl px-4 py-12">{children}</main>
+    </div>
+  );
+}

--- a/app/(legal)/privacy/page.tsx
+++ b/app/(legal)/privacy/page.tsx
@@ -1,0 +1,170 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
+
+export const metadata: Metadata = { title: 'Privacy Policy' };
+
+// Manually maintained — update when the policy content changes.
+const LAST_UPDATED = 'June 25, 2026';
+
+export default function PrivacyPolicyPage() {
+  return (
+    <article>
+      <h1 className="text-2xl font-semibold tracking-tight">Privacy Policy</h1>
+      <p className="text-muted-foreground mt-2 text-sm">
+        Last updated: {LAST_UPDATED}
+      </p>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          1. Information We Collect
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio collects the following information when you use the platform:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
+          <li>
+            <strong className="text-foreground">Name and email address</strong>{' '}
+            — provided through Neon Auth when you sign in with a one-time code.
+          </li>
+          <li>
+            <strong className="text-foreground">Application responses</strong> —
+            the answers you submit to global and position-specific questions
+            when applying to student government positions.
+          </li>
+          <li>
+            <strong className="text-foreground">
+              Application status and review history
+            </strong>{' '}
+            — records of the status changes your applications go through during
+            the review process.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We do not collect payment information, location data, or any
+          information beyond what is necessary to manage the application
+          process.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">2. How We Use It</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          The information collected is used solely to operate Aplio as an
+          internal student government application management tool:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
+          <li>
+            Reviewing your applications for student government positions you
+            have applied to.
+          </li>
+          <li>
+            Communicating with you about the status of your application,
+            including interview scheduling and final decisions.
+          </li>
+          <li>
+            Maintaining a record of positions and cycles for administrative
+            purposes.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Your information is never used for advertising, marketing, or sold to
+          third parties.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">3. Who Can See It</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Access to your information is scoped to the minimum necessary:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
+          <li>
+            <strong className="text-foreground">You</strong> can view your own
+            applications, responses, and status history at any time.
+          </li>
+          <li>
+            <strong className="text-foreground">Position managers</strong> can
+            see applications submitted to the specific positions they manage.
+            They cannot see your applications to other positions.
+          </li>
+          <li>
+            <strong className="text-foreground">Platform admins</strong> can see
+            all applications and user records in order to operate and maintain
+            the system.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          No other users can view your application responses.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">4. Data Retention</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Application records are retained for the duration of the program and
+          for a reasonable period thereafter for historical reference. If you
+          would like your account or application data deleted, please contact
+          your student government representative (see Section 6). We will
+          process deletion requests in accordance with applicable organizational
+          policies.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">5. Third-Party Services</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio uses the following third-party services to operate:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
+          <li>
+            <strong className="text-foreground">Neon Auth</strong> — handles
+            authentication via one-time email codes. Your email address is
+            shared with Neon to verify your identity. Neon&apos;s privacy policy
+            governs how they handle authentication data.
+          </li>
+          <li>
+            <strong className="text-foreground">Vercel</strong> — hosts the
+            Aplio platform. Application data is stored and processed on
+            Vercel&apos;s infrastructure. Vercel&apos;s privacy policy governs
+            their infrastructure handling.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          No other third-party services receive your personal information.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">6. Contact</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If you have questions about this Privacy Policy or would like to
+          request deletion of your data, please contact your student government
+          representative through your organization&apos;s standard communication
+          channels.
+        </p>
+      </section>
+
+      <footer className="border-border text-muted-foreground mt-12 flex flex-wrap items-center gap-x-2 border-t pt-6 text-xs">
+        <Link
+          href={PRIVACY_HREF}
+          className="hover:text-foreground hover:underline"
+        >
+          Privacy Policy
+        </Link>
+        <span aria-hidden>·</span>
+        <Link
+          href={TERMS_HREF}
+          className="hover:text-foreground hover:underline"
+        >
+          Terms of Service
+        </Link>
+        <span aria-hidden>·</span>
+        <Link href="/login" className="hover:text-foreground hover:underline">
+          Back to sign in
+        </Link>
+      </footer>
+    </article>
+  );
+}

--- a/app/(legal)/terms/page.tsx
+++ b/app/(legal)/terms/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
+
+export const metadata: Metadata = { title: 'Terms of Service' };
+
+// Manually maintained — update when the terms content changes.
+const LAST_UPDATED = 'June 25, 2026';
+
+export default function TermsOfServicePage() {
+  return (
+    <article>
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Terms of Service
+      </h1>
+      <p className="text-muted-foreground mt-2 text-sm">
+        Last updated: {LAST_UPDATED}
+      </p>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">1. Acceptance of Terms</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          By accessing or using Aplio, you agree to be bound by these Terms of
+          Service. If you do not agree to these terms, do not use the platform.
+          These terms apply to all users of the platform, including applicants
+          and administrators.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">2. Intended Use</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio is an internal tool designed exclusively for managing
+          applications to student government positions. The platform may only be
+          used for this purpose. Unauthorized use of the platform for any other
+          purpose — including testing, scraping, or circumventing access
+          controls — is not permitted.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">3. Accurate Information</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          By submitting an application, you agree that all information you
+          provide is truthful, accurate, and complete to the best of your
+          knowledge. Submitting false or misleading information in an
+          application may result in the rejection or withdrawal of your
+          application and may be subject to further action under applicable
+          student organization policies.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          4. No Guarantee of Acceptance
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Submitting an application through Aplio does not guarantee acceptance
+          to any position. All applications are subject to review and evaluation
+          by position managers and administrators. Decisions are made at the
+          discretion of the student government organization and are final.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">5. Account Termination</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Platform administrators may deactivate or remove accounts at any time,
+          including for violation of these Terms of Service or applicable
+          student organization policies. If your account is deactivated, you may
+          lose access to application records stored on the platform. Contact
+          your student government representative if you believe your account was
+          deactivated in error.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          6. Limitation of Liability
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio is provided as-is for internal organizational use. The student
+          government organization and platform maintainers make no warranties,
+          express or implied, regarding the availability, reliability, or
+          fitness of the platform for any particular purpose. To the maximum
+          extent permitted by applicable law, the organization is not liable for
+          any loss or damage arising from your use of or inability to use the
+          platform.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          7. Governing Jurisdiction
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These Terms of Service are governed by applicable student organization
+          policies and any institutional rules of the associated academic
+          institution. Disputes arising from the use of this platform will be
+          resolved in accordance with those policies.
+        </p>
+      </section>
+
+      <footer className="border-border text-muted-foreground mt-12 flex flex-wrap items-center gap-x-2 border-t pt-6 text-xs">
+        <Link
+          href={PRIVACY_HREF}
+          className="hover:text-foreground hover:underline"
+        >
+          Privacy Policy
+        </Link>
+        <span aria-hidden>·</span>
+        <Link
+          href={TERMS_HREF}
+          className="hover:text-foreground hover:underline"
+        >
+          Terms of Service
+        </Link>
+        <span aria-hidden>·</span>
+        <Link href="/login" className="hover:text-foreground hover:underline">
+          Back to sign in
+        </Link>
+      </footer>
+    </article>
+  );
+}

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
 import prisma from '@/lib/prisma';
 import type { NavIdentity } from '@/lib/types';
 
+import { AppFooter } from '@/components/layouts/app-footer';
 import { MobileNav } from '@/components/layouts/mobile-nav';
 import { Sidebar } from '@/components/layouts/sidebar';
 
@@ -42,6 +43,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         />
         <main className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 p-6">{children}</div>
+          <AppFooter />
         </main>
       </div>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,8 +1,10 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { AuthView } from '@neondatabase/auth/react/ui';
 
 import { getOptionalUser } from '@/lib/auth/server';
+import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
 
 // Auto-forward only when the user has both a valid auth session and an active
 // app User row. Deactivated users and provisioning gaps stay on /login.
@@ -11,14 +13,31 @@ export default async function SignInPage() {
   if (user) redirect('/');
 
   return (
-    <AuthView
-      path="SIGN_IN"
-      classNames={{ form: { otpInputContainer: 'justify-center' } }}
-      localization={{
-        SIGN_IN_DESCRIPTION:
-          'Enter your email to receive a one-time sign-in code',
-        EMAIL_OTP: '',
-      }}
-    />
+    <div className="flex w-full flex-col items-center gap-6">
+      <AuthView
+        path="SIGN_IN"
+        classNames={{ form: { otpInputContainer: 'justify-center' } }}
+        localization={{
+          SIGN_IN_DESCRIPTION:
+            'Enter your email to receive a one-time sign-in code',
+          EMAIL_OTP: '',
+        }}
+      />
+      <p className="text-muted-foreground text-xs">
+        <Link
+          href={PRIVACY_HREF}
+          className="hover:text-foreground hover:underline"
+        >
+          Privacy Policy
+        </Link>
+        {' · '}
+        <Link
+          href={TERMS_HREF}
+          className="hover:text-foreground hover:underline"
+        >
+          Terms of Service
+        </Link>
+      </p>
+    </div>
   );
 }

--- a/components/layouts/app-footer.tsx
+++ b/components/layouts/app-footer.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
+
+export function AppFooter() {
+  return (
+    <footer className="text-muted-foreground border-border flex flex-wrap items-center gap-x-2 border-t px-6 py-4 text-xs">
+      <Link
+        href={PRIVACY_HREF}
+        className="hover:text-foreground hover:underline"
+      >
+        Privacy Policy
+      </Link>
+      <span aria-hidden>·</span>
+      <Link href={TERMS_HREF} className="hover:text-foreground hover:underline">
+        Terms of Service
+      </Link>
+      <span aria-hidden>·</span>
+      <span>© {new Date().getFullYear()} Student Government</span>
+    </footer>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -152,3 +152,8 @@ export const AVAILABILITY_VARIANTS: Record<PositionAvailability, BadgeVariant> =
     closed_by_date: 'outline',
     unavailable: 'outline',
   };
+
+// Public URLs for the legal pages — referenced from the login footer, app footer,
+// and each legal page's cross-link footer. One edit when the URLs change.
+export const PRIVACY_HREF = '/privacy';
+export const TERMS_HREF = '/terms';


### PR DESCRIPTION
Closes #181

## Summary

- Adds static `/privacy` (Privacy Policy) and `/terms` (Terms of Service) pages accessible without authentication, via a new `(legal)` route group with its own public layout — no auth gate, no app chrome.
- Adds a shared `AppFooter` component rendered in both authenticated app shells (`(main)` and `(app)` layouts) with links to both legal pages and a copyright line.
- Adds a small `text-xs` legal-links footer below the login card on `/login`.

## Changes

- **`app/(legal)/layout.tsx`** — minimal public layout (no `getCurrentUser`, no sidebar); owns the `max-w-3xl` reading container. Mirrors `app/login/layout.tsx` as the precedent for public routes outside the auth-gated `(main)` tree.
- **`app/(legal)/privacy/page.tsx`** — Privacy Policy page at URL `/privacy`; covers all 6 required sections (information collected, how used, who can see it, data retention, third-party services, contact). `export const metadata` sets the page title.
- **`app/(legal)/terms/page.tsx`** — Terms of Service page at URL `/terms`; covers all 7 required sections (acceptance, intended use, accurate information, no guarantee, account termination, limitation of liability, governing jurisdiction).
- **`components/layouts/app-footer.tsx`** — `AppFooter` server component with `border-t` separator, `Privacy Policy · Terms of Service · © [year] Student Government` links in `text-xs text-muted-foreground`. Extracted to avoid duplicating identical markup across two shells.
- **`app/(main)/layout.tsx`** — renders `<AppFooter />` after the `children` div inside `<main>`.
- **`app/(app)/layout.tsx`** — same, keeps the parallel shell in sync.
- **`app/login/page.tsx`** — wraps `AuthView` in a flex column and adds `Privacy Policy · Terms of Service` footer below the auth card.
- **`lib/constants.ts`** — adds `PRIVACY_HREF = '/privacy'` and `TERMS_HREF = '/terms'` constants referenced from all three footer surfaces.

**No server actions, no data fetching, no Prisma, no schema changes.** Loading/empty/error states are N/A — these are fully static server components with zero async work.

## Testing plan

**Setup**
- [ ] Pull the branch, `npm ci`, `npm run prisma:generate`, `npm run dev`.

**Unauthenticated access (core AC)**
- [ ] Without logging in (incognito/clear session), navigate directly to `/privacy` — page renders the Privacy Policy; no redirect to `/login`; no sidebar or app chrome visible.
- [ ] Navigate directly to `/terms` — renders Terms of Service; no redirect; no chrome.

**Login-page footer**
- [ ] Go to `/login` (logged out) — a `Privacy Policy · Terms of Service` line appears below the sign-in card in small muted text.
- [ ] Click "Privacy Policy" — lands on `/privacy`. Back, click "Terms of Service" — lands on `/terms`.

**Authenticated-layout footer**
- [ ] Log in (real auth or dev bypass via `/login/bypass`). On any app page (e.g. `/`, `/positions`, `/my-applications`) — a footer line `Privacy Policy · Terms of Service · © 2026 Student Government` appears at the bottom of the scroll area.
- [ ] Click each link — reaches `/privacy` / `/terms`.

**Content completeness**
- [ ] Privacy page contains all 6 sections: information collected; how used; who can see it; data retention; third-party services (Neon Auth, Vercel); contact placeholder.
- [ ] Terms page contains all 7 sections: acceptance; intended use; accurate information; no guarantee of acceptance; account termination; limitation of liability; governing jurisdiction placeholder.
- [ ] Each page shows a "Last updated: June 25, 2026" line near the top.

**Typography / a11y / responsive**
- [ ] Each page has exactly one `h1` (the title) and `h2` section headings with no skipped levels.
- [ ] Content is centered, readable single-column (`max-w-3xl`), legible in both light and dark themes.
- [ ] At 375px, 768px, 1280px — content reflows with no overflow; footer links wrap gracefully.
- [ ] All links are keyboard-reachable with a visible focus ring; `·` separators are not announced by screen reader (decorative, `aria-hidden`).
- [ ] Each page footer includes cross-links to both legal pages and "Back to sign in" (`/login`).

**Edge cases**
- [ ] Visiting `/privacy` while logged in — page renders (no redirect), no auth wall.
- [ ] Visiting `/privacy/anything` — falls through to the existing 404 page.

## Automated checks

- `npm run prettier:check` — pass
- `npm run eslint:check` — pass
- `npm run tsc:check` — pass

## Notes

The `(legal)` route group is URL-invisible — pages resolve to bare `/privacy` and `/terms`, not `/legal/privacy`. This avoids placing the pages under `app/(main)/` (which calls `getCurrentUser()` and redirects unauthenticated visitors), satisfying AC #1 without modifying the existing auth gate.
