### PR TITLE
#77 User Management

### DIFF
--- a/app/(main)/(auth)/users/loading.tsx
+++ b/app/(main)/(auth)/users/loading.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function UsersLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header skeleton */}
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-7 w-24" />
+        <Skeleton className="h-4 w-14" />
+      </div>
+
+      {/* Search input skeleton */}
+      <Skeleton className="h-9 w-64" />
+
+      {/* Table skeleton */}
+      <div className="rounded-lg border">
+        {/* Table header */}
+        <div className="border-b px-4 py-3">
+          <div className="flex items-center gap-8">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-14" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="ml-auto h-4 w-16" />
+          </div>
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-8 border-b px-4 py-4 last:border-b-0"
+          >
+            <div className="flex flex-col gap-1">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-44" />
+            </div>
+            <Skeleton className="h-5 w-12" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-8" />
+            <div className="ml-auto flex gap-2">
+              <Skeleton className="h-8 w-24" />
+              <Skeleton className="h-8 w-20" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/(auth)/users/loading.tsx
+++ b/app/(main)/(auth)/users/loading.tsx
@@ -21,6 +21,7 @@ export default function UsersLoading() {
             <Skeleton className="h-4 w-16" />
             <Skeleton className="h-4 w-14" />
             <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-28" />
             <Skeleton className="ml-auto h-4 w-16" />
           </div>
         </div>
@@ -36,6 +37,9 @@ export default function UsersLoading() {
             <Skeleton className="h-5 w-12" />
             <Skeleton className="h-4 w-20" />
             <Skeleton className="h-4 w-8" />
+            <div className="flex gap-1">
+              <Skeleton className="h-5 w-20" />
+            </div>
             <div className="ml-auto flex gap-2">
               <Skeleton className="h-8 w-24" />
               <Skeleton className="h-8 w-20" />

--- a/app/(main)/(auth)/users/page.tsx
+++ b/app/(main)/(auth)/users/page.tsx
@@ -1,7 +1,26 @@
-export default function UsersPage() {
+import { redirect } from 'next/navigation';
+
+import { getUsersForAdmin } from '@/prisma/data/users';
+
+import { getCurrentUser } from '@/lib/auth/server';
+
+import { UsersTable } from '@/components/features/users-table';
+import { PageHeader } from '@/components/layouts/page-header';
+
+export default async function UsersPage() {
+  const user = await getCurrentUser();
+  if (!user.isAdmin) redirect('/');
+
+  const users = await getUsersForAdmin();
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Users"
+        description={`${users.length} ${users.length === 1 ? 'user' : 'users'}`}
+      />
+
+      <UsersTable users={users} currentUserId={user.id} />
     </div>
   );
 }

--- a/components/features/users-table.tsx
+++ b/components/features/users-table.tsx
@@ -44,7 +44,8 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
   const [confirmDeactivateId, setConfirmDeactivateId] = useState<string | null>(
     null,
   );
-  const [pendingToggleId, setPendingToggleId] = useState<string | null>(null);
+  const [togglingAdminId, setTogglingAdminId] = useState<string | null>(null);
+  const [, startToggleTransition] = useTransition();
   const [isPendingDeactivate, startDeactivateTransition] = useTransition();
 
   const q = query.trim().toLowerCase();
@@ -56,20 +57,22 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
       )
     : users;
 
-  async function handleToggleAdmin(userId: string, makeAdmin: boolean) {
-    setPendingToggleId(userId);
-    try {
-      const result = await toggleUserAdmin({ userId, makeAdmin });
-      if (result?.error) {
-        toast.error(result.error);
-        return;
+  function handleToggleAdmin(userId: string, makeAdmin: boolean) {
+    setTogglingAdminId(userId);
+    startToggleTransition(async () => {
+      try {
+        const result = await toggleUserAdmin({ userId, makeAdmin });
+        if (result?.error) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(makeAdmin ? 'User promoted to admin.' : 'Admin removed.');
+      } catch {
+        toast.error('Something went wrong. Please try again.');
+      } finally {
+        setTogglingAdminId(null);
       }
-      toast.success(makeAdmin ? 'User promoted to admin.' : 'Admin removed.');
-    } catch {
-      toast.error('Something went wrong. Please try again.');
-    } finally {
-      setPendingToggleId(null);
-    }
+    });
   }
 
   function handleDeactivateConfirm() {
@@ -86,7 +89,6 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
         setConfirmDeactivateId(null);
       } catch {
         toast.error('Something went wrong. Please try again.');
-        setConfirmDeactivateId(null);
       }
     });
   }
