### PR TITLE
#190 Auto-migrate Production DB On Merge To Main

### DIFF
--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -1,0 +1,106 @@
+# Migrate Production DB — deploy pending migrations to long-lived environments
+#
+# Required secrets (GitHub → Settings → Secrets and variables → Actions):
+#   PRODUCTION_DATABASE_URL — direct/unpooled Postgres connection string for the
+#                             production database; used on pushes to `main`.
+#   DEV_DATABASE_URL        — direct/unpooled Postgres connection string for the
+#                             dev database; used on pushes to `dev`.
+#
+# Both secrets MUST use a direct (unpooled) connection — `prisma migrate deploy`
+# requires a direct connection; a pooled/PgBouncer endpoint will cause the
+# migration step to fail. The selected secret is assigned to DATABASE_URL at
+# runtime by branch.
+#
+# Failure model: a failed migration fails this workflow loudly (no continue-on-error).
+# There is no automated rollback — manual intervention is required on failure.
+#
+# Note on missing-secret behavior: unlike the Neon preview workflow (where secrets
+# are optional conveniences), a missing secret for the branch being deployed is a
+# hard failure (`::error::` + exit 1). Silently skipping would allow schema drift
+# to go undetected, which defeats the purpose of this workflow.
+
+name: Migrate Production DB
+
+on:
+  push:
+    branches: [main, dev]
+
+# Per-branch serialization: two pushes to the same branch queue rather than race
+# (cancel-in-progress: false). Cross-branch runs are independent (different ref key
+# → different concurrency group) so a main run and a dev run proceed in parallel.
+# Migrations must never be interrupted mid-apply, so cancel-in-progress is false —
+# stricter than the preview workflow where cancelling a branch-create is harmless.
+concurrency:
+  group: migrate-db-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Deploy migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - name: Install dependencies
+        # npm ci is the correct CI form — lockfile-faithful, no resolution surprises.
+        run: npm ci
+
+      - name: Select database URL
+        # secrets.* cannot be addressed dynamically by a runtime key in a ${{ }} expression.
+        # Both secrets are read into step-level env: (so GitHub masks them in logs), then a
+        # case statement maps the current branch to the correct one and writes it to
+        # $GITHUB_ENV as DATABASE_URL for the subsequent migrate step.
+        #
+        # Fail-loud on a missing secret: unlike the Neon preview workflow's warn-and-skip
+        # for optional secrets, a missing connection string here means the migration cannot
+        # run — silently skipping would let schema drift go unnoticed.
+        env:
+          PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          DEV_DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+        run: |
+          case "${{ github.ref_name }}" in
+            main)
+              SELECTED_SECRET="$PRODUCTION_DATABASE_URL"
+              SECRET_NAME="PRODUCTION_DATABASE_URL"
+              ;;
+            dev)
+              SELECTED_SECRET="$DEV_DATABASE_URL"
+              SECRET_NAME="DEV_DATABASE_URL"
+              ;;
+            *)
+              echo "::error::Unrecognized branch '${{ github.ref_name }}'. Update on.push.branches and the case statement together."
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$SELECTED_SECRET" ]; then
+            echo "::error::Required secret $SECRET_NAME for branch ${{ github.ref_name }} is not configured. Add it under GitHub → Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+          echo "DATABASE_URL=$SELECTED_SECRET" >> "$GITHUB_ENV"
+
+      - name: Generate Prisma client
+        # Guards against config/schema drift; aligns with the preview workflow.
+        # migrate deploy does not strictly require the generated client, but this
+        # catches schema/config issues early in the same way the preview workflow does.
+        run: npm run prisma:generate
+
+      - name: Apply migrations
+        # DATABASE_URL is set in the job environment by the preceding select step.
+        # No continue-on-error: a migration failure MUST turn this check red.
+        # prisma migrate deploy is idempotent — re-running on a push with no new
+        # migrations is a safe no-op (exits 0).
+        run: npm run prisma:migrate:deploy

--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -13,11 +13,6 @@
 #
 # Failure model: a failed migration fails this workflow loudly (no continue-on-error).
 # There is no automated rollback — manual intervention is required on failure.
-#
-# Note on missing-secret behavior: unlike the Neon preview workflow (where secrets
-# are optional conveniences), a missing secret for the branch being deployed is a
-# hard failure (`::error::` + exit 1). Silently skipping would allow schema drift
-# to go undetected, which defeats the purpose of this workflow.
 
 name: Migrate Production DB
 
@@ -25,14 +20,9 @@ on:
   push:
     branches: [main, dev]
 
-# Per-branch serialization: two pushes to the same branch queue rather than race
-# (cancel-in-progress: false). Cross-branch runs are independent (different ref key
-# → different concurrency group) so a main run and a dev run proceed in parallel.
-# Migrations must never be interrupted mid-apply, so cancel-in-progress is false —
-# stricter than the preview workflow where cancelling a branch-create is harmless.
 concurrency:
   group: migrate-db-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: false # migrations must not be interrupted mid-apply
 
 permissions:
   contents: read
@@ -54,18 +44,9 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        # npm ci is the correct CI form — lockfile-faithful, no resolution surprises.
         run: npm ci
 
       - name: Select database URL
