### PR TITLE
#177 Redesign Home Page Dashboard With Stats, Activity, And Compact Widgets

### DIFF
--- a/components/features/activity-feed.tsx
+++ b/components/features/activity-feed.tsx
@@ -1,0 +1,160 @@
+import { Activity } from 'lucide-react';
+
+import { getMyRecentActivity } from '@/prisma/data/applications';
+import { getRecentApplications } from '@/prisma/data/applications';
+
+import {
+  APPLICATION_STATUS_BADGE_VARIANT,
+  APPLICATION_STATUS_LABELS,
+  STATUS_BADGE_VARIANT_TO_DOT,
+} from '@/lib/constants';
+import { type ActivityItem } from '@/lib/types';
+import { formatRelativeTime } from '@/lib/utils';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+// ─── Presentational leaf ─────────────────────────────────────────────────────
+
+interface ActivityFeedListProps {
+  items: ActivityItem[];
+  emptyDescription: string;
+}
+
+function ActivityFeedList({ items, emptyDescription }: ActivityFeedListProps) {
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <CardTitle className="text-base font-semibold">
+          Recent activity
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {items.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-10 text-center">
+            <Activity
+              className="text-muted-foreground size-10"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-medium">No recent activity</p>
+            <p className="text-muted-foreground text-sm">{emptyDescription}</p>
+          </div>
+        ) : (
+          <ol>
+            {items.map((item) => {
+              const dotClass =
+                STATUS_BADGE_VARIANT_TO_DOT[item.statusVariant] ??
+                'bg-muted-foreground';
+              const isoString = item.timestamp.toISOString();
+              const relativeTime = formatRelativeTime(item.timestamp);
+
+              return (
+                <li
+                  key={item.id}
+                  className="flex items-start gap-3 border-b px-4 py-3 last:border-0"
+                >
+                  <span
+                    className={`mt-1.5 size-2 shrink-0 rounded-full ${dotClass}`}
+                    aria-hidden="true"
+                  />
+                  <p className="line-clamp-2 min-w-0 flex-1 text-sm">
+                    {item.sentence}
+                  </p>
+                  <time
+                    dateTime={isoString}
+                    className="text-muted-foreground ml-auto shrink-0 text-xs tabular-nums"
+                  >
+                    {relativeTime}
+                  </time>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Applicant feed wrapper ───────────────────────────────────────────────────
+
+interface ApplicantActivityFeedProps {
+  userId: string;
+}
+
+// Feed shows applicant's own non-draft applications ordered by updatedAt DESC.
+// Copy describes current state ("is {Status}") — avoids asserting a from-state
+// we cannot prove (no status-history table; see issue §0).
+export async function ApplicantActivityFeed({
+  userId,
+}: ApplicantActivityFeedProps) {
+  const applications = await getMyRecentActivity(userId, 10);
+
+  const items: ActivityItem[] = applications.map((app) => {
+    const statusLabel = APPLICATION_STATUS_LABELS[app.status];
+    const variant = APPLICATION_STATUS_BADGE_VARIANT[app.status];
+    return {
+      id: app.id,
+      statusVariant: variant,
+      sentence: `Your application for ${app.position.title} is ${statusLabel}`,
+      timestamp: app.updatedAt,
+    };
+  });
+
+  return (
+    <ActivityFeedList
+      items={items}
+      emptyDescription="Updates to your applications will show up here."
+    />
+  );
+}
+
+// ─── Admin feed wrapper ───────────────────────────────────────────────────────
+
+// Feed shows most recent non-draft applications across all positions, ordered
+// by submittedAt DESC — a provable "applied" event stream (unlike updatedAt).
+// Returns cross-user data — must only be called from an admin-gated context.
+export async function AdminActivityFeed() {
+  const applications = await getRecentApplications(10);
+
+  const items: ActivityItem[] = applications.map((app) => {
+    const applicantLabel = app.user.name ?? app.user.email;
+    const variant = APPLICATION_STATUS_BADGE_VARIANT[app.status];
+    return {
+      id: app.id,
+      statusVariant: variant,
+      sentence: `${applicantLabel} applied for ${app.position.title}`,
+      timestamp: app.submittedAt,
+    };
+  });
+
+  return (
+    <ActivityFeedList
+      items={items}
+      emptyDescription="New applications across all positions will show up here."
+    />
+  );
+}
+
+// ─── Shared skeleton ─────────────────────────────────────────────────────────
+
+export function ActivityFeedSkeleton() {
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="border-b p-4">
+        <div className="bg-muted h-5 w-32 animate-pulse rounded" />
+      </CardHeader>
+      <CardContent className="p-0">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 border-b px-4 py-3 last:border-0"
+          >
+            <div className="bg-muted size-2 shrink-0 animate-pulse rounded-full" />
+            <div className="bg-muted h-4 flex-1 animate-pulse rounded" />
+            <div className="bg-muted h-3 w-12 animate-pulse rounded" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/activity-feed.tsx
+++ b/components/features/activity-feed.tsx
@@ -1,7 +1,9 @@
 import { Activity } from 'lucide-react';
 
-import { getMyRecentActivity } from '@/prisma/data/applications';
-import { getRecentApplications } from '@/prisma/data/applications';
+import {
+  getMyRecentActivity,
+  getRecentApplications,
+} from '@/prisma/data/applications';
 
 import {
   APPLICATION_STATUS_BADGE_VARIANT,
@@ -22,56 +24,60 @@ interface ActivityFeedListProps {
 
 function ActivityFeedList({ items, emptyDescription }: ActivityFeedListProps) {
   return (
-    <Card className="gap-0 p-0">
-      <CardHeader className="border-b p-4">
-        <CardTitle className="text-base font-semibold">
-          Recent activity
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="p-0">
-        {items.length === 0 ? (
-          <div className="flex flex-col items-center gap-2 py-10 text-center">
-            <Activity
-              className="text-muted-foreground size-10"
-              aria-hidden="true"
-            />
-            <p className="text-sm font-medium">No recent activity</p>
-            <p className="text-muted-foreground text-sm">{emptyDescription}</p>
-          </div>
-        ) : (
-          <ol>
-            {items.map((item) => {
-              const dotClass =
-                STATUS_BADGE_VARIANT_TO_DOT[item.statusVariant] ??
-                'bg-muted-foreground';
-              const isoString = item.timestamp.toISOString();
-              const relativeTime = formatRelativeTime(item.timestamp);
+    <section aria-label="Recent activity">
+      <Card className="gap-0 p-0">
+        <CardHeader className="border-b p-4">
+          <CardTitle className="text-base font-semibold">
+            Recent activity
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {items.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-center">
+              <Activity
+                className="text-muted-foreground size-10"
+                aria-hidden="true"
+              />
+              <p className="text-sm font-medium">No recent activity</p>
+              <p className="text-muted-foreground text-sm">
+                {emptyDescription}
+              </p>
+            </div>
+          ) : (
+            <ol>
+              {items.map((item) => {
+                const dotClass =
+                  STATUS_BADGE_VARIANT_TO_DOT[item.statusVariant] ??
+                  'bg-muted-foreground';
+                const isoString = item.timestamp.toISOString();
+                const relativeTime = formatRelativeTime(item.timestamp);
 
-              return (
-                <li
-                  key={item.id}
-                  className="flex items-start gap-3 border-b px-4 py-3 last:border-0"
-                >
-                  <span
-                    className={`mt-1.5 size-2 shrink-0 rounded-full ${dotClass}`}
-                    aria-hidden="true"
-                  />
-                  <p className="line-clamp-2 min-w-0 flex-1 text-sm">
-                    {item.sentence}
-                  </p>
-                  <time
-                    dateTime={isoString}
-                    className="text-muted-foreground ml-auto shrink-0 text-xs tabular-nums"
+                return (
+                  <li
+                    key={item.id}
+                    className="flex items-start gap-3 border-b px-4 py-3 last:border-0"
                   >
-                    {relativeTime}
-                  </time>
-                </li>
-              );
-            })}
-          </ol>
-        )}
-      </CardContent>
-    </Card>
+                    <span
+                      className={`mt-1.5 size-2 shrink-0 rounded-full ${dotClass}`}
+                      aria-hidden="true"
+                    />
+                    <p className="line-clamp-2 min-w-0 flex-1 text-sm">
+                      {item.sentence}
+                    </p>
+                    <time
+                      dateTime={isoString}
+                      className="text-muted-foreground ml-auto shrink-0 text-xs tabular-nums"
+                    >
+                      {relativeTime}
+                    </time>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+    </section>
   );
 }
 
@@ -144,7 +150,7 @@ export function ActivityFeedSkeleton() {
         <div className="bg-muted h-5 w-32 animate-pulse rounded" />
       </CardHeader>
       <CardContent className="p-0">
-        {Array.from({ length: 5 }).map((_, i) => (
+        {Array.from({ length: 10 }).map((_, i) => (
           <div
             key={i}
             className="flex items-center gap-3 border-b px-4 py-3 last:border-0"

--- a/components/features/admin-dashboard.tsx
+++ b/components/features/admin-dashboard.tsx
@@ -1,5 +1,9 @@
 import { Suspense } from 'react';
 
+import {
+  ActivityFeedSkeleton,
+  AdminActivityFeed,
+} from '@/components/features/activity-feed';
 import { OpenPositionsSummary } from '@/components/features/open-positions-summary';
 import { PipelineSummary } from '@/components/features/pipeline-summary';
 import { RecentApplications } from '@/components/features/recent-applications';
@@ -8,8 +12,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 function PipelineSummarySkeleton() {
   return (
-    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
-      {Array.from({ length: 6 }).map((_, i) => (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7">
+      {Array.from({ length: 7 }).map((_, i) => (
         <Card key={i} className="p-4">
           <CardContent className="p-0">
             <Skeleton className="h-3 w-20" />
@@ -31,24 +35,14 @@ function RecentApplicationsSkeleton() {
         </div>
       </CardHeader>
       <CardContent className="p-0">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="border-b px-4 py-4 last:border-0">
-            <div className="hidden grid-cols-4 gap-4 md:grid">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="h-5 w-20 rounded-md" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-            <div className="flex flex-col gap-2 md:hidden">
-              <div className="flex items-center justify-between gap-2">
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-5 w-20 rounded-md" />
-              </div>
-              <div className="flex items-center justify-between gap-2">
-                <Skeleton className="h-4 w-28" />
-                <Skeleton className="h-4 w-24" />
-              </div>
-            </div>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 border-b px-4 py-3 last:border-0"
+          >
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-5 w-20 rounded-md" />
+            <Skeleton className="h-4 w-20" />
           </div>
         ))}
       </CardContent>
@@ -66,7 +60,7 @@ function OpenPositionsSummarySkeleton() {
         </div>
       </CardHeader>
       <CardContent className="p-0">
-        {Array.from({ length: 4 }).map((_, i) => (
+        {Array.from({ length: 3 }).map((_, i) => (
           <div
             key={i}
             className="flex items-center justify-between border-b px-4 py-3 last:border-0"
@@ -95,11 +89,15 @@ export function AdminDashboard() {
       </Suspense>
 
       <Suspense fallback={<RecentApplicationsSkeleton />}>
-        <RecentApplications />
+        <RecentApplications limit={3} />
       </Suspense>
 
       <Suspense fallback={<OpenPositionsSummarySkeleton />}>
-        <OpenPositionsSummary />
+        <OpenPositionsSummary take={3} />
+      </Suspense>
+
+      <Suspense fallback={<ActivityFeedSkeleton />}>
+        <AdminActivityFeed />
       </Suspense>
     </div>
   );

--- a/components/features/applicant-summary.tsx
+++ b/components/features/applicant-summary.tsx
@@ -1,0 +1,48 @@
+import { getMySubmittedCount } from '@/prisma/data/applications';
+import { getAcceptingPositionsCount } from '@/prisma/data/positions';
+
+import { StatCard } from '@/components/features/stat-card';
+
+interface ApplicantSummaryProps {
+  userId: string;
+}
+
+// Revised per change request: applicant sees exactly 2 stat cards —
+// Submitted and Open positions. In-review/accepted cards were removed.
+export async function ApplicantSummary({ userId }: ApplicantSummaryProps) {
+  const [submitted, openPositions] = await Promise.all([
+    getMySubmittedCount(userId),
+    getAcceptingPositionsCount(),
+  ]);
+
+  return (
+    <section aria-label="Application summary">
+      {/* Stable 2-up grid at every breakpoint — no column bump needed for two items */}
+      <div className="grid grid-cols-2 gap-4">
+        <StatCard
+          label="Submitted"
+          value={submitted}
+          dotClassName="bg-primary"
+        />
+        <StatCard
+          label="Open positions"
+          value={openPositions}
+          dotClassName="bg-info"
+        />
+      </div>
+    </section>
+  );
+}
+
+export function ApplicantSummarySkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {Array.from({ length: 2 }).map((_, i) => (
+        <div key={i} className="bg-card rounded-lg border p-4">
+          <div className="bg-muted h-3 w-20 animate-pulse rounded" />
+          <div className="bg-muted mt-2 h-8 w-12 animate-pulse rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/features/my-applications-widget.tsx
+++ b/components/features/my-applications-widget.tsx
@@ -13,17 +13,10 @@ import { formatDate } from '@/lib/utils';
 
 import { ApplicationStatusBadge } from '@/components/features/status-badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 
 interface MyApplicationsWidgetProps {
   userId: string;
+  limit?: number;
 }
 
 function buildCountsSummary(counts: Partial<Record<string, number>>): string {
@@ -58,9 +51,10 @@ function buildCountsSummary(counts: Partial<Record<string, number>>): string {
 
 export async function MyApplicationsWidget({
   userId,
+  limit = 3,
 }: MyApplicationsWidgetProps) {
   const [applications, counts] = await Promise.all([
-    getRecentMyApplications(userId),
+    getRecentMyApplications(userId, limit),
     getMyApplicationStatusCounts(userId),
   ]);
 
@@ -81,9 +75,10 @@ export async function MyApplicationsWidget({
           </div>
           <Link
             href="/my-applications"
+            aria-label="See all applications"
             className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
           >
-            View all
+            See all
             <ArrowRight className="size-3.5" aria-hidden="true" />
           </Link>
         </div>
@@ -103,47 +98,37 @@ export async function MyApplicationsWidget({
             </Link>
           </div>
         ) : (
-          <CompactApplicationTable applications={applications} />
+          <ApplicationList applications={applications} />
         )}
       </CardContent>
     </Card>
   );
 }
 
-function CompactApplicationTable({
+function ApplicationList({
   applications,
 }: {
   applications: MyApplicationListItem[];
 }) {
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Position</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>Applied</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {applications.map((app) => (
-          <TableRow key={app.id}>
-            <TableCell>
-              <Link
-                href={`/positions/${app.positionId}`}
-                className="font-medium hover:underline"
-              >
-                {app.position.title}
-              </Link>
-            </TableCell>
-            <TableCell>
-              <ApplicationStatusBadge status={app.status} />
-            </TableCell>
-            <TableCell className="text-muted-foreground">
-              {app.status === 'draft' ? '—' : formatDate(app.submittedAt)}
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+    <ul className="divide-y">
+      {applications.map((app) => (
+        <li
+          key={app.id}
+          className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3"
+        >
+          <Link
+            href={`/positions/${app.positionId}`}
+            className="min-w-0 flex-1 truncate text-sm font-medium hover:underline"
+          >
+            {app.position.title}
+          </Link>
+          <ApplicationStatusBadge status={app.status} />
+          <span className="text-muted-foreground shrink-0 text-xs">
+            {app.status === 'draft' ? '—' : formatDate(app.submittedAt)}
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/components/features/open-positions-summary.tsx
+++ b/components/features/open-positions-summary.tsx
@@ -8,8 +8,14 @@ import { type OpenPositionSummaryItem } from '@/lib/types';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
-export async function OpenPositionsSummary() {
-  const positions = await getOpenPositionsSummary();
+interface OpenPositionsSummaryProps {
+  take?: number;
+}
+
+export async function OpenPositionsSummary({
+  take = 3,
+}: OpenPositionsSummaryProps) {
+  const positions = await getOpenPositionsSummary(take);
 
   return (
     <Card className="gap-0 p-0">
@@ -20,9 +26,10 @@ export async function OpenPositionsSummary() {
           </CardTitle>
           <Link
             href="/positions"
+            aria-label="See all positions"
             className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
           >
-            View all
+            See all
             <ArrowRight className="size-3.5" aria-hidden="true" />
           </Link>
         </div>

--- a/components/features/open-positions-widget.tsx
+++ b/components/features/open-positions-widget.tsx
@@ -9,11 +9,17 @@ import { formatDate, getPositionAvailability } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
-export async function OpenPositionsWidget() {
+interface OpenPositionsWidgetProps {
+  limit?: number;
+}
+
+export async function OpenPositionsWidget({
+  limit = 3,
+}: OpenPositionsWidgetProps) {
   // getOpenPositions returns only open positions; does not surface a manager's
   // draft/closed positions in this "Open Positions" widget context.
   const positions = await getOpenPositions();
-  const displayed = positions.slice(0, 5);
+  const displayed = positions.slice(0, limit);
 
   return (
     <Card className="gap-0 p-0">
@@ -24,9 +30,10 @@ export async function OpenPositionsWidget() {
           </CardTitle>
           <Link
             href="/positions"
+            aria-label="See all positions"
             className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
           >
-            View all
+            See all
             <ArrowRight className="size-3.5" aria-hidden="true" />
           </Link>
         </div>

--- a/components/features/pipeline-summary.tsx
+++ b/components/features/pipeline-summary.tsx
@@ -31,7 +31,7 @@ export async function PipelineSummary() {
           No applications submitted yet.
         </p>
       )}
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-7">
         {/* Leading "Total" card — sum of all non-draft pipeline statuses */}
         <StatCard label="Total" value={total} dotClassName="bg-primary" />
 

--- a/components/features/pipeline-summary.tsx
+++ b/components/features/pipeline-summary.tsx
@@ -4,9 +4,10 @@ import { getApplicationStatusCounts } from '@/prisma/data/applications';
 import {
   APPLICATION_STATUS_BADGE_VARIANT,
   APPLICATION_STATUS_LABELS,
+  STATUS_BADGE_VARIANT_TO_DOT,
 } from '@/lib/constants';
 
-import { Card, CardContent } from '@/components/ui/card';
+import { StatCard } from '@/components/features/stat-card';
 
 // Statuses surfaced in the pipeline summary (excludes draft).
 const PIPELINE_STATUSES = [
@@ -17,17 +18,6 @@ const PIPELINE_STATUSES = [
   $Enums.ApplicationStatus.accepted,
   $Enums.ApplicationStatus.rejected,
 ] as const;
-
-// Map badge variant to a design-token dot color for stat card accents.
-const BADGE_VARIANT_TO_DOT: Record<string, string> = {
-  info: 'bg-info',
-  warning: 'bg-warning',
-  success: 'bg-success',
-  destructive: 'bg-destructive',
-  secondary: 'bg-muted-foreground',
-  default: 'bg-primary',
-  outline: 'bg-border',
-};
 
 export async function PipelineSummary() {
   const counts = await getApplicationStatusCounts();
@@ -41,30 +31,23 @@ export async function PipelineSummary() {
           No applications submitted yet.
         </p>
       )}
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7">
+        {/* Leading "Total" card — sum of all non-draft pipeline statuses */}
+        <StatCard label="Total" value={total} dotClassName="bg-primary" />
+
         {PIPELINE_STATUSES.map((status) => {
           const count = counts[status] ?? 0;
           const variant = APPLICATION_STATUS_BADGE_VARIANT[status];
           const dotClass =
-            BADGE_VARIANT_TO_DOT[variant] ?? 'bg-muted-foreground';
+            STATUS_BADGE_VARIANT_TO_DOT[variant] ?? 'bg-muted-foreground';
 
           return (
-            <Card key={status} className="p-4">
-              <CardContent className="p-0">
-                <div className="flex items-center gap-1.5">
-                  <span
-                    className={`size-2 shrink-0 rounded-full ${dotClass}`}
-                    aria-hidden="true"
-                  />
-                  <p className="text-muted-foreground text-xs">
-                    {APPLICATION_STATUS_LABELS[status]}
-                  </p>
-                </div>
-                <p className="mt-2 text-2xl font-semibold tabular-nums">
-                  {count}
-                </p>
-              </CardContent>
-            </Card>
+            <StatCard
+              key={status}
+              label={APPLICATION_STATUS_LABELS[status]}
+              value={count}
+              dotClassName={dotClass}
+            />
           );
         })}
       </div>

--- a/components/features/recent-applications.tsx
+++ b/components/features/recent-applications.tsx
@@ -9,17 +9,15 @@ import { formatDate } from '@/lib/utils';
 
 import { ApplicationStatusBadge } from '@/components/features/status-badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 
-export async function RecentApplications() {
-  const applications = await getRecentApplications();
+interface RecentApplicationsProps {
+  limit?: number;
+}
+
+export async function RecentApplications({
+  limit = 3,
+}: RecentApplicationsProps) {
+  const applications = await getRecentApplications(limit);
 
   return (
     // overflow-hidden clips the header hover highlight to the card's rounded corners
@@ -31,9 +29,10 @@ export async function RecentApplications() {
           </CardTitle>
           <Link
             href="/applications"
+            aria-label="See all applications"
             className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
           >
-            View all
+            See all
             <ArrowRight className="size-3.5" aria-hidden="true" />
           </Link>
         </div>
@@ -54,87 +53,43 @@ export async function RecentApplications() {
             </div>
           </div>
         ) : (
-          <>
-            {/* Desktop table */}
-            <div className="hidden md:block">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Applicant</TableHead>
-                    <TableHead>Position</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Applied</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {applications.map((app) => (
-                    <ApplicationRow key={app.id} app={app} />
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-
-            {/* Mobile stacked cards */}
-            <div className="flex flex-col divide-y md:hidden">
-              {applications.map((app) => (
-                <ApplicationCard key={app.id} app={app} />
-              ))}
-            </div>
-          </>
+          <ApplicationList applications={applications} />
         )}
       </CardContent>
     </Card>
   );
 }
 
-function ApplicationRow({ app }: { app: AdminApplicationListItem }) {
-  const applicantLabel = app.user.name ?? app.user.email;
-
+function ApplicationList({
+  applications,
+}: {
+  applications: AdminApplicationListItem[];
+}) {
   return (
-    <TableRow>
-      <TableCell>
-        <Link
-          href={`/applications/${app.id}`}
-          className="font-medium hover:underline"
-        >
-          {applicantLabel}
-        </Link>
-      </TableCell>
-      <TableCell className="text-muted-foreground">
-        {app.position.title}
-      </TableCell>
-      <TableCell>
-        <ApplicationStatusBadge status={app.status} />
-      </TableCell>
-      <TableCell className="text-muted-foreground">
-        {formatDate(app.submittedAt)}
-      </TableCell>
-    </TableRow>
-  );
-}
-
-function ApplicationCard({ app }: { app: AdminApplicationListItem }) {
-  const applicantLabel = app.user.name ?? app.user.email;
-
-  return (
-    <div className="flex flex-col gap-2 p-4">
-      <div className="flex items-center justify-between gap-2">
-        <Link
-          href={`/applications/${app.id}`}
-          className="font-medium hover:underline"
-        >
-          {applicantLabel}
-        </Link>
-        <ApplicationStatusBadge status={app.status} />
-      </div>
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-muted-foreground text-sm">
-          {app.position.title}
-        </span>
-        <span className="text-muted-foreground text-sm">
-          {formatDate(app.submittedAt)}
-        </span>
-      </div>
-    </div>
+    <ul className="divide-y">
+      {applications.map((app) => {
+        const applicantLabel = app.user.name ?? app.user.email;
+        return (
+          <li
+            key={app.id}
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3"
+          >
+            <Link
+              href={`/applications/${app.id}`}
+              className="min-w-0 flex-1 truncate text-sm font-medium hover:underline"
+            >
+              {applicantLabel}
+            </Link>
+            <span className="text-muted-foreground hidden shrink-0 text-xs sm:inline">
+              {app.position.title}
+            </span>
+            <ApplicationStatusBadge status={app.status} />
+            <span className="text-muted-foreground shrink-0 text-xs">
+              {formatDate(app.submittedAt)}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/components/features/recent-applications.tsx
+++ b/components/features/recent-applications.tsx
@@ -80,7 +80,7 @@ function ApplicationList({
             >
               {applicantLabel}
             </Link>
-            <span className="text-muted-foreground hidden shrink-0 text-xs sm:inline">
+            <span className="text-muted-foreground shrink-0 text-xs">
               {app.position.title}
             </span>
             <ApplicationStatusBadge status={app.status} />

--- a/components/features/stat-card.tsx
+++ b/components/features/stat-card.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent } from '@/components/ui/card';
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  dotClassName: string;
+}
+
+// Presentational stat card used by PipelineSummary (admin) and ApplicantSummary.
+// Server-safe — no 'use client' needed.
+export function StatCard({ label, value, dotClassName }: StatCardProps) {
+  return (
+    <Card className="p-4">
+      <CardContent className="p-0">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`size-2 shrink-0 rounded-full ${dotClassName}`}
+            aria-hidden="true"
+          />
+          <p className="text-muted-foreground text-xs">{label}</p>
+        </div>
+        <p className="mt-2 text-2xl font-semibold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/user-dashboard.tsx
+++ b/components/features/user-dashboard.tsx
@@ -1,5 +1,13 @@
 import { Suspense } from 'react';
 
+import {
+  ActivityFeedSkeleton,
+  ApplicantActivityFeed,
+} from '@/components/features/activity-feed';
+import {
+  ApplicantSummary,
+  ApplicantSummarySkeleton,
+} from '@/components/features/applicant-summary';
 import { MyApplicationsWidget } from '@/components/features/my-applications-widget';
 import { OpenPositionsWidget } from '@/components/features/open-positions-widget';
 import { ProfileCompletenessBanner } from '@/components/features/profile-completeness-banner';
@@ -25,12 +33,13 @@ function MyApplicationsWidgetSkeleton() {
       </CardHeader>
       <CardContent className="p-0">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="border-b px-4 py-3 last:border-0">
-            <div className="grid grid-cols-3 gap-4">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-5 w-20 rounded-md" />
-              <Skeleton className="h-4 w-24" />
-            </div>
+          <div
+            key={i}
+            className="flex items-center gap-3 border-b px-4 py-3 last:border-0"
+          >
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-5 w-20 rounded-md" />
+            <Skeleton className="h-4 w-20" />
           </div>
         ))}
       </CardContent>
@@ -82,12 +91,20 @@ export function UserDashboard({ userId, userName }: UserDashboardProps) {
         <ProfileCompletenessBanner userId={userId} />
       </Suspense>
 
+      <Suspense fallback={<ApplicantSummarySkeleton />}>
+        <ApplicantSummary userId={userId} />
+      </Suspense>
+
       <Suspense fallback={<MyApplicationsWidgetSkeleton />}>
-        <MyApplicationsWidget userId={userId} />
+        <MyApplicationsWidget userId={userId} limit={3} />
       </Suspense>
 
       <Suspense fallback={<OpenPositionsWidgetSkeleton />}>
-        <OpenPositionsWidget />
+        <OpenPositionsWidget limit={3} />
+      </Suspense>
+
+      <Suspense fallback={<ActivityFeedSkeleton />}>
+        <ApplicantActivityFeed userId={userId} />
       </Suspense>
     </div>
   );

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -165,6 +165,11 @@ export const AVAILABILITY_VARIANTS: Record<PositionAvailability, BadgeVariant> =
     unavailable: 'outline',
   };
 
+// Public URLs for the legal pages — referenced from the login footer, app footer,
+// and each legal page's cross-link footer. One edit when the URLs change.
+export const PRIVACY_HREF = '/privacy';
+export const TERMS_HREF = '/terms';
+
 // Maps badge variant to a design-token dot color used in stat cards and the
 // activity feed. Extracted from pipeline-summary.tsx so both consumers share
 // one source of truth (ENGINEERING §1: abstract at 2+).

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -165,7 +165,15 @@ export const AVAILABILITY_VARIANTS: Record<PositionAvailability, BadgeVariant> =
     unavailable: 'outline',
   };
 
-// Public URLs for the legal pages — referenced from the login footer, app footer,
-// and each legal page's cross-link footer. One edit when the URLs change.
-export const PRIVACY_HREF = '/privacy';
-export const TERMS_HREF = '/terms';
+// Maps badge variant to a design-token dot color used in stat cards and the
+// activity feed. Extracted from pipeline-summary.tsx so both consumers share
+// one source of truth (ENGINEERING §1: abstract at 2+).
+export const STATUS_BADGE_VARIANT_TO_DOT: Record<string, string> = {
+  info: 'bg-info',
+  warning: 'bg-warning',
+  success: 'bg-success',
+  destructive: 'bg-destructive',
+  secondary: 'bg-muted-foreground',
+  default: 'bg-primary',
+  outline: 'bg-border',
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,6 +9,8 @@ import type { Prisma } from '@/prisma/client';
 
 import type { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
 
+import type { BadgeVariant } from '@/components/ui/badge';
+
 export type PositionWithQuestions = {
   id: string;
   title: string;
@@ -205,7 +207,7 @@ export type ApplicationForReview = Prisma.ApplicationGetPayload<{
 // statusVariant drives the dot color; sentence is pre-rendered safe copy.
 export type ActivityItem = {
   id: string;
-  statusVariant: string;
+  statusVariant: BadgeVariant;
   sentence: string;
   timestamp: Date;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -200,6 +200,16 @@ export type ApplicationForReview = Prisma.ApplicationGetPayload<{
   };
 }>;
 
+// Activity feed item — role-agnostic shape produced by the applicant/admin
+// feed wrappers and consumed by the shared ActivityFeedList leaf.
+// statusVariant drives the dot color; sentence is pre-rendered safe copy.
+export type ActivityItem = {
+  id: string;
+  statusVariant: string;
+  sentence: string;
+  timestamp: Date;
+};
+
 // Identity shape passed to nav components so sidebar and mobile nav agree
 // on what to display in the user menu.
 export interface NavIdentity {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,6 +35,26 @@ export function formatDate(date: Date): string {
 }
 
 /**
+ * Returns a human-readable relative time string for a past date.
+ * Rules: <1 min → "Just now"; <60 min → "Nm ago"; <24 h → "Nh ago";
+ * <7 d → "Nd ago"; otherwise falls back to formatDate.
+ * `now` is injectable for deterministic testing.
+ */
+export function formatRelativeTime(date: Date, now: Date = new Date()): string {
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return formatDate(date);
+}
+
+/**
  * Derives the applicant-facing availability of a position.
  *
  * Date semantics (important — positions use date-only inputs):

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -271,6 +271,28 @@ export async function getApplications(
   });
 }
 
+// Applicant-scoped: count of non-draft applications for the stat card.
+// Uses a direct count rather than re-fetching the full groupBy result to keep it cheap.
+export async function getMySubmittedCount(userId: string): Promise<number> {
+  return prisma.application.count({
+    where: { userId, deletedAt: null, status: { not: 'draft' } },
+  });
+}
+
+// Applicant-scoped: most recent non-draft applications ordered by last update,
+// used for the applicant activity feed. Reuses applicationSelect which includes updatedAt.
+export async function getMyRecentActivity(
+  userId: string,
+  take = 10,
+): Promise<MyApplicationListItem[]> {
+  return prisma.application.findMany({
+    where: { userId, deletedAt: null, status: { not: 'draft' } },
+    select: applicationSelect,
+    orderBy: { updatedAt: 'desc' },
+    take,
+  });
+}
+
 // Returns positions the caller may review — used to populate the Position filter
 // Select on /applications. Admins see all non-deleted; managers see their positions.
 export async function getReviewablePositions(user: {

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -131,9 +131,10 @@ export async function getPositionAccess(
 
 // Admin-only: open positions with filtered non-draft application counts in a single query.
 // Returns cross-position data — must only be called from an admin-gated context.
-export async function getOpenPositionsSummary(): Promise<
-  OpenPositionSummaryItem[]
-> {
+// Optional `take` limits the result set; pass 3 for the compact dashboard widget.
+export async function getOpenPositionsSummary(
+  take?: number,
+): Promise<OpenPositionSummaryItem[]> {
   return prisma.position.findMany({
     where: { status: 'open', deletedAt: null },
     select: {
@@ -148,6 +149,7 @@ export async function getOpenPositionsSummary(): Promise<
       },
     },
     orderBy: { title: 'asc' },
+    ...(take !== undefined ? { take } : {}),
   });
 }
 
@@ -180,6 +182,18 @@ export async function getPositionDetail(
       managers: { select: { id: true } },
     },
   });
+}
+
+// Applicant-facing: count of positions currently accepting applications
+// (status open AND inside the date window). Date-window logic is delegated to
+// isAcceptingApplications to stay in sync with getPositionAvailability — a pure
+// DB count({ where: { status: 'open' } }) would include upcoming/closed-by-date.
+export async function getAcceptingPositionsCount(): Promise<number> {
+  const positions = await prisma.position.findMany({
+    where: { status: 'open', deletedAt: null },
+    select: { status: true, opensAt: true, closesAt: true },
+  });
+  return positions.filter((p) => isAcceptingApplications(p)).length;
 }
 
 export async function getPositionForEdit(


### PR DESCRIPTION
Closes #177

## Summary

- Adds stat cards to both the applicant dashboard (Submitted + Open positions) and the admin dashboard (Total + 6 per-status cards) so the home page provides immediate value instead of duplicating list pages
- Replaces full tables in `RecentApplications` and `MyApplicationsWidget` with compact 3-row stacked lists; caps all four widgets at 3 items with "See all" links
- Adds a "Recent activity" feed to both dashboards (derived from `updatedAt`/`submittedAt` per the schema-constraint design in the plan)

## Changes

- `lib/constants.ts` — extracted `STATUS_BADGE_VARIANT_TO_DOT` from `pipeline-summary.tsx` (shared by stat cards + activity feed)
- `lib/types.ts` — added `ActivityItem` type for the feed leaf
- `lib/utils.ts` — added `formatRelativeTime` (compact relative timestamps: "Just now" / "Nm ago" / "Nh ago" / "Nd ago" / `formatDate` fallback)
- `components/features/stat-card.tsx` (new) — presentational `StatCard` leaf used by both dashboards
- `components/features/applicant-summary.tsx` (new) — `ApplicantSummary` server component (Submitted + Open positions stat cards) + `ApplicantSummarySkeleton`
- `components/features/activity-feed.tsx` (new) — `ActivityFeedList` leaf + `ApplicantActivityFeed` + `AdminActivityFeed` wrappers + `ActivityFeedSkeleton`
- `components/features/pipeline-summary.tsx` — switched to `StatCard`, imported dot map from constants, added leading "Total" card, updated grid to `grid-cols-2 md:grid-cols-4 lg:grid-cols-7`
- `prisma/data/applications.ts` — added `getMySubmittedCount` and `getMyRecentActivity`
- `prisma/data/positions.ts` — added `getAcceptingPositionsCount` (date-window aware); added optional `take` to `getOpenPositionsSummary`
- `components/features/my-applications-widget.tsx` — dropped `Table`, compact stacked list, capped to 3, "See all" + `aria-label`
- `components/features/open-positions-widget.tsx` — capped to 3, "See all" + `aria-label`
- `components/features/recent-applications.tsx` — replaced desktop table + mobile cards with single stacked list, capped to 3, "See all" + `aria-label`
- `components/features/open-positions-summary.tsx` — capped to 3 via `take`, "See all" + `aria-label`
- `components/features/admin-dashboard.tsx` — added `AdminActivityFeed` as bottom section; updated skeletons to 3-row stacked layout + 7-card pipeline grid
- `components/features/user-dashboard.tsx` — added `ApplicantSummary` (after banner) and `ApplicantActivityFeed` (bottom); updated widget skeletons to match compact list layout

## Testing plan

**Applicant dashboard**
- [ ] Sign in as an applicant with several applications spanning statuses. Visit `/`.
- [ ] Confirm exactly 2 stat cards appear — "Submitted" and "Open positions" — with no "In review" or "Accepted" card.
- [ ] Cross-check Submitted count against the non-draft applications in `/my-applications`; cross-check Open positions count against `/positions`.
- [ ] Confirm "My Applications" widget shows at most 3 rows (compact list, no table header), each with position link, status badge, applied date; "See all" link goes to `/my-applications`.
- [ ] Confirm "Open Positions" widget shows at most 3 rows; "See all" goes to `/positions`.
- [ ] Confirm "Recent activity" feed shows up to 10 of the signed-in user's applications, newest by `updatedAt` first, copy reads "Your application for {title} is {Status}"; no links or buttons inside rows.
- [ ] Sign in as a brand-new applicant: Submitted = 0, Open positions = live count; widgets show empty states; feed shows empty state.
- [ ] As applicant with only drafts: Submitted = 0; feed shows empty state (drafts excluded); my-applications widget still lists the draft with "—" date.

**Admin dashboard**
- [ ] Sign in as admin. Visit `/`.
- [ ] Confirm 7 stat cards: "Total" (non-draft) + 6 per-status cards; counts match `/applications`.
- [ ] Confirm "Recent Applications" widget shows at most 3 rows as a compact list (no full table), each linking to `/applications/{id}`; "See all" goes to `/applications`.
- [ ] Confirm "Open Positions" widget shows at most 3 rows; "See all" goes to `/positions`.
- [ ] Confirm "Recent activity" shows up to 10 newest non-draft applications across all positions, copy reads "{Applicant} applied for {title}"; read-only.
- [ ] On a fresh instance with no applications: Total + status cards = 0, "No applications submitted yet" helper visible; widgets + feed show empty states.

**Cross-cutting**
- [ ] Resize to 375px, 768px, 1280px: applicant stat row stays 2-up; admin stat grid reflows (2-up → 4 → 7-up); no horizontal scroll.
- [ ] Toggle dark mode: surfaces, dots, and badges use tokens only (no hardcoded colors).
- [ ] Keyboard: tab through "See all" links shows visible focus rings; each announces its destination via `aria-label`; feed rows are non-interactive (not focusable).
- [ ] Confirm no full-length table duplicating a list page on either dashboard.
- [ ] Loading skeletons appear for each section on a throttled connection and match the resolved layout.
- [ ] `npm run prettier:check && npm run eslint:check && npm run tsc:check` all pass.

## Automated checks

- `npm run tsc:check` — pass
- `npm run eslint:check` — pass
- `npm run prettier:check` — pass

## Notes

The activity feed is a derived "latest state" stream, not an event log — the schema has no `ApplicationStatusEvent` table (see issue §0). Applicant copy describes current status ("is {Status}") without asserting a prior state; admin copy uses `submittedAt` which is a provable "applied" event. A true audit timeline is noted as a follow-up in the issue.