@@ -111,7 +113,6 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             className="max-w-sm"
-            aria-label="Search users by name or email"
           />
         </div>
 
@@ -141,7 +142,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                   const isSelf = user.id === currentUserId;
                   const isManager = user._count.managedPositions > 0;
                   const appCount = user._count.applications;
-                  const isTogglingAdmin = pendingToggleId === user.id;
+                  const isTogglingAdmin = togglingAdminId === user.id;
 
                   return (
                     <TableRow key={user.id}>

--- a/components/features/users-table.tsx
+++ b/components/features/users-table.tsx
@@ -124,6 +124,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                 <TableHead>Roles</TableHead>
                 <TableHead>Joined</TableHead>
                 <TableHead>Applications</TableHead>
+                <TableHead>Managed Positions</TableHead>
                 <TableHead>Actions</TableHead>
               </TableRow>
             </TableHeader>
@@ -131,7 +132,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
               {filtered.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={5}
+                    colSpan={6}
                     className="text-muted-foreground text-center"
                   >
                     No users match your search.
@@ -140,7 +141,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
               ) : (
                 filtered.map((user) => {
                   const isSelf = user.id === currentUserId;
-                  const isManager = user._count.managedPositions > 0;
+                  const isManager = user.managedPositions.length > 0;
                   const appCount = user._count.applications;
                   const isTogglingAdmin = togglingAdminId === user.id;
 
@@ -189,7 +190,25 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                         )}
                       </TableCell>
                       <TableCell>
-                        <div className="flex flex-wrap gap-2">
+                        {isManager ? (
+                          <div className="flex flex-wrap gap-1">
+                            {user.managedPositions.slice(0, 2).map((pos) => (
+                              <Badge key={pos.id} variant="outline">
+                                {pos.title}
+                              </Badge>
+                            ))}
+                            {user.managedPositions.length > 2 && (
+                              <Badge variant="outline">
+                                +{user.managedPositions.length - 2} more
+                              </Badge>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex flex-wrap justify-end gap-2">
                           <Button
                             variant="outline"
                             size="sm"

--- a/components/features/users-table.tsx
+++ b/components/features/users-table.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, useTransition } from 'react';
+
+import { Users } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { deactivateUser, toggleUserAdmin } from '@/prisma/actions/users';
+
+import type { AdminUserListItem } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface UsersTableProps {
+  users: AdminUserListItem[];
+  currentUserId: string;
+}
+
+export function UsersTable({ users, currentUserId }: UsersTableProps) {
+  const [query, setQuery] = useState('');
+  const [confirmDeactivateId, setConfirmDeactivateId] = useState<string | null>(
+    null,
+  );
+  const [pendingToggleId, setPendingToggleId] = useState<string | null>(null);
+  const [isPendingDeactivate, startDeactivateTransition] = useTransition();
+
+  const q = query.trim().toLowerCase();
+  const filtered = q
+    ? users.filter(
+        (u) =>
+          (u.name ?? '').toLowerCase().includes(q) ||
+          u.email.toLowerCase().includes(q),
+      )
+    : users;
+
+  async function handleToggleAdmin(userId: string, makeAdmin: boolean) {
+    setPendingToggleId(userId);
+    try {
+      const result = await toggleUserAdmin({ userId, makeAdmin });
+      if (result?.error) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(makeAdmin ? 'User promoted to admin.' : 'Admin removed.');
+    } catch {
+      toast.error('Something went wrong. Please try again.');
+    } finally {
+      setPendingToggleId(null);
+    }
+  }
+
+  function handleDeactivateConfirm() {
+    if (!confirmDeactivateId) return;
+    const targetId = confirmDeactivateId;
+    startDeactivateTransition(async () => {
+      try {
+        const result = await deactivateUser({ userId: targetId });
+        if (result?.error) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success('User deactivated.');
+        setConfirmDeactivateId(null);
+      } catch {
+        toast.error('Something went wrong. Please try again.');
+        setConfirmDeactivateId(null);
+      }
+    });
+  }
+
+  if (users.length === 0)
+    return (
+      <EmptyState
+        icon={Users}
+        title="No users found"
+        description="Active users will appear here."
+      />
+    );
+
+  return (
+    <>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="users-search">Search</Label>
+          <Input
+            id="users-search"
+            placeholder="Search by name or email"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="max-w-sm"
+            aria-label="Search users by name or email"
+          />
+        </div>
+
+        <Card className="gap-0 p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>User</TableHead>
+                <TableHead>Roles</TableHead>
+                <TableHead>Joined</TableHead>
+                <TableHead>Applications</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={5}
+                    className="text-muted-foreground text-center"
+                  >
+                    No users match your search.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filtered.map((user) => {
+                  const isSelf = user.id === currentUserId;
+                  const isManager = user._count.managedPositions > 0;
+                  const appCount = user._count.applications;
+                  const isTogglingAdmin = pendingToggleId === user.id;
+
+                  return (
+                    <TableRow key={user.id}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium">
+                            {user.name ?? user.email}
+                          </span>
+                          {user.name && (
+                            <span className="text-muted-foreground text-xs">
+                              {user.email}
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {user.isAdmin && (
+                            <Badge variant="default">Admin</Badge>
+                          )}
+                          {isManager && (
+                            <Badge variant="secondary">Manager</Badge>
+                          )}
+                          {!user.isAdmin && !isManager && (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>{formatDate(user.createdAt)}</TableCell>
+                      <TableCell>
+                        {appCount > 0 ? (
+                          <Button
+                            variant="link"
+                            size="sm"
+                            asChild
+                            className="h-auto p-0"
+                          >
+                            <Link href={`/applications?userId=${user.id}`}>
+                              {appCount}
+                            </Link>
+                          </Button>
+                        ) : (
+                          <span className="text-muted-foreground">0</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isSelf || isTogglingAdmin}
+                            title={
+                              isSelf
+                                ? 'You cannot change your own admin role'
+                                : undefined
+                            }
+                            aria-disabled={isSelf}
+                            onClick={() =>
+                              handleToggleAdmin(user.id, !user.isAdmin)
+                            }
+                          >
+                            {isTogglingAdmin
+                              ? 'Saving…'
+                              : user.isAdmin
+                                ? 'Remove admin'
+                                : 'Make admin'}
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            disabled={isSelf}
+                            title={
+                              isSelf
+                                ? 'You cannot deactivate your own account'
+                                : undefined
+                            }
+                            aria-disabled={isSelf}
+                            onClick={() => setConfirmDeactivateId(user.id)}
+                          >
+                            Deactivate
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </Card>
+      </div>
+
+      <Dialog
+        open={!!confirmDeactivateId}
+        onOpenChange={(open) => !open && setConfirmDeactivateId(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Deactivate user?</DialogTitle>
+            <DialogDescription>
+              This will block the user from accessing the app on their next
+              request. This action cannot be undone from this page.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeactivateId(null)}
+              disabled={isPendingDeactivate}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeactivateConfirm}
+              disabled={isPendingDeactivate}
+            >
+              {isPendingDeactivate ? 'Deactivating…' : 'Deactivate'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -212,6 +212,24 @@ export type ActivityItem = {
   timestamp: Date;
 };
 
+// Admin-only type — exposes other users' identities (name/email/role/counts).
+// Must only be used in admin-gated contexts; never serialize to non-admin clients.
+export type AdminUserListItem = Prisma.UserGetPayload<{
+  select: {
+    id: true;
+    name: true;
+    email: true;
+    isAdmin: true;
+    createdAt: true;
+    _count: {
+      select: {
+        managedPositions: { where: { deletedAt: null } };
+        applications: { where: { deletedAt: null; status: { not: 'draft' } } };
+      };
+    };
+  };
+}>;
+
 // Identity shape passed to nav components so sidebar and mobile nav agree
 // on what to display in the user menu.
 export interface NavIdentity {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -221,9 +221,9 @@ export type AdminUserListItem = Prisma.UserGetPayload<{
     email: true;
     isAdmin: true;
     createdAt: true;
+    managedPositions: { select: { id: true; title: true } };
     _count: {
       select: {
-        managedPositions: { where: { deletedAt: null } };
         applications: { where: { deletedAt: null; status: { not: 'draft' } } };
       };
     };

--- a/prisma/actions/users.ts
+++ b/prisma/actions/users.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { z } from 'zod/v4';
+
+import { getCurrentUser } from '@/lib/auth/server';
+import prisma from '@/lib/prisma';
+
+const toggleAdminSchema = z.object({
+  userId: z.string().min(1),
+  makeAdmin: z.boolean(),
+});
+
+const deactivateSchema = z.object({ userId: z.string().min(1) });
+
+type ActionError = { error: string };
+
+export async function toggleUserAdmin(
+  input: unknown,
+): Promise<ActionError | void> {
+  const user = await getCurrentUser();
+  if (!user.isAdmin) return { error: 'Unauthorized' };
+
+  const parsed = toggleAdminSchema.safeParse(input);
+  if (!parsed.success) return { error: 'Invalid input' };
+
+  const { userId, makeAdmin } = parsed.data;
+
+  // An admin cannot change their own admin role — defense in depth beyond the UI guard.
+  if (userId === user.id)
+    return { error: 'You cannot change your own admin role.' };
+
+  const result = await prisma.user.updateMany({
+    where: { id: userId, deletedAt: null },
+    data: { isAdmin: makeAdmin, updatedById: user.id },
+  });
+
+  // Not reachable from the freshly-rendered admin list → unexpected → throw.
+  if (result.count === 0)
+    throw new Error('User not found or already deactivated');
+
+  revalidatePath('/users');
+}
+
+export async function deactivateUser(
+  input: unknown,
+): Promise<ActionError | void> {
+  const user = await getCurrentUser();
+  if (!user.isAdmin) return { error: 'Unauthorized' };
+
+  const parsed = deactivateSchema.safeParse(input);
+  if (!parsed.success) return { error: 'Invalid input' };
+
+  const { userId } = parsed.data;
+
+  // An admin cannot deactivate their own account — defense in depth beyond the UI guard.
+  if (userId === user.id)
+    return { error: 'You cannot deactivate your own account.' };
+
+  const result = await prisma.user.updateMany({
+    where: { id: userId, deletedAt: null },
+    data: { deletedAt: new Date(), deletedById: user.id },
+  });
+
+  // Not reachable from the freshly-rendered admin list → unexpected → throw.
+  if (result.count === 0)
+    throw new Error('User not found or already deactivated');
+
+  revalidatePath('/users');
+}

--- a/prisma/data/users.ts
+++ b/prisma/data/users.ts
@@ -14,9 +14,13 @@ export async function getUsersForAdmin(): Promise<AdminUserListItem[]> {
       email: true,
       isAdmin: true,
       createdAt: true,
+      managedPositions: {
+        where: { deletedAt: null },
+        select: { id: true, title: true },
+        orderBy: { title: 'asc' },
+      },
       _count: {
         select: {
-          managedPositions: { where: { deletedAt: null } },
           applications: {
             where: { deletedAt: null, status: { not: 'draft' } },
           },

--- a/prisma/data/users.ts
+++ b/prisma/data/users.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+import prisma from '@/lib/prisma';
+import type { AdminUserListItem } from '@/lib/types';
+
+// Returns all active (non-deactivated) users for the admin /users page.
+// Admin-only — exposes user identities; never call from a non-admin context.
+export async function getUsersForAdmin(): Promise<AdminUserListItem[]> {
+  return prisma.user.findMany({
+    where: { deletedAt: null },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      isAdmin: true,
+      createdAt: true,
+      _count: {
+        select: {
+          managedPositions: { where: { deletedAt: null } },
+          applications: {
+            where: { deletedAt: null, status: { not: 'draft' } },
+          },
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}


### PR DESCRIPTION
Closes #77

## Summary

- Adds an admin-only `/users` page for viewing, searching, promoting/demoting, and deactivating users
- Implements two server actions (`toggleUserAdmin`, `deactivateUser`) with auth checks, zod validation, self-action guards, and toast feedback
- Client-side search island filters the table by name/email with no server round-trip

## Changes

- `lib/types.ts` — add `AdminUserListItem` (Prisma payload with filtered `_count` for managed positions and non-draft applications); documented admin-only
- `prisma/data/users.ts` — new `getUsersForAdmin()` data function; single query with both relation counts, no N+1, filtered and ordered by join date
- `prisma/actions/users.ts` — new `toggleUserAdmin` and `deactivateUser` server actions; admin check, zod parse, self-guard (server-side + UI-level), scoped `updateMany`, throw on count 0, `revalidatePath('/users')`
- `components/features/users-table.tsx` — `'use client'` island with search input, shadcn `Table`, Admin/Manager badges, application-count links to `/applications?userId=<id>`, promote/demote button, deactivate button + confirm Dialog; disabled self-action buttons with explanatory titles; toasts on every action
- `app/(main)/(auth)/users/page.tsx` — replaces stub; admin gate, data fetch, page header with user count, renders `UsersTable`
- `app/(main)/(auth)/users/loading.tsx` — route-level skeleton matching the table layout for no-shift loading experience

## Testing plan

- [ ] As admin, open `/users` — page renders the table with all active users
- [ ] As applicant or manager, navigate directly to `/users` — redirected to `/`; Users nav link absent in their sidebar
- [ ] Each row shows name + email (email-only when name is null), correct Admin/Manager badges, Joined date, and application count
- [ ] Application count cell: clicking a non-zero count navigates to `/applications?userId=<id>` and shows that user's applications; a zero count shows a plain "0"
- [ ] Type part of a name in the search box — only matching rows remain; clear the input — all rows return; no network request fires (verify in devtools)
- [ ] Type a search term with no matches — table body shows "No users match your search."
- [ ] Click "Make admin" on another user's row — toast "User promoted to admin.", Admin badge appears, button flips to "Remove admin"; reload confirms persistence
- [ ] Click "Remove admin" — toast "Admin removed.", badge gone, button flips back
- [ ] On your own row, the promote/demote button is disabled with an explanatory title
- [ ] Click "Deactivate" on another user's row — confirm dialog appears; click Cancel — nothing changes; click Deactivate — toast "User deactivated.", row disappears
- [ ] On your own row, the Deactivate button is disabled with an explanatory title
- [ ] Log in as a just-deactivated user — denied access and redirected to the deactivated notice (enforcement from #153)
- [ ] Hard-reload `/users` — skeleton visible before rows paint; no layout shift on resolve
- [ ] Operate search, promote, and deactivate-confirm entirely by keyboard (Tab/Enter/Escape); visible focus rings; confirm dialog traps focus and Escape closes it
- [ ] Verify table and badges render correctly in light and dark themes; at mobile width the table scrolls horizontally

## Automated checks

- `npm run tsc:check` — passes (no type errors)
- `npm run eslint:check` — passes (0 warnings)
- `npm run prettier:check` — passes (all files formatted)

## Notes

- No schema changes — `User.isAdmin` and `User.deletedAt` already exist; Manager status is derived from the existing `PositionManagers` many-to-many relation
- Self-action guards are enforced both in the UI (disabled buttons) and server-side in both actions — the acting admin can never lock themselves out
- Deactivation enforcement (blocking `deletedAt`-set users on next request) was already implemented by #153; this ticket only provides the action that sets the field
- Client-side search ships the full active-user list to the admin client — acceptable per the ticket's "user counts are small enough" premise; server-side pagination is the documented follow-up if needed