-        # secrets.* cannot be addressed dynamically by a runtime key in a ${{ }} expression.
-        # Both secrets are read into step-level env: (so GitHub masks them in logs), then a
-        # case statement maps the current branch to the correct one and writes it to
-        # $GITHUB_ENV as DATABASE_URL for the subsequent migrate step.
-        #
-        # Fail-loud on a missing secret: unlike the Neon preview workflow's warn-and-skip
-        # for optional secrets, a missing connection string here means the migration cannot
-        # run — silently skipping would let schema drift go unnoticed.
         env:
           PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
           DEV_DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
@@ -93,14 +74,7 @@ jobs:
           echo "DATABASE_URL=$SELECTED_SECRET" >> "$GITHUB_ENV"
 
       - name: Generate Prisma client
-        # Guards against config/schema drift; aligns with the preview workflow.
-        # migrate deploy does not strictly require the generated client, but this
-        # catches schema/config issues early in the same way the preview workflow does.
         run: npm run prisma:generate
 
       - name: Apply migrations
-        # DATABASE_URL is set in the job environment by the preceding select step.
-        # No continue-on-error: a migration failure MUST turn this check red.
-        # prisma migrate deploy is idempotent — re-running on a push with no new
-        # migrations is a safe no-op (exits 0).
         run: npm run prisma:migrate:deploy


### PR DESCRIPTION
Closes #190

## Summary

- Adds `.github/workflows/migrate-production.yml` — a single workflow that runs `prisma migrate deploy` against the correct long-lived database on every push to `main` or `dev`.
- Branch-to-secret mapping happens in a shell `case` step (GitHub forbids dynamic secret indexing in expressions), following the same probe pattern as `neon-preview-branch.yml`.
- Missing-secret is a hard failure (`::error::` + `exit 1`), not a warn-and-skip, because silently skipping would allow schema drift to go undetected.

## Changes

- **`.github/workflows/migrate-production.yml`** (new file)
  - Trigger: `on: push: branches: [main, dev]`
  - Concurrency group keyed on `github.ref` with `cancel-in-progress: false` — same-branch runs serialize; cross-branch runs are independent
  - `permissions: contents: read`
  - Single job `migrate`, `timeout-minutes: 15`, `runs-on: ubuntu-latest`
  - Steps: checkout → setup-node (v4, node-version-file, npm cache) → `npm ci` → select DATABASE_URL (case on branch, both secrets read into step env for masking, written to `$GITHUB_ENV`) → `npm run prisma:generate` → `npm run prisma:migrate:deploy`
  - Header comment documents both secrets (`PRODUCTION_DATABASE_URL` → `main`, `DEV_DATABASE_URL` → `dev`), the direct-connection requirement, and the manual-intervention-on-failure note

## Testing plan

- [ ] **YAML format.** Confirm `npm run prettier:check` passes for the new file (already verified locally).
- [ ] **Trigger scoping.** Open a throwaway PR and confirm the `Migrate Production DB` workflow does **not** appear in the PR's checks (only lint/prettier/tsc/Neon-preview run).
- [ ] **Secret-missing path (before adding secrets).** Push a no-op commit to `main` (or merge a trivial PR) and confirm the workflow fails at "Select database URL" with `::error::` naming `PRODUCTION_DATABASE_URL`, run is **red**.
- [ ] **Provision secrets.** Add repo secrets `PRODUCTION_DATABASE_URL` (production direct/unpooled Neon string) and `DEV_DATABASE_URL` (dev direct/unpooled Neon string) under GitHub → Settings → Secrets and variables → Actions.
- [ ] **Happy path — production, pending migration.** Merge a PR to `main` that adds a new Prisma migration. Confirm the run is **green**, the migration appears in the production `_prisma_migrations` table.
- [ ] **Happy path — dev, pending migration.** Push a commit to `dev` carrying a new migration. Confirm the run is **green** and migration lands in the **dev** DB (production untouched).
- [ ] **Branch isolation.** Confirm a `main` push does not migrate the dev DB and vice-versa (check the "Select database URL" log — masked value, correct branch label).
- [ ] **No-op path — no pending migration.** Push a commit to either branch with no migration changes. Confirm run is **green**, `migrate deploy` reports no pending migrations.
- [ ] **Concurrency.** (Optional.) Push two commits to the same branch quickly; confirm second queues behind first. Also confirm a near-simultaneous `main` + `dev` push runs in parallel.
- [ ] **Failure path — bad connection.** (Optional.) Temporarily point a test secret at a pooled/invalid URL, push the matching branch, confirm the migration step fails red with no `continue-on-error` swallowing it.
- [ ] **No secret leakage.** Inspect a successful run's logs and confirm the connection string appears masked (`***`) throughout.

## Automated checks

- Prettier: passed
- ESLint: passed
- TypeScript: passed

## Notes

- This is an infra-only change: no application source, schema, or migration files are modified.
- The `dev` branch trigger supersedes the original AC ("push to `main` only") per the revised plan, which reflects later human feedback and is authoritative.
- The filename `migrate-production.yml` is kept as specified in the AC; it now covers both long-lived environments.
- No `npx prisma` is used — all Prisma commands go through `npm run prisma:*` scripts per project conventions.
