### PR TITLE
#180 Simplify Position Cards And Add Position Detail Page

### DIFF
--- a/app/(main)/(auth)/positions/[id]/loading.tsx
+++ b/app/(main)/(auth)/positions/[id]/loading.tsx
@@ -1,0 +1,42 @@
+export default function PositionDetailLoading() {
+  return (
+    <div className="mx-auto max-w-2xl">
+      {/* Back link */}
+      <div className="bg-muted mb-6 h-8 w-36 animate-pulse rounded" />
+
+      {/* Title + action buttons */}
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="bg-muted h-8 w-64 animate-pulse rounded" />
+        <div className="flex gap-2">
+          <div className="bg-muted h-8 w-16 animate-pulse rounded" />
+          <div className="bg-muted h-8 w-32 animate-pulse rounded" />
+        </div>
+      </div>
+
+      {/* Status badge + dates */}
+      <div className="mb-6 flex items-center gap-2">
+        <div className="bg-muted h-5 w-16 animate-pulse rounded-full" />
+        <div className="bg-muted h-4 w-28 animate-pulse rounded" />
+      </div>
+
+      {/* Description section */}
+      <div className="mb-6 flex flex-col gap-2">
+        <div className="bg-muted h-5 w-28 animate-pulse rounded" />
+        <div className="bg-muted h-4 w-full animate-pulse rounded" />
+        <div className="bg-muted h-4 w-5/6 animate-pulse rounded" />
+        <div className="bg-muted h-4 w-4/6 animate-pulse rounded" />
+      </div>
+
+      {/* Questions section */}
+      <div className="flex flex-col gap-3">
+        <div className="bg-muted h-5 w-40 animate-pulse rounded" />
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="bg-muted h-4 w-48 animate-pulse rounded" />
+            <div className="bg-muted h-5 w-24 animate-pulse rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/(auth)/positions/[id]/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/page.tsx
@@ -1,0 +1,164 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { FileQuestion, Inbox, Pencil } from 'lucide-react';
+
+import { getPositionDetail } from '@/prisma/data/positions';
+
+import { getCurrentUser } from '@/lib/auth/server';
+import { QUESTION_TYPE_LABELS } from '@/lib/constants';
+import { formatDate, getPositionAvailability } from '@/lib/utils';
+
+import { PositionStatusBadge } from '@/components/features/status-badge';
+import { PageHeader } from '@/components/layouts/page-header';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface PositionDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PositionDetailPage({
+  params,
+}: PositionDetailPageProps) {
+  const { id } = await params;
+  const user = await getCurrentUser();
+
+  const position = await getPositionDetail(id);
+
+  // Stale or deleted link → send the user back to the list.
+  if (!position) redirect('/positions');
+
+  const isManager = position.managers.some((m) => m.id === user.id);
+  const isAdminOrManager = user.isAdmin || isManager;
+  const availability = getPositionAvailability(position);
+
+  // Draft gate: non-admins/non-managers see a friendly notice — not an error page,
+  // not a redirect — because a draft URL is a legitimately reachable state (stale link).
+  if (position.status === 'draft' && !isAdminOrManager) {
+    return (
+      <div className="mx-auto flex max-w-2xl flex-col gap-6">
+        <PageHeader
+          title="Position not available"
+          backHref="/positions"
+          backLabel="Back to positions"
+        />
+        <div className="bg-muted rounded-lg p-6">
+          <p className="font-medium">This position is not available</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            This position isn&apos;t open for applications right now.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const adminActions = isAdminOrManager ? (
+    <div className="flex flex-wrap gap-2">
+      <Button asChild variant="outline" size="sm">
+        <Link href={`/positions/${id}/edit`}>
+          <Pencil className="size-4" />
+          Edit
+        </Link>
+      </Button>
+      <Button asChild variant="outline" size="sm">
+        <Link href={`/positions/${id}/applications`}>
+          <Inbox className="size-4" />
+          View Applications
+        </Link>
+      </Button>
+    </div>
+  ) : undefined;
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-6">
+      <PageHeader
+        title={position.title}
+        backHref="/positions"
+        backLabel="Back to positions"
+        actions={adminActions}
+      />
+
+      {/* Status + dates */}
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <PositionStatusBadge position={position} />
+          {position.opensAt && (
+            <span className="text-muted-foreground text-sm">
+              Opens {formatDate(position.opensAt)}
+            </span>
+          )}
+          {position.closesAt && (
+            <span className="text-muted-foreground text-sm">
+              Closes {formatDate(position.closesAt)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Full description */}
+      <section>
+        <h2 className="text-lg font-semibold">Description</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed whitespace-pre-line">
+          {position.description}
+        </p>
+      </section>
+
+      {/* Questions preview */}
+      <section>
+        <h2 className="text-lg font-semibold">Application questions</h2>
+        {position.questions.length === 0 ? (
+          <div className="text-muted-foreground mt-2 flex items-center gap-2 text-sm">
+            <FileQuestion className="size-4 shrink-0" />
+            <span>No additional questions for this position.</span>
+          </div>
+        ) : (
+          <ul className="mt-2 flex flex-col gap-3">
+            {position.questions.map((q) => (
+              <li key={q.id} className="flex flex-col gap-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium">{q.label}</span>
+                  <Badge variant="secondary" className="text-xs">
+                    {QUESTION_TYPE_LABELS[q.type]}
+                  </Badge>
+                  {q.required && (
+                    <Badge variant="outline" className="text-xs">
+                      Required
+                    </Badge>
+                  )}
+                </div>
+                {(q.type === 'single_choice' || q.type === 'multiple_choice') &&
+                  q.options.length > 0 && (
+                    <ul className="text-muted-foreground ml-1 list-inside list-disc text-xs">
+                      {q.options.map((opt) => (
+                        <li key={opt}>{opt}</li>
+                      ))}
+                    </ul>
+                  )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Apply CTA or status notice for applicants */}
+      {!isAdminOrManager && (
+        <div>
+          {availability === 'accepting' ? (
+            <Button asChild>
+              <Link href={`/positions/${id}/apply`}>Apply</Link>
+            </Button>
+          ) : availability === 'upcoming' && position.opensAt ? (
+            <p className="text-muted-foreground text-sm">
+              Applications open {formatDate(position.opensAt)}.
+            </p>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              Applications are closed for this position.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -1,15 +1,11 @@
-'use client';
-
 import Link from 'next/link';
-import { useState } from 'react';
 
-import { ChevronDown, ChevronUp, Inbox, Pencil } from 'lucide-react';
+import { Inbox, Pencil } from 'lucide-react';
 
 import type { PositionWithQuestions } from '@/lib/types';
 import { formatDate, getPositionAvailability } from '@/lib/utils';
 
 import { PositionStatusBadge } from '@/components/features/status-badge';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -18,106 +14,79 @@ interface PositionCardProps {
   canManage?: boolean;
 }
 
+// Server component — accordion removed; flat summary card with always-visible
+// truncated description and a CTA row linking into the detail page.
 export function PositionCard({
   position,
   canManage = false,
 }: PositionCardProps) {
-  const [open, setOpen] = useState(false);
-
-  // Derive availability once per render so copy and button logic stay in sync.
   const availability = getPositionAvailability(position);
   const isAccepting = availability === 'accepting';
 
+  let dateLabel: string | null = null;
+  if (availability === 'accepting' && position.closesAt)
+    dateLabel = `Closes ${formatDate(position.closesAt)}`;
+  else if (availability === 'upcoming' && position.opensAt)
+    dateLabel = `Opens ${formatDate(position.opensAt)}`;
+  else if (
+    (availability === 'closed_by_date' || availability === 'unavailable') &&
+    position.closesAt
+  )
+    dateLabel = `Closed ${formatDate(position.closesAt)}`;
+
   return (
-    <Card className="gap-0 p-0">
-      <CardHeader className="p-0">
-        <button
-          type="button"
-          className="flex w-full items-center justify-between p-4 text-left"
-          onClick={() => setOpen((prev) => !prev)}
-          aria-expanded={open}
-        >
-          <div className="flex items-center gap-3">
-            <CardTitle className="text-lg">{position.title}</CardTitle>
-            {canManage && <PositionStatusBadge position={position} />}
-          </div>
-          {open ? (
-            <ChevronUp className="text-muted-foreground size-5 shrink-0" />
-          ) : (
-            <ChevronDown className="text-muted-foreground size-5 shrink-0" />
-          )}
-        </button>
+    <Card className="flex flex-col gap-0 p-0">
+      <CardHeader className="p-4 pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-lg leading-snug">
+            {position.title}
+          </CardTitle>
+          <PositionStatusBadge position={position} />
+        </div>
       </CardHeader>
 
-      {open && (
-        <CardContent className="flex flex-col gap-4 px-4 pb-4">
-          <p className="text-muted-foreground text-sm">
-            {position.description}
-          </p>
+      <CardContent className="flex flex-col gap-3 px-4 pb-4">
+        <p className="text-muted-foreground line-clamp-2 text-sm">
+          {position.description}
+        </p>
 
-          {position.questions.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <p className="text-sm font-medium">Application questions</p>
-              <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
-                {position.questions.map(
-                  (question: PositionWithQuestions['questions'][number]) => (
-                    <li key={question.id}>{question.label}</li>
-                  ),
-                )}
-              </ul>
-            </div>
+        {dateLabel && (
+          <p className="text-muted-foreground text-xs">{dateLabel}</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2 pt-1">
+          {canManage ? (
+            <>
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/positions/${position.id}`}>View Details</Link>
+              </Button>
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/positions/${position.id}/edit`}>
+                  <Pencil className="size-4" />
+                  Edit
+                </Link>
+              </Button>
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/positions/${position.id}/applications`}>
+                  <Inbox className="size-4" />
+                  Applications
+                </Link>
+              </Button>
+            </>
+          ) : (
+            <>
+              {isAccepting && (
+                <Button asChild size="sm">
+                  <Link href={`/positions/${position.id}/apply`}>Apply</Link>
+                </Button>
+              )}
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/positions/${position.id}`}>View Details</Link>
+              </Button>
+            </>
           )}
-
-          <div className="flex items-center gap-2 pt-2">
-            {canManage ? (
-              <>
-                {isAccepting && (
-                  <Button asChild>
-                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
-                  </Button>
-                )}
-                <Button asChild variant="outline">
-                  <Link href={`/positions/${position.id}/edit`}>
-                    <Pencil className="size-4" />
-                    Edit
-                  </Link>
-                </Button>
-                <Button asChild variant="outline">
-                  <Link href={`/positions/${position.id}/applications`}>
-                    <Inbox className="size-4" />
-                    Applications
-                  </Link>
-                </Button>
-              </>
-            ) : (
-              <>
-                {isAccepting && (
-                  <>
-                    <Button asChild>
-                      <Link href={`/positions/${position.id}/apply`}>
-                        Apply
-                      </Link>
-                    </Button>
-                    {position.closesAt && (
-                      <span className="text-muted-foreground text-sm">
-                        Closes {formatDate(position.closesAt)}
-                      </span>
-                    )}
-                  </>
-                )}
-                {availability === 'upcoming' && position.opensAt && (
-                  <Badge variant="secondary">
-                    Opens {formatDate(position.opensAt)}
-                  </Badge>
-                )}
-                {availability === 'closed_by_date' && (
-                  <Badge variant="outline">Closed</Badge>
-                )}
-              </>
-            )}
-          </div>
-        </CardContent>
-      )}
+        </div>
+      </CardContent>
     </Card>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,6 +32,13 @@ export type PositionManager = {
   email: string;
 };
 
+// Detail view type: full read payload including managers for the access check.
+// Manager ids are consumed server-side only; name/email are not needed for the
+// draft gate check so we keep the manager shape minimal (§3).
+export type PositionDetail = PositionWithQuestions & {
+  managers: { id: string }[];
+};
+
 // Narrowed question shape — only the fields rendered by the edit page and
 // PositionQuestionsSection; audit columns are excluded to avoid leaking them
 // across the server/client prop boundary.

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -4,6 +4,7 @@ import { UNRESOLVED_APPLICATION_STATUSES } from '@/lib/constants';
 import prisma from '@/lib/prisma';
 import {
   type OpenPositionSummaryItem,
+  type PositionDetail,
   type PositionForEdit,
   type PositionWithQuestions,
 } from '@/lib/types';
@@ -147,6 +148,37 @@ export async function getOpenPositionsSummary(): Promise<
       },
     },
     orderBy: { title: 'asc' },
+  });
+}
+
+// Full read payload for the detail page: any non-deleted status (no status filter),
+// no applications, managers fetched as id-only for the draft gate check (§3).
+export async function getPositionDetail(
+  id: string,
+): Promise<PositionDetail | null> {
+  return prisma.position.findFirst({
+    where: { id, deletedAt: null },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      description: true,
+      opensAt: true,
+      closesAt: true,
+      questions: {
+        where: { deletedAt: null },
+        orderBy: { order: 'asc' },
+        select: {
+          id: true,
+          label: true,
+          type: true,
+          required: true,
+          options: true,
+          order: true,
+        },
+      },
+      managers: { select: { id: true } },
+    },
   });
 }
 


### PR DESCRIPTION
Closes #180

## Summary

- Converts `PositionCard` from a client-side accordion to a flat server component with an always-visible truncated description and a "View Details" CTA, eliminating client JS from the positions list
- Adds a new `/positions/[id]` detail page showing full description, questions preview, status/dates, and an Apply CTA gated to accepting positions
- Adds `PositionDetail` type and `getPositionDetail` data function; draft positions render a friendly "not available" notice for non-admin/non-manager viewers instead of an error or redirect

## Changes

- `lib/types.ts` — adds `PositionDetail = PositionWithQuestions & { managers: { id: string }[] }`
- `prisma/data/positions.ts` — adds `getPositionDetail(id)`: full read payload, no status filter, managers as id-only
- `components/features/position-card.tsx` — removes `'use client'`, `useState`, and accordion; always-visible card with truncated description, status badge, date line, and CTA row (Apply + View Details for applicants; View Details + Edit + Applications for admins/managers)
- `app/(main)/(auth)/positions/[id]/page.tsx` — new server-component detail page: draft gate for non-admins, full description, questions preview with designed empty state, Apply CTA gated to `accepting` + non-admin, admin action buttons
- `app/(main)/(auth)/positions/[id]/loading.tsx` — skeleton matching the detail layout

## Testing plan

- [ ] **Card — open position (applicant):** Go to `/positions`. Each open card shows title, "Open" badge, 2-line truncated description with no accordion/chevron, a "Closes {date}" line when a close date exists, and Apply (primary) + View Details (outline) buttons.
- [ ] **Card — closed/upcoming (applicant):** Closed card shows "Closed" badge, closed date, only View Details. Upcoming shows "Upcoming" + "Opens {date}" + only View Details.
- [ ] **Card — admin:** Cards show status badge + View Details, Edit, Applications buttons. No Apply button.
- [ ] **View Details navigation:** Clicking "View Details" on any card lands on `/positions/[id]` for that position.
- [ ] **Detail page — open position (applicant):** h1 title, "Open" badge, dates, full untruncated description, Application questions section with type/required markers, Back to positions link, primary Apply button. Clicking Apply reaches the apply flow.
- [ ] **Detail page — no questions:** Position with zero questions shows the designed empty state ("No additional questions…"), not a blank gap.
- [ ] **Detail page — closed/upcoming (applicant):** Closed → full detail, no Apply button, "Applications are closed…" note. Upcoming → no Apply, "Applications open {date}" note.
- [ ] **Detail page — draft as applicant:** Navigate directly to a draft position's `/positions/[id]` as a non-admin/non-manager → see "This position is not available" notice + back link. No description or questions shown. Not an error page.
- [ ] **Detail page — draft as admin/manager:** Same draft URL as admin/manager → full detail with Edit + View Applications buttons.
- [ ] **Not found:** `/positions/some-nonexistent-id` → redirected to `/positions` with no crash.
- [ ] **Loading state:** Hard-navigate to a detail page — skeleton layout shows with no layout shift on content resolve.
- [ ] **Accessibility:** Tab through detail page — back link, action buttons, Apply are keyboard-reachable with visible focus rings; heading order is h1→h2.
- [ ] **Responsive:** At 375px header action buttons stack; card CTA row wraps gracefully. At 768/1280 inline layout.
- [ ] **Both themes:** Card and detail page render correctly in light and dark mode (no off-theme colors).

## Automated checks

- `npm run tsc:check` — passes
- `npm run eslint:check` — passes
- `npm run prettier:check` — passes

## Notes

- The card is now a **pure server component** — no `'use client'`, no `useState`. The positions list is fully server-rendered with no client JS.
- Per the scope boundary: `positions/page.tsx` is untouched; the card redesign composes onto the existing `canManage` prop regardless of whether #176 has merged.
- The detail page is **dynamic** (depends on the session for the draft gate and admin actions); no new cache tags are introduced — existing position mutations already revalidate `/positions`.
- `getPositionDetail` fetches managers as `{ id }` only (not `name`/`email`) since the detail page only needs ids for the role check; this avoids serializing other-users' identity to the client (§3).
