### PR TITLE
#178 Add Client-Side Column Sorting With URL Query Params To All Tables

### DIFF
--- a/components/features/applications-table.tsx
+++ b/components/features/applications-table.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
-import { ArrowDown, ArrowUp, ArrowUpDown, FileText, Inbox } from 'lucide-react';
+import { FileText, Inbox } from 'lucide-react';
 
 import type { $Enums } from '@/prisma/client';
 
@@ -17,6 +17,12 @@ import type {
 import { formatDate } from '@/lib/utils';
 
 import { ApplicationsBulkBar } from '@/components/features/applications-bulk-bar';
+// SortableHeader is the shared indicator component — this table keeps its own
+// server-side sort mechanism (router.push re-fetches within the 100-row cap),
+// unlike the client-sorted tables that use useSortableTable. The ?sort=field:direction
+// param format here is intentionally different from the client tables' ?sort=&dir=
+// to avoid coupling the server re-fetch contract to a client-state abstraction.
+import { SortableHeader } from '@/components/features/sortable-header';
 import { ApplicationStatusBadge } from '@/components/features/status-badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -34,63 +40,6 @@ interface ApplicationsTableProps {
   applications: ApplicationListRow[];
   hasActiveFilters: boolean;
   sort?: ApplicationSort;
-}
-
-interface SortableHeadProps {
-  field: ApplicationSortField;
-  sort?: ApplicationSort;
-  onSort: (
-    field: ApplicationSortField,
-    direction: ApplicationSortDirection,
-  ) => void;
-  children: React.ReactNode;
-}
-
-function SortableHead({ field, sort, onSort, children }: SortableHeadProps) {
-  const isActive = sort?.field === field;
-  const isAsc = isActive && sort?.direction === 'asc';
-
-  function handleClick() {
-    if (!isActive) {
-      // Default to desc for date (newest first), asc for name/status (A-Z).
-      const defaultDir: ApplicationSortDirection =
-        field === 'date' ? 'desc' : 'asc';
-      onSort(field, defaultDir);
-    } else {
-      onSort(field, isAsc ? 'desc' : 'asc');
-    }
-  }
-
-  return (
-    <TableHead>
-      <button
-        type="button"
-        onClick={handleClick}
-        className="hover:text-foreground flex items-center gap-1 font-medium transition-colors"
-        aria-label={`Sort by ${String(children)}${isActive ? (isAsc ? ', currently ascending' : ', currently descending') : ''}`}
-      >
-        {children}
-        {isActive ? (
-          isAsc ? (
-            <ArrowUp
-              className="text-foreground h-3.5 w-3.5"
-              aria-hidden="true"
-            />
-          ) : (
-            <ArrowDown
-              className="text-foreground h-3.5 w-3.5"
-              aria-hidden="true"
-            />
-          )
-        ) : (
-          <ArrowUpDown
-            className="text-muted-foreground h-3.5 w-3.5"
-            aria-hidden="true"
-          />
-        )}
-      </button>
-    </TableHead>
-  );
 }
 
 export function ApplicationsTable({
@@ -147,7 +96,19 @@ export function ApplicationsTable({
   ) {
     const params = new URLSearchParams(searchParams.toString());
     params.set('sort', `${field}:${direction}`);
+    // router.push triggers a server re-fetch — required because this table is
+    // capped at 100 rows and must sort server-side for correct ordering.
     router.push(`${pathname}?${params.toString()}`);
+  }
+
+  function toggleSort(field: ApplicationSortField) {
+    const isActive = sort?.field === field;
+    if (!isActive) {
+      // Default to desc for date (newest first), asc for name/status (A-Z).
+      handleSort(field, field === 'date' ? 'desc' : 'asc');
+    } else {
+      handleSort(field, sort?.direction === 'asc' ? 'desc' : 'asc');
+    }
   }
 
   if (applications.length === 0) {
@@ -214,16 +175,49 @@ export function ApplicationsTable({
                     aria-label="Select all applications"
                   />
                 </TableHead>
-                <SortableHead field="name" sort={sort} onSort={handleSort}>
-                  Applicant
-                </SortableHead>
+                <SortableHeader
+                  label="Applicant"
+                  sortKey="name"
+                  active={sort?.field === 'name'}
+                  direction={sort?.direction ?? 'asc'}
+                  ariaSort={
+                    sort?.field === 'name'
+                      ? sort.direction === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                  onToggle={() => toggleSort('name')}
+                />
                 <TableHead>Position</TableHead>
-                <SortableHead field="status" sort={sort} onSort={handleSort}>
-                  Status
-                </SortableHead>
-                <SortableHead field="date" sort={sort} onSort={handleSort}>
-                  Submitted
-                </SortableHead>
+                <SortableHeader
+                  label="Status"
+                  sortKey="status"
+                  active={sort?.field === 'status'}
+                  direction={sort?.direction ?? 'asc'}
+                  ariaSort={
+                    sort?.field === 'status'
+                      ? sort.direction === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                  onToggle={() => toggleSort('status')}
+                />
+                <SortableHeader
+                  label="Submitted"
+                  sortKey="date"
+                  active={sort?.field === 'date'}
+                  direction={sort?.direction ?? 'asc'}
+                  ariaSort={
+                    sort?.field === 'date'
+                      ? sort.direction === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                  onToggle={() => toggleSort('date')}
+                />
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/components/features/applications-table.tsx
+++ b/components/features/applications-table.tsx
@@ -177,7 +177,6 @@ export function ApplicationsTable({
                 </TableHead>
                 <SortableHeader
                   label="Applicant"
-                  sortKey="name"
                   active={sort?.field === 'name'}
                   direction={sort?.direction ?? 'asc'}
                   ariaSort={
@@ -192,7 +191,6 @@ export function ApplicationsTable({
                 <TableHead>Position</TableHead>
                 <SortableHeader
                   label="Status"
-                  sortKey="status"
                   active={sort?.field === 'status'}
                   direction={sort?.direction ?? 'asc'}
                   ariaSort={
@@ -206,7 +204,6 @@ export function ApplicationsTable({
                 />
                 <SortableHeader
                   label="Submitted"
-                  sortKey="date"
                   active={sort?.field === 'date'}
                   direction={sort?.direction ?? 'asc'}
                   ariaSort={

--- a/components/features/global-questions-table.tsx
+++ b/components/features/global-questions-table.tsx
@@ -9,8 +9,13 @@ import { deleteGlobalQuestion } from '@/prisma/actions/global-questions';
 
 import { QUESTION_TYPE_LABELS } from '@/lib/constants';
 import type { GlobalQuestionListItem } from '@/lib/types';
+import {
+  type SortableColumn,
+  useSortableTable,
+} from '@/lib/use-sortable-table';
 
 import { GlobalQuestionDialog } from '@/components/features/global-question-dialog';
+import { SortableHeader } from '@/components/features/sortable-header';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -36,9 +41,24 @@ interface GlobalQuestionsTableProps {
   questions: GlobalQuestionListItem[];
 }
 
+const COLUMNS: SortableColumn<GlobalQuestionListItem>[] = [
+  { key: 'order', accessor: (q) => q.order },
+  { key: 'label', accessor: (q) => q.label },
+  { key: 'type', accessor: (q) => QUESTION_TYPE_LABELS[q.type] },
+  // Sort 1 (yes) before 0 (no) when ascending so required questions surface first.
+  { key: 'required', accessor: (q) => (q.required ? 1 : 0) },
+];
+
 export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Default sort: order ascending — the meaningful sequence for global questions.
+  const { sortedRows, sort, toggle, ariaSort } = useSortableTable(
+    questions,
+    COLUMNS,
+    { defaultSort: { key: 'order', direction: 'asc' } },
+  );
 
   async function handleDelete() {
     if (!deletingId) return;
@@ -74,16 +94,49 @@ export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-16">Order</TableHead>
-              <TableHead>Label</TableHead>
-              <TableHead className="w-36">Type</TableHead>
+              <SortableHeader
+                label="Order"
+                sortKey="order"
+                active={sort.key === 'order'}
+                direction={sort.direction}
+                ariaSort={ariaSort('order')}
+                onToggle={() => toggle('order')}
+                className="w-16"
+              />
+              <SortableHeader
+                label="Label"
+                sortKey="label"
+                active={sort.key === 'label'}
+                direction={sort.direction}
+                ariaSort={ariaSort('label')}
+                onToggle={() => toggle('label')}
+              />
+              <SortableHeader
+                label="Type"
+                sortKey="type"
+                active={sort.key === 'type'}
+                direction={sort.direction}
+                ariaSort={ariaSort('type')}
+                onToggle={() => toggle('type')}
+                className="w-36"
+              />
+              {/* Options column — not sortable (rendered chips, not data) */}
               <TableHead>Options</TableHead>
-              <TableHead className="w-28">Required</TableHead>
+              <SortableHeader
+                label="Required"
+                sortKey="required"
+                active={sort.key === 'required'}
+                direction={sort.direction}
+                ariaSort={ariaSort('required')}
+                onToggle={() => toggle('required')}
+                className="w-28"
+              />
+              {/* Actions column — not sortable */}
               <TableHead className="w-32">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {questions.map((question) => (
+            {sortedRows.map((question) => (
               <TableRow key={question.id}>
                 <TableCell>{question.order}</TableCell>
                 <TableCell className="font-medium">{question.label}</TableCell>
@@ -140,9 +193,9 @@ export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
         </Table>
       </Card>
 
-      {/* Mobile stacked cards */}
+      {/* Mobile stacked cards — sort order from sortedRows reflects active sort */}
       <div className="flex flex-col gap-3 md:hidden">
-        {questions.map((question) => (
+        {sortedRows.map((question) => (
           <Card key={question.id} className="p-4">
             <div className="flex flex-col gap-3">
               <div className="flex items-start justify-between gap-2">

--- a/components/features/global-questions-table.tsx
+++ b/components/features/global-questions-table.tsx
@@ -96,7 +96,6 @@ export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
             <TableRow>
               <SortableHeader
                 label="Order"
-                sortKey="order"
                 active={sort.key === 'order'}
                 direction={sort.direction}
                 ariaSort={ariaSort('order')}
@@ -105,7 +104,6 @@ export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
               />
               <SortableHeader
                 label="Label"
-                sortKey="label"
                 active={sort.key === 'label'}
                 direction={sort.direction}
                 ariaSort={ariaSort('label')}
@@ -113,7 +111,6 @@ export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
               />
               <SortableHeader
                 label="Type"
-                sortKey="type"
                 active={sort.key === 'type'}
                 direction={sort.direction}
                 ariaSort={ariaSort('type')}
@@ -124,7 +121,6 @@ export function GlobalQuestionsTable({ questions }: GlobalQuestionsTableProps) {
               <TableHead>Options</TableHead>
               <SortableHeader
                 label="Required"
-                sortKey="required"
                 active={sort.key === 'required'}
                 direction={sort.direction}
                 ariaSort={ariaSort('required')}

--- a/components/features/my-applications-table.tsx
+++ b/components/features/my-applications-table.tsx
@@ -1,11 +1,19 @@
+'use client';
+
 import Link from 'next/link';
 
 import { FileText } from 'lucide-react';
 
+import { APPLICATION_STATUS_LABELS } from '@/lib/constants';
 import { type MyApplicationListItem } from '@/lib/types';
+import {
+  type SortableColumn,
+  useSortableTable,
+} from '@/lib/use-sortable-table';
 import { formatDate } from '@/lib/utils';
 
 import { MyApplicationRowActions } from '@/components/features/my-application-row-actions';
+import { SortableHeader } from '@/components/features/sortable-header';
 import { ApplicationStatusBadge } from '@/components/features/status-badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -23,9 +31,22 @@ interface MyApplicationsTableProps {
   applications: MyApplicationListItem[];
 }
 
+const COLUMNS: SortableColumn<MyApplicationListItem>[] = [
+  { key: 'position', accessor: (a) => a.position.title },
+  // Sort by human label A-Z so order matches what the user reads in the badge.
+  { key: 'status', accessor: (a) => APPLICATION_STATUS_LABELS[a.status] },
+  // Drafts have null submittedAt — they sort last (null-last rule in the hook).
+  { key: 'applied', accessor: (a) => a.submittedAt },
+];
+
 export function MyApplicationsTable({
   applications,
 }: MyApplicationsTableProps) {
+  const { sortedRows, sort, toggle, ariaSort } = useSortableTable(
+    applications,
+    COLUMNS,
+  );
+
   if (applications.length === 0)
     return (
       <EmptyState
@@ -48,14 +69,35 @@ export function MyApplicationsTable({
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Position</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Applied</TableHead>
+              <SortableHeader
+                label="Position"
+                sortKey="position"
+                active={sort.key === 'position'}
+                direction={sort.direction}
+                ariaSort={ariaSort('position')}
+                onToggle={() => toggle('position')}
+              />
+              <SortableHeader
+                label="Status"
+                sortKey="status"
+                active={sort.key === 'status'}
+                direction={sort.direction}
+                ariaSort={ariaSort('status')}
+                onToggle={() => toggle('status')}
+              />
+              <SortableHeader
+                label="Applied"
+                sortKey="applied"
+                active={sort.key === 'applied'}
+                direction={sort.direction}
+                ariaSort={ariaSort('applied')}
+                onToggle={() => toggle('applied')}
+              />
               <TableHead>Action</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {applications.map((app) => (
+            {sortedRows.map((app) => (
               <TableRow key={app.id}>
                 <TableCell>
                   <Link
@@ -93,9 +135,9 @@ export function MyApplicationsTable({
         </Table>
       </div>
 
-      {/* Mobile stacked cards — shown only on mobile */}
+      {/* Mobile stacked cards — sort order from sortedRows reflects active sort */}
       <div className="flex flex-col divide-y md:hidden">
-        {applications.map((app) => (
+        {sortedRows.map((app) => (
           <div key={app.id} className="flex flex-col gap-2 p-4">
             <div className="flex items-center justify-between gap-2">
               <Link

--- a/components/features/my-applications-table.tsx
+++ b/components/features/my-applications-table.tsx
@@ -71,7 +71,6 @@ export function MyApplicationsTable({
             <TableRow>
               <SortableHeader
                 label="Position"
-                sortKey="position"
                 active={sort.key === 'position'}
                 direction={sort.direction}
                 ariaSort={ariaSort('position')}
@@ -79,7 +78,6 @@ export function MyApplicationsTable({
               />
               <SortableHeader
                 label="Status"
-                sortKey="status"
                 active={sort.key === 'status'}
                 direction={sort.direction}
                 ariaSort={ariaSort('status')}
@@ -87,7 +85,6 @@ export function MyApplicationsTable({
               />
               <SortableHeader
                 label="Applied"
-                sortKey="applied"
                 active={sort.key === 'applied'}
                 direction={sort.direction}
                 ariaSort={ariaSort('applied')}

--- a/components/features/position-applications-table.tsx
+++ b/components/features/position-applications-table.tsx
@@ -60,7 +60,6 @@ export function PositionApplicationsTable({
             <TableRow>
               <SortableHeader
                 label="Applicant"
-                sortKey="applicant"
                 active={sort.key === 'applicant'}
                 direction={sort.direction}
                 ariaSort={ariaSort('applicant')}
@@ -68,7 +67,6 @@ export function PositionApplicationsTable({
               />
               <SortableHeader
                 label="Submitted"
-                sortKey="submitted"
                 active={sort.key === 'submitted'}
                 direction={sort.direction}
                 ariaSort={ariaSort('submitted')}
@@ -76,7 +74,6 @@ export function PositionApplicationsTable({
               />
               <SortableHeader
                 label="Status"
-                sortKey="status"
                 active={sort.key === 'status'}
                 direction={sort.direction}
                 ariaSort={ariaSort('status')}

--- a/components/features/position-applications-table.tsx
+++ b/components/features/position-applications-table.tsx
@@ -1,16 +1,23 @@
+'use client';
+
 import { Inbox } from 'lucide-react';
 
+import { APPLICATION_STATUS_LABELS } from '@/lib/constants';
 import { type PositionApplicationListItem } from '@/lib/types';
+import {
+  type SortableColumn,
+  useSortableTable,
+} from '@/lib/use-sortable-table';
 import { formatDate } from '@/lib/utils';
 
 import { ApplicationStatusControl } from '@/components/features/application-status-control';
+import { SortableHeader } from '@/components/features/sortable-header';
 import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
@@ -19,9 +26,21 @@ interface PositionApplicationsTableProps {
   applications: PositionApplicationListItem[];
 }
 
+const COLUMNS: SortableColumn<PositionApplicationListItem>[] = [
+  { key: 'applicant', accessor: (a) => a.user.name ?? a.user.email },
+  { key: 'submitted', accessor: (a) => a.submittedAt },
+  // Sort by human label A-Z so order matches what the user reads in the status control.
+  { key: 'status', accessor: (a) => APPLICATION_STATUS_LABELS[a.status] },
+];
+
 export function PositionApplicationsTable({
   applications,
 }: PositionApplicationsTableProps) {
+  const { sortedRows, sort, toggle, ariaSort } = useSortableTable(
+    applications,
+    COLUMNS,
+  );
+
   if (applications.length === 0)
     return (
       <EmptyState
@@ -39,13 +58,34 @@ export function PositionApplicationsTable({
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Applicant</TableHead>
-              <TableHead>Submitted</TableHead>
-              <TableHead>Status</TableHead>
+              <SortableHeader
+                label="Applicant"
+                sortKey="applicant"
+                active={sort.key === 'applicant'}
+                direction={sort.direction}
+                ariaSort={ariaSort('applicant')}
+                onToggle={() => toggle('applicant')}
+              />
+              <SortableHeader
+                label="Submitted"
+                sortKey="submitted"
+                active={sort.key === 'submitted'}
+                direction={sort.direction}
+                ariaSort={ariaSort('submitted')}
+                onToggle={() => toggle('submitted')}
+              />
+              <SortableHeader
+                label="Status"
+                sortKey="status"
+                active={sort.key === 'status'}
+                direction={sort.direction}
+                ariaSort={ariaSort('status')}
+                onToggle={() => toggle('status')}
+              />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {applications.map((app) => {
+            {sortedRows.map((app) => {
               const displayName = app.user.name ?? app.user.email;
               return (
                 <TableRow key={app.id}>
@@ -73,9 +113,9 @@ export function PositionApplicationsTable({
         </Table>
       </div>
 
-      {/* Mobile stacked cards — shown only on mobile */}
+      {/* Mobile stacked cards — sort order from sortedRows reflects active sort */}
       <div className="flex flex-col divide-y md:hidden">
-        {applications.map((app) => {
+        {sortedRows.map((app) => {
           const displayName = app.user.name ?? app.user.email;
           return (
             <div key={app.id} className="flex flex-col gap-2 p-4">

--- a/components/features/sortable-header.tsx
+++ b/components/features/sortable-header.tsx
@@ -8,7 +8,6 @@ import { TableHead } from '@/components/ui/table';
 
 interface SortableHeaderProps {
   label: string;
-  sortKey: string;
   active: boolean;
   direction: SortDirection;
   ariaSort: 'ascending' | 'descending' | 'none';

--- a/components/features/sortable-header.tsx
+++ b/components/features/sortable-header.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+
+import type { SortDirection } from '@/lib/use-sortable-table';
+
+import { TableHead } from '@/components/ui/table';
+
+interface SortableHeaderProps {
+  label: string;
+  sortKey: string;
+  active: boolean;
+  direction: SortDirection;
+  ariaSort: 'ascending' | 'descending' | 'none';
+  onToggle: () => void;
+  className?: string;
+}
+
+export function SortableHeader({
+  label,
+  active,
+  direction,
+  ariaSort,
+  onToggle,
+  className,
+}: SortableHeaderProps) {
+  const isAsc = active && direction === 'asc';
+
+  return (
+    <TableHead aria-sort={ariaSort} className={className}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="hover:text-foreground flex items-center gap-1 font-medium transition-colors"
+        aria-label={`Sort by ${label}${active ? (isAsc ? ', currently ascending' : ', currently descending') : ''}`}
+      >
+        {label}
+        {active ? (
+          isAsc ? (
+            <ArrowUp
+              className="text-foreground h-3.5 w-3.5"
+              aria-hidden="true"
+            />
+          ) : (
+            <ArrowDown
+              className="text-foreground h-3.5 w-3.5"
+              aria-hidden="true"
+            />
+          )
+        ) : (
+          <ArrowUpDown
+            className="text-muted-foreground h-3.5 w-3.5"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </TableHead>
+  );
+}

--- a/components/providers/index.tsx
+++ b/components/providers/index.tsx
@@ -1,3 +1,5 @@
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
+
 import { ThemeProvider } from '@/components/providers/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 
@@ -5,14 +7,16 @@ import { QueryProvider } from './query-provider';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-    >
-      <QueryProvider>{children}</QueryProvider>
-      <Toaster />
-    </ThemeProvider>
+    <NuqsAdapter>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+      >
+        <QueryProvider>{children}</QueryProvider>
+        <Toaster />
+      </ThemeProvider>
+    </NuqsAdapter>
   );
 }

--- a/lib/use-sortable-table.ts
+++ b/lib/use-sortable-table.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { parseAsStringEnum, parseAsStringLiteral, useQueryStates } from 'nuqs';
 
@@ -58,7 +58,10 @@ export function useSortableTable<T>(
   columns: SortableColumn<T>[],
   options?: UseSortableTableOptions,
 ): UseSortableTableResult<T> {
-  const validKeys = columns.map((c) => c.key) as [string, ...string[]];
+  const validKeys = useMemo(
+    () => columns.map((c) => c.key) as [string, ...string[]],
+    [columns],
+  );
 
   const [params, setParams] = useQueryStates(
     {
@@ -68,25 +71,37 @@ export function useSortableTable<T>(
     { history: 'replace', scroll: false, shallow: true },
   );
 
+  const defaultSortKey = options?.defaultSort?.key;
+  const defaultSortDirection = options?.defaultSort?.direction;
+
   // Resolve sort state: URL params take precedence; fall back to defaultSort.
+  // Primitive deps prevent recomputing when an inline defaultSort object is passed.
   const sort: SortState = useMemo(() => {
     if (params.sort !== null)
       return { key: params.sort, direction: params.dir ?? 'asc' };
-    return options?.defaultSort ?? { key: null, direction: 'asc' };
-  }, [params.sort, params.dir, options]);
+    if (defaultSortKey !== undefined)
+      return { key: defaultSortKey, direction: defaultSortDirection ?? 'asc' };
+    return { key: null, direction: 'asc' };
+  }, [params.sort, params.dir, defaultSortKey, defaultSortDirection]);
 
-  function toggle(key: string) {
-    if (sort.key !== key) {
-      // Inactive column → sort asc.
-      void setParams({ sort: key as (typeof validKeys)[number], dir: 'asc' });
-    } else if (sort.direction === 'asc') {
-      // Active asc → sort desc.
-      void setParams({ sort: key as (typeof validKeys)[number], dir: 'desc' });
-    } else {
-      // Active desc → clear (return to default order).
-      void setParams({ sort: null, dir: null });
-    }
-  }
+  const toggle = useCallback(
+    (key: string) => {
+      if (sort.key !== key) {
+        // Inactive column → sort asc.
+        void setParams({ sort: key as (typeof validKeys)[number], dir: 'asc' });
+      } else if (sort.direction === 'asc') {
+        // Active asc → sort desc.
+        void setParams({
+          sort: key as (typeof validKeys)[number],
+          dir: 'desc',
+        });
+      } else {
+        // Active desc → clear (return to default order).
+        void setParams({ sort: null, dir: null });
+      }
+    },
+    [sort.key, sort.direction, setParams],
+  );
 
   const sortedRows = useMemo(() => {
     if (!sort.key) return rows;
@@ -102,10 +117,13 @@ export function useSortableTable<T>(
     });
   }, [rows, columns, sort.key, sort.direction]);
 
-  function ariaSort(key: string): 'ascending' | 'descending' | 'none' {
-    if (sort.key !== key) return 'none';
-    return sort.direction === 'asc' ? 'ascending' : 'descending';
-  }
+  const ariaSort = useCallback(
+    (key: string): 'ascending' | 'descending' | 'none' => {
+      if (sort.key !== key) return 'none';
+      return sort.direction === 'asc' ? 'ascending' : 'descending';
+    },
+    [sort.key, sort.direction],
+  );
 
   return { sortedRows, sort, toggle, ariaSort };
 }

--- a/lib/use-sortable-table.ts
+++ b/lib/use-sortable-table.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { parseAsStringEnum, parseAsStringLiteral, useQueryStates } from 'nuqs';
+
+export type SortDirection = 'asc' | 'desc';
+
+// A column the table can sort by. `key` is the URL token; `accessor` extracts
+// the comparable value from a row.
+export interface SortableColumn<T> {
+  key: string;
+  accessor: (row: T) => string | number | Date | null | undefined;
+}
+
+export interface SortState {
+  key: string | null;
+  direction: SortDirection;
+}
+
+interface UseSortableTableOptions {
+  defaultSort?: SortState;
+}
+
+interface UseSortableTableResult<T> {
+  sortedRows: T[];
+  sort: SortState;
+  toggle: (key: string) => void;
+  ariaSort: (key: string) => 'ascending' | 'descending' | 'none';
+}
+
+function compareValues(
+  a: string | number | Date | null | undefined,
+  b: string | number | Date | null | undefined,
+): number {
+  // Null/undefined always sort last regardless of direction.
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  if (typeof a === 'string' && typeof b === 'string')
+    return a.localeCompare(b, undefined, {
+      sensitivity: 'base',
+      numeric: true,
+    });
+
+  // Fallback for mixed types — convert to string.
+  return String(a).localeCompare(String(b), undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  });
+}
+
+export function useSortableTable<T>(
+  rows: T[],
+  columns: SortableColumn<T>[],
+  options?: UseSortableTableOptions,
+): UseSortableTableResult<T> {
+  const validKeys = columns.map((c) => c.key) as [string, ...string[]];
+
+  const [params, setParams] = useQueryStates(
+    {
+      sort: parseAsStringLiteral(validKeys),
+      dir: parseAsStringEnum<SortDirection>(['asc', 'desc']),
+    },
+    { history: 'replace', scroll: false, shallow: true },
+  );
+
+  // Resolve sort state: URL params take precedence; fall back to defaultSort.
+  const sort: SortState = useMemo(() => {
+    if (params.sort !== null)
+      return { key: params.sort, direction: params.dir ?? 'asc' };
+    return options?.defaultSort ?? { key: null, direction: 'asc' };
+  }, [params.sort, params.dir, options]);
+
+  function toggle(key: string) {
+    if (sort.key !== key) {
+      // Inactive column → sort asc.
+      void setParams({ sort: key as (typeof validKeys)[number], dir: 'asc' });
+    } else if (sort.direction === 'asc') {
+      // Active asc → sort desc.
+      void setParams({ sort: key as (typeof validKeys)[number], dir: 'desc' });
+    } else {
+      // Active desc → clear (return to default order).
+      void setParams({ sort: null, dir: null });
+    }
+  }
+
+  const sortedRows = useMemo(() => {
+    if (!sort.key) return rows;
+
+    const column = columns.find((c) => c.key === sort.key);
+    if (!column) return rows;
+
+    return [...rows].sort((a, b) => {
+      const valA = column.accessor(a);
+      const valB = column.accessor(b);
+      const cmp = compareValues(valA, valB);
+      return sort.direction === 'desc' ? -cmp : cmp;
+    });
+  }, [rows, columns, sort.key, sort.direction]);
+
+  function ariaSort(key: string): 'ascending' | 'descending' | 'none' {
+    if (sort.key !== key) return 'none';
+    return sort.direction === 'asc' ? 'ascending' : 'descending';
+  }
+
+  return { sortedRows, sort, toggle, ariaSort };
+}


### PR DESCRIPTION
Closes #178

## Summary

- Adds a generic `useSortableTable` hook (`lib/use-sortable-table.ts`) backed by `nuqs` URL state — reads and writes `?sort=<key>&dir=asc|desc` with `history: 'replace'` so sort toggles don't push history entries or trigger server round-trips
- Adds a shared `SortableHeader` presentational component (`components/features/sortable-header.tsx`) with consistent arrow-icon indicators and `aria-sort` / `aria-label` accessibility attributes, replacing the private `SortableHead` in `applications-table.tsx`
- Wires client-side sort into `my-applications-table`, `position-applications-table`, and `global-questions-table`; the server-side sort on `/applications` (capped at 100 rows) is kept intact and only its header is normalised to the shared component

## Changes

- `components/providers/index.tsx` — wrap app in `NuqsAdapter` (one-time prerequisite for `useQueryStates`)
- `lib/use-sortable-table.ts` — new generic hook: URL-backed sort state, in-memory stable sort, null-last comparator, `useMemo` for sorted rows
- `components/features/sortable-header.tsx` — new shared header-cell component with arrow icons and ARIA attributes
- `components/features/my-applications-table.tsx` — add `'use client'`, wire hook with Position/Status/Applied columns
- `components/features/position-applications-table.tsx` — add `'use client'`, wire hook with Applicant/Submitted/Status columns
- `components/features/global-questions-table.tsx` — wire hook with Order/Label/Type/Required columns; default sort by Order asc
- `components/features/applications-table.tsx` — replace private `SortableHead` with shared `SortableHeader`; server-side sort mechanism unchanged

## Testing plan

**A. `/my-applications` (client-side sort)**
- [ ] Default order matches today's (most-recently-updated first); headers show neutral `⇅` indicator
- [ ] Click **Position** → rows sort A→Z, header shows up-arrow, URL becomes `?sort=position&dir=asc`
- [ ] Click **Position** again → Z→A, down-arrow, `dir=desc`; click third time → default order restored, URL params removed
- [ ] Click **Applied** → draft rows ("—") cluster at the bottom in both directions
- [ ] Refresh with `?sort=position&dir=desc` active → order and indicator persist
- [ ] Copy URL with sort params, open in new tab → loads already sorted
- [ ] **Action** column header shows no sort indicator and is not clickable
- [ ] Mobile (375px): stacked cards reflect active sort order; no sort controls appear

**B. `/positions/[id]/applications` (client-side sort)**
- [ ] Sort by **Applicant** and **Submitted** columns with three-click cycle
- [ ] URL params written and survive refresh
- [ ] Per-row **Status control** still works after sorting

**C. Global questions table (client-side sort)**
- [ ] Default sort is by **Order** ascending
- [ ] Sort by **Label**, **Type**, **Required** with three-click cycle and URL params
- [ ] **Options** and **Actions** columns show no indicator and are not clickable
- [ ] Edit dialog opens correctly after sorting
- [ ] Delete dialog still works and shows success toast

**D. `/applications` (server-side sort regression)**
- [ ] Existing sort (Applicant / Status / Submitted) still works and re-fetches (capped at 100)
- [ ] Sort indicator looks identical to the other tables (shared component)
- [ ] Existing `?sort=field:direction` URLs still work

**E. Accessibility / keyboard**
- [ ] Tab to a sortable header, press Enter/Space → sorts; visible focus ring present
- [ ] `aria-sort` attribute updates on the `<th>` element; button `aria-label` announces direction

**F. Robustness**
- [ ] Set `?sort=nonsense&dir=sideways` on each client table → renders in default order without error

## Automated checks

- `npm run tsc:check` — passes
- `npm run eslint:check` — passes
- `npm run prettier:check` — passes

## Notes

The `/applications` table intentionally keeps its own `?sort=field:direction` URL format (not the shared `?sort=&dir=` scheme used by the new client tables). This is because it triggers a server re-fetch for a 100-row-capped query, and coupling it to the `nuqs`-based client abstraction would break correct ordering. The divergence is documented in an inline comment in `applications-table.tsx`.

Mobile sort controls are deliberately not added (no "Sort by" dropdown on mobile). The stacked card lists reflect whatever sort is active (from `sortedRows`), so a sort chosen on desktop or arriving via a shared URL is reflected on mobile. A mobile sort UI is a reasonable follow-up.
