### PR TITLE
#192 Applications Toolbar: Full-Width Layout And Fix Clipped Focus Rings

### DIFF
--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -94,10 +94,12 @@ export function ApplicationsToolbar({
   }
 
   return (
-    // min-w-0 prevents the toolbar from expanding the page when filter controls
-    // change width; overflow-x-auto lets it scroll on very narrow viewports
-    // instead of reflowing the surrounding layout.
-    <div className="min-w-0 overflow-x-auto">
+    // w-full spans the full content column to match the table sibling below.
+    // p-1 gives ≥3px clearance on all sides so 3px focus rings (input.tsx,
+    // select.tsx) are not clipped: overflow-x: auto forces overflow-y to auto
+    // per the CSS spec, silently clipping any ring bleed outside the box.
+    // min-w-0 + overflow-x-auto preserve narrow-viewport horizontal scrolling.
+    <div className="w-full min-w-0 overflow-x-auto p-1">
       <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="filter-position" className="text-xs">
@@ -149,8 +151,7 @@ export function ApplicationsToolbar({
           <Label htmlFor="filter-search" className="text-xs">
             Search
           </Label>
-          {/* pb-0.5 gives the focus ring room on the bottom edge so it is not clipped */}
-          <div className="relative pb-0.5">
+          <div className="relative">
             <Input
               id="filter-search"
               aria-label="Search applications"


### PR DESCRIPTION
Closes #192

## Summary

- Add `w-full` to the toolbar's outer scroll container so it spans the full `max-w-6xl` content column, matching the table sibling below
- Add `p-1` (4px) padding to the outer scroll container to give ≥3px clearance on all sides for the 3px focus rings — `overflow-x: auto` forces `overflow-y` to auto per the CSS spec, silently clipping any ring bleed outside the box
- Remove the `pb-0.5` workaround on the search wrapper (now redundant) and its stale comment, which also restores correct baseline alignment with the selects under `sm:items-end`

## Changes

- `components/features/applications-toolbar.tsx` — three edits: outer-container className (`min-w-0 overflow-x-auto` → `w-full min-w-0 overflow-x-auto p-1`), updated comment explaining the `p-1` ring-clearance constraint, and search-wrapper className (`relative pb-0.5` → `relative`) with comment removal

## Testing plan

- [ ] **Full width:** the filter toolbar spans the same horizontal width as the applications table directly below it (both fill the `max-w-6xl` content column); the toolbar no longer hugs its controls on the left with empty space to the right
- [ ] **Baseline alignment:** the Position select, Status select, and Search input all sit on the same bottom edge — no 2px vertical offset of the search input relative to the selects
- [ ] **Focus ring — search (bottom edge):** Tab to (or click) the Search input; the blue ring is fully visible on all four sides, including the bottom edge that was previously clipped
- [ ] **Focus ring — selects:** Tab to the Position select and the Status select; each shows its full focus ring on all four sides with no clipping
- [ ] **Focus ring — clear button:** with a filter active, Tab to the `Clear filters` button; its focus ring is fully visible
- [ ] **Active-filter state:** apply a Position, a Status, and a Search value; `Clear filters` appears and the bar aligns correctly; clicking it resets all filters (URL params cleared)
- [ ] **Narrow viewport:** at mobile width, controls stack vertically; at the `sm` breakpoint if the row is wider than the viewport it scrolls horizontally and rings at scroll extremes are not clipped
- [ ] **Keyboard-only pass:** Tab through Position → Status → Search → clear-X (when present) → Clear filters; focus order is logical and every control shows a complete, unclipped ring

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

No schema changes, no server actions, no new types — this is a pure CSS/layout fix in a single client component. The `min-w-0` and `overflow-x-auto` utilities are retained unchanged to preserve existing narrow-viewport horizontal scroll behavior.
