### PR TITLE
#194 Show App Version Next To User Name In User Menu

### DIFF
--- a/components/layouts/mobile-nav.tsx
+++ b/components/layouts/mobile-nav.tsx
@@ -42,7 +42,14 @@ export function MobileNav({
     <header className="bg-sidebar border-sidebar-border flex h-14 items-center border-b px-4 md:hidden">
       <Link href="/" className="flex items-center gap-2">
         <Image src="/logo-dark.svg" alt="Aplio" width={32} height={32} />
-        <span className="text-sm font-semibold tracking-tight">Aplio</span>
+        <span className="flex items-baseline gap-1.5">
+          <span className="text-sm font-semibold tracking-tight">Aplio</span>
+          {process.env.version && (
+            <span className="text-muted-foreground shrink-0 text-xs font-normal">
+              v{process.env.version}
+            </span>
+          )}
+        </span>
       </Link>
 
       <div className="ml-auto">
@@ -69,8 +76,15 @@ export function MobileNav({
                     width={32}
                     height={32}
                   />
-                  <span className="text-sm font-semibold tracking-tight">
-                    Aplio
+                  <span className="flex items-baseline gap-1.5">
+                    <span className="text-sm font-semibold tracking-tight">
+                      Aplio
+                    </span>
+                    {process.env.version && (
+                      <span className="text-muted-foreground shrink-0 text-xs font-normal">
+                        v{process.env.version}
+                      </span>
+                    )}
                   </span>
                 </Link>
               </SheetTitle>

--- a/components/layouts/sidebar.tsx
+++ b/components/layouts/sidebar.tsx
@@ -37,7 +37,14 @@ export function Sidebar({
       <div className="border-sidebar-border flex h-14 items-center border-b px-4">
         <Link href="/" className="flex items-center gap-2">
           <Image src="/logo-dark.svg" alt="Aplio" width={32} height={32} />
-          <span className="text-sm font-semibold tracking-tight">Aplio</span>
+          <span className="flex items-baseline gap-1.5">
+            <span className="text-sm font-semibold tracking-tight">Aplio</span>
+            {process.env.version && (
+              <span className="text-muted-foreground shrink-0 text-xs font-normal">
+                v{process.env.version}
+              </span>
+            )}
+          </span>
         </Link>
       </div>
 

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -26,7 +26,6 @@ interface UserMenuProps {
 export function UserMenu({ identity, onNavigate }: UserMenuProps) {
   const { name, email, roleLabel, isBypass } = identity;
   const displayName = name ?? email;
-  const version = process.env.version;
   const [pending, startTransition] = useTransition();
 
   return (
@@ -37,14 +36,7 @@ export function UserMenu({ identity, onNavigate }: UserMenuProps) {
           className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors"
         >
           <div className="min-w-0 flex-1">
-            <p className="flex items-baseline gap-1.5 text-sm font-medium">
-              <span className="truncate">{displayName}</span>
-              {version && (
-                <span className="text-muted-foreground shrink-0 text-xs font-normal">
-                  v{version}
-                </span>
-              )}
-            </p>
+            <p className="truncate text-sm font-medium">{displayName}</p>
             <p className="text-muted-foreground text-xs">{roleLabel}</p>
           </div>
           <ChevronUp

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -26,6 +26,7 @@ interface UserMenuProps {
 export function UserMenu({ identity, onNavigate }: UserMenuProps) {
   const { name, email, roleLabel, isBypass } = identity;
   const displayName = name ?? email;
+  const version = process.env.version;
   const [pending, startTransition] = useTransition();
 
   return (
@@ -36,7 +37,14 @@ export function UserMenu({ identity, onNavigate }: UserMenuProps) {
           className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors"
         >
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">{displayName}</p>
+            <p className="truncate text-sm font-medium">
+              {displayName}
+              {version && (
+                <span className="text-muted-foreground ml-1.5 shrink-0 text-xs font-normal">
+                  v{version}
+                </span>
+              )}
+            </p>
             <p className="text-muted-foreground text-xs">{roleLabel}</p>
           </div>
           <ChevronUp

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -37,10 +37,10 @@ export function UserMenu({ identity, onNavigate }: UserMenuProps) {
           className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors"
         >
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">
-              {displayName}
+            <p className="flex items-baseline gap-1.5 text-sm font-medium">
+              <span className="truncate">{displayName}</span>
               {version && (
-                <span className="text-muted-foreground ml-1.5 shrink-0 text-xs font-normal">
+                <span className="text-muted-foreground shrink-0 text-xs font-normal">
                   v{version}
                 </span>
               )}


### PR DESCRIPTION
Closes #194

## Summary

- Appends the build-injected app version (`process.env.version`) inline to the right of the display name in the `UserMenu` trigger button
- Styled as `text-muted-foreground text-xs font-normal` with `ml-1.5 shrink-0` so it reads as secondary metadata and never gets swallowed when the name truncates
- The `DropdownMenuLabel` block inside the dropdown is unchanged — version appears in the trigger only

## Changes

- **`components/layouts/user-menu.tsx`** — reads `process.env.version` (build-time inlined by `next.config.ts`; typed `string | undefined`) and conditionally renders a `<span>` after `{displayName}` in the trigger `<p>`. Guard prevents rendering when the value is absent (`vundefined` never appears).

## Testing plan

- [ ] Sign in and locate the `UserMenu` trigger in the sidebar. Confirm the display name is followed inline by a muted, smaller `v0.1.0` matching `package.json`; role label sits on the line below unchanged.
- [ ] Confirm the version tag is gray (`text-muted-foreground`), `text-xs`, and not bold — visually subordinate to the name.
- [ ] Open the user menu dropdown. Confirm the `DropdownMenuLabel` header shows name + role label only — no version repeated.
- [ ] Narrow the viewport (or use a long display name) to trigger name truncation. Confirm the name ellipsizes while `v0.1.0` stays fully visible and is not clipped (`shrink-0`).
- [ ] Mobile/responsive check: open the sidebar Sheet/drawer on a small screen; confirm the version renders correctly inline.
- [ ] Temporarily bump `package.json` `version` to `0.2.0`, restart dev, and confirm the trigger shows `v0.2.0`. Revert the bump.

## Automated checks

- `npm run prettier:check` — pass
- `npm run eslint:check` — pass
- `npm run tsc:check` — pass

## Notes

No schema changes, no server actions, no new dependencies, no new files. `process.env.version` is a build-time static string replacement inlined by `next.config.ts` line 5 (`env: { version: config.version }`), so it works in the `'use client'` component with zero runtime cost.
