### PR TITLE
#188 Autonomous Rebase Conflict Resolution In Pipeline

### DIFF
--- a/.claude/agents/revise-agent.md
+++ b/.claude/agents/revise-agent.md
@@ -68,7 +68,15 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
    npm run prisma:generate
    ```
 
-   If the rebase **conflicts**: **`git rebase --abort`** and escalate — **never resolve conflicts yourself and never `git rebase --continue`**. Write the conflict description to `.temp/conflict-<pr>.md`, `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/conflict-<pr>.md`, `gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "revising" --add-label "needs human"`, and end with: `BLOCKED: rebase of <branch> onto origin/<base> conflicts in <files>; human decision needed.` (If the rebase pauses for a non-conflict reason and you must continue, use `git -c core.editor=true rebase --continue` — never an `ENV=val` prefix.)
+   If the rebase **conflicts**, follow the **Rebase conflict protocol** below — attempt autonomous resolution for structurally unambiguous conflicts, escalate only when judgment requires the original author. **Fail closed: when in doubt about any single conflict, abort the whole rebase and escalate** — never partially resolve, and never let an auto-resolve silently drop a side's logic.
+
+   **Rebase conflict protocol** (the canonical classification matrix — what is auto-resolvable vs. what must escalate — lives in `.claude/docs/PIPELINE.md` → "Rebase conflict protocol"; read it before classifying):
+
+   - **a. Never-touch short-circuit (check first).** List conflicted files with `git diff --name-only --diff-filter=U`. If **any** conflicted file is a Prisma migration (`prisma/migrations/**/*.sql`), `CLAUDE.md` or any `.claude/docs/**` file, or env/config (`.env*`, `next.config.*`), **skip classification entirely and escalate** (step e) — these are correctness- or policy-critical and never safe to auto-merge, however trivial the diff looks.
+   - **b. Inspect.** Otherwise, for each conflicted file use **Grep** (`<<<<<<<`) to find the markers and **Read** to inspect both sides of every hunk. Never `cat`/`sed`/shell-redirect.
+   - **c. Classify** every conflict against the matrix in `PIPELINE.md`. A conflict is **auto-resolvable** only when ours and theirs are in clearly separate, non-overlapping sections (e.g. each side added a different import/export), one side made a whitespace/formatting-only change in the other's area, one side deleted a block the other never touched, or it is a generated lockfile. It must **escalate** when both sides modified the same function body / expression / schema field / constant or the same lines, or when accepting one side would drop the other's logic. If **all** conflicts are auto-resolvable → step d; if **any** is ambiguous/semantic → step e (abort the entire rebase, do not partially resolve).
+   - **d. Resolve (all auto-resolvable).** For each file, use **Edit/Write** to produce the merged content with **every conflict marker removed** (`<<<<<<<`, `=======`, `>>>>>>>`), then `git add "<path>"` (quote the path — `(group)`/`[id]` segments break an unquoted add). For `package-lock.json`, prefer taking the base's lockfile and re-running `npm ci` so it reflects the rebased tree, rather than hand-merging JSON. Then continue **non-interactively**: `git -c core.editor=true rebase --continue` (never a bare `git rebase --continue` that may open an editor, never an `ENV=val` prefix). A rebase can pause more than once — if a later step surfaces new conflicts, **re-run this protocol from step a** for them. Record each file's resolution strategy for the step 7 summary. When the rebase completes, proceed to `npm ci` / `npm run prisma:generate` and the rest of the steps as normal.
+   - **e. Escalate (any ambiguous/semantic/never-touch).** `git rebase --abort`. Write a `## Pipeline Escalation` body to `.temp/conflict-<pr>.md` (Write tool) that lists each conflicting file, the specific ambiguous hunks, both sides of each conflict, and why autonomous resolution was not safe. Then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/conflict-<pr>.md`, `gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "revising" --add-label "needs human"`, and end with: `BLOCKED: rebase of <branch> onto origin/<base> has ambiguous conflicts in <files>; human decision needed.`
 
 3. **Apply fixes** per the review's findings. Fix **every finding the review flagged at this cycle's bar** (the review uses an escalating bar — on an early cycle that includes Low/Nit; fix them rather than deferring), all **introduced in this PR**. Skip a flagged item only if it's genuinely not an issue (explain the skip). **Preexisting** findings of any severity: do not fix — note them as suggested future tickets in the summary. No scope creep beyond the review.
 
@@ -108,6 +116,9 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
 
    ```
    ## Revision Summary — Cycle <n>
+
+   ### Rebase conflicts resolved
+   - `path/to/file.ts` — strategy used (e.g. "accepted both imports", "kept ours — their change was whitespace-only")
 
    ### Fixed
    - **R<c>-<id>** [`path/to/file.ts:42`](permalink) — what changed and why

--- a/.claude/docs/PIPELINE.md
+++ b/.claude/docs/PIPELINE.md
@@ -30,7 +30,7 @@ File the issue → in the cockpit: "work on #N, auto-approve the plan" → wait 
 
 - **Cockpit** (`/pipeline`, a skill) runs in the human's interactive session. It owns the conversation, the human gates (`AskUserQuestion`), and the wakeup schedule (`ScheduleWakeup`) — tools that only exist in a main session, not a subagent.
 - **Stage workers** are **subagents** in `.claude/agents/` (`plan-agent`, `impl-agent`, `review-agent`, `revise-agent`). Each carries its own `model`, tool scope, `permissionMode`, and (for the two that write code) `isolation: worktree` in its frontmatter. The cockpit dispatches by `subagent_type`; it sets nothing else at the call site.
-- **`impl-agent` and `revise-agent` get their own isolated git worktree** — a fresh checkout where they `npm ci` + `npm run prisma:generate`, do the work, and push a feature branch. impl branches from `main`; **revise rebases onto the PR's base branch** (`baseRefName`, not assumed `main`). No manual `git worktree`, symlinks, or `.env` are involved.
+- **`impl-agent` and `revise-agent` get their own isolated git worktree** — a fresh checkout where they `npm ci` + `npm run prisma:generate`, do the work, and push a feature branch. impl branches from `main`; **revise rebases onto the PR's base branch** (`baseRefName`, not assumed `main`), autonomously resolving structurally unambiguous conflicts and escalating only ambiguous ones (see "Rebase conflict protocol"). No manual `git worktree`, symlinks, or `.env` are involved.
 - **`plan-agent` and `review-agent` are read-only on source** (`disallowedTools: Edit`); they only read code and write to GitHub via `gh`.
 
 ### Why background dispatch needs care
@@ -77,14 +77,14 @@ Rule: **every stage agent's first action is swapping its trigger label for its i
 
 ### PR labels
 
-| Label              | Set by                        | Type      | Meaning                                                                                   |
-| ------------------ | ----------------------------- | --------- | ----------------------------------------------------------------------------------------- |
-| `ready for review` | `impl-agent` / `revise-agent` | trigger   | Dispatch `review-agent`                                                                   |
-| `reviewing`        | `review-agent`                | in-flight | Review underway                                                                           |
-| `needs revision`   | `review-agent`                | trigger   | Dispatch `revise-agent` (subject to cycle cap)                                            |
-| `revising`         | `revise-agent`                | in-flight | Fixes underway                                                                            |
-| `approved`         | `review-agent`                | terminal  | Findings are at/under the current cycle's bar (escalating, below); human merges on GitHub |
-| `needs human`      | Cockpit / `revise-agent`      | gate      | 5 cycles without convergence or rebase conflict; pipeline stops                           |
+| Label              | Set by                        | Type      | Meaning                                                                                          |
+| ------------------ | ----------------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `ready for review` | `impl-agent` / `revise-agent` | trigger   | Dispatch `review-agent`                                                                          |
+| `reviewing`        | `review-agent`                | in-flight | Review underway                                                                                  |
+| `needs revision`   | `review-agent`                | trigger   | Dispatch `revise-agent` (subject to cycle cap)                                                   |
+| `revising`         | `revise-agent`                | in-flight | Fixes underway                                                                                   |
+| `approved`         | `review-agent`                | terminal  | Findings are at/under the current cycle's bar (escalating, below); human merges on GitHub        |
+| `needs human`      | Cockpit / `revise-agent`      | gate      | 5 cycles without convergence, or an ambiguous rebase conflict needing the author; pipeline stops |
 
 ## Stages and models
 
@@ -146,7 +146,41 @@ Write the message to `.temp/commit-msg.txt` and `git commit -F .temp/commit-msg.
 
 - **Review ↔ revise non-convergence** — before each revise dispatch the cockpit counts `## Code Review` comments; at 5 with Critical/Medium still found it labels `needs human`, comments, and stops dispatching for it.
 - **Impl blocker** — `impl-agent` comments `## Blocker`, labels `blocked`, and reports `BLOCKED:`; the cockpit relays and resumes the same agent with the human's decision.
-- **Rebase conflict during revision** — `revise-agent` aborts the rebase, comments, labels `needs human`.
+- **Rebase conflict during revision** — `revise-agent` attempts autonomous resolution per the **Rebase conflict protocol** below; it aborts, comments with a `## Pipeline Escalation`, and labels `needs human` **only** when a conflict is ambiguous/semantic (or on the never-touch list).
+
+### Rebase conflict protocol (for `revise-agent`)
+
+When `git rebase origin/<base>` hits conflicts, `revise-agent` resolves the structurally unambiguous ones itself and escalates the rest. **Fail closed:** if any single conflict is ambiguous or on the never-touch list, abort the **entire** rebase and escalate — never partially resolve, and never let an auto-resolve silently drop a side's logic.
+
+1. **Inspect conflicts** — run `git diff --name-only --diff-filter=U` to list conflicted files. For each file, read the conflict markers (via the Grep/Read tools — `<<<<<<<`).
+
+2. **Classify each conflict:**
+
+   | Auto-resolvable ✓                                                                                                      | Escalate ✗                                                                            |
+   | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+   | Our changes and theirs are in clearly separate sections of the file (non-overlapping line ranges within the same hunk) | Both sides modified the same function body, same expression, or same schema field     |
+   | `package-lock.json` or other generated/lockfile conflicts                                                              | Prisma migration files (`prisma/migrations/**/*.sql`) — never auto-resolve migrations |
+   | Theirs added a new import / export; ours added a different one; no line overlap                                        | Type definitions or constants where both sides changed the same key                   |
+   | Theirs made a whitespace/formatting-only change in our area                                                            | Logic changes on the same lines from both sides                                       |
+   | One side deleted a block entirely that the other side didn't touch                                                     | Any conflict where accepting one side would silently drop the other's logic           |
+
+3. **If all conflicts are auto-resolvable:**
+   - Resolve each conflict (pick ours, pick theirs, or merge cleanly) with the Edit/Write tools — removing every conflict marker — then `git add "<path>"` (quoted), then `git -c core.editor=true rebase --continue` (non-interactive; never a bare `--continue` that may open an editor). For `package-lock.json`, prefer taking the base's lockfile and re-running `npm ci` over hand-merging JSON. A rebase may pause repeatedly — re-run this protocol for any new conflicts each pause.
+   - In the revision summary comment, list each resolved file and state the resolution strategy used (e.g. "accepted both imports", "kept ours — their change was whitespace-only").
+
+4. **If any conflict is ambiguous/semantic:**
+   - `git rebase --abort` immediately (abort the whole rebase — do not leave a half-rebased state).
+   - Comment on the PR with a `## Pipeline Escalation` section that:
+     - Lists each conflicting file and the specific hunks that are ambiguous.
+     - Describes both sides of each conflict.
+     - States why autonomous resolution was not safe.
+   - Label the issue `needs human` and stop.
+
+5. **Never** auto-resolve conflicts in (escalate regardless of apparent simplicity):
+   - Prisma migration files (`prisma/migrations/**/*.sql`)
+   - `CLAUDE.md` or any `.claude/docs/` file
+   - Environment config (`.env*`, `next.config.*`)
+
 - **Plan questions** — `plan-agent` never guesses: it returns `QUESTIONS FOR HUMAN:` and the cockpit relays, then resumes it with answers.
 
 ## Stopping & draining

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Next.js 16 (App Router, React 19) · Prisma 7 · Tailwind CSS 4 · shadcn/ui (Ra
 - **Commit:** subject `#XXX message in lowercase imperative mood` (no colon after the number, **under 80 chars**, no trailing period); then — only if the _why_ isn't obvious — a blank line and a short body (wrap ~72, a few lines max; narrative belongs in the PR, not the commit); then a blank line and a `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer. Commit each logical unit separately. **Write the message to a file and `git commit -F .temp/commit-msg.txt`** — inline multi-line `-m … -m …` collapses on Windows, dropping the subject and the co-authorship. Delete tracked files with `git rm`.
 - **Branch:** `XXX-ticket-name-in-kebab-case`.
 - **PR:** title `#XXX Ticket Name In Title Case`; body contains `Closes #XXX`; assign `b-at-neu`.
+- **Rebase conflicts in pipeline:** `revise-agent` attempts autonomous resolution for structurally unambiguous conflicts (non-overlapping sections, generated files, dual independent imports). It escalates to `needs human` only when both sides modified the same logical unit. Agents should document every resolution in the revision summary. Full protocol: `.claude/docs/PIPELINE.md` → "Rebase conflict protocol".
 
 ## Pre-push checks (always, before pushing)
 


### PR DESCRIPTION
Closes #188

## Summary

Replaces the pipeline's "every rebase conflict escalates to a human" rule with an autonomous **classify → resolve-or-escalate** protocol for `revise-agent`. The agent now resolves structurally unambiguous conflicts itself (non-overlapping sections, generated lockfiles, dual independent imports, whitespace-only changes) and escalates only when a conflict is genuinely semantic — both sides modifying the same logical unit — or when the file is on a hard never-touch list.

The design is **fail-closed**: if any single conflict in the rebase is ambiguous, semantic, or never-touch, the whole rebase is aborted (no partial resolution) and the PR is labeled `needs human` with a `## Pipeline Escalation` comment that shows both sides of each ambiguous hunk.

The issue listed only `PIPELINE.md` + `CLAUDE.md`, but those are inert without the file the agent actually obeys at runtime — `.claude/agents/revise-agent.md` previously hard-coded "never resolve conflicts yourself and never `git rebase --continue`". That file is the load-bearing change here.

## Changes

- **`.claude/agents/revise-agent.md`** — rewrote step 2's conflict branch from unconditional abort+escalate to the classify→resolve-or-escalate protocol: never-touch short-circuit first, Grep/Read to inspect markers, Edit/Write to resolve, quoted `git add "<path>"`, non-interactive `git -c core.editor=true rebase --continue`, and re-run the loop on multi-pause rebases. Added an optional `### Rebase conflicts resolved` block to the step 7 revision-summary template.
- **`.claude/docs/PIPELINE.md`** — replaced the one-line rebase rule with the canonical **"Rebase conflict protocol"** subsection (numbered steps + the auto-resolvable-vs-escalate classification matrix); updated the `needs human` PR-label row to say "ambiguous rebase conflict" (not every conflict); noted autonomous resolution on the worktree bullet.
- **`CLAUDE.md`** — added a "Rebase conflicts in pipeline" bullet to **Commits, Branches, PRs**, pointing at the full protocol.

## Design decisions

- **Single source of truth.** The classification matrix lives once in `PIPELINE.md`; `revise-agent.md` cross-references it and carries the operational steps. The short *never-touch* safety list (migrations, `.claude` docs, env/config) is deliberately restated inline in the agent file — it is a fail-closed invariant that must be impossible to miss.
- **Non-interactive git.** The resolve path uses `git -c core.editor=true rebase --continue` (no bare `--continue`, no `ENV=val` prefix) per the agent's existing operating rules, so it can't hang on an editor in a background subagent.
- **Tool-based inspection.** Markers are found with Grep (`<<<<<<<`) and read with Read; resolutions are written with Edit/Write — never `cat`/`sed`/shell redirection.

## Automated checks

- [x] `prettier` — `.claude/docs/PIPELINE.md`, `.claude/agents/revise-agent.md`, `CLAUDE.md` all pass `npx prettier --check`. (Repo-wide `npm run prettier:check` has pre-existing failures in untouched files/worktrees; the three edited files conform.)
- `eslint` / `tsc` — not applicable; this change touches only markdown instruction files.

## Notes

- No application/runtime impact — no schema, migrations, server actions, components, or routes. These are pipeline instruction docs only.
- The behavioral test cases (trivial dual-import → auto-resolve; same-function-body → escalate; Prisma migration → always escalate; never-touch docs/config → escalate) are best exercised by real pipeline runs after merge; the pre-merge gate is the cross-file consistency read-through plus prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
