### PR TITLE
#200 Reduce Pipeline Output Verbosity

### DIFF
--- a/.claude/agents/plan-agent.md
+++ b/.claude/agents/plan-agent.md
@@ -15,11 +15,10 @@ You are the Plan agent (Stage 1) of the pipeline in `.claude/docs/PIPELINE.md`. 
 
 ## Operating rules (read first)
 
-- **Reading/searching:** use the **Read / Grep / Glob** tools for all file inspection. **Never** shell out to `cat`/`head`/`tail`/`grep`/`find`/`ls` — nor to `python3`/`node -e`/`perl`/`awk`/`sed`/`wc` — for **anything** (not just JSON); they are intentionally not on the allowlist, so a denial there means _use the tool_, not retry. **Map the need to a tool:** list a directory → **Glob `<dir>/*`**; read/inspect/count a file → **Read**; search the tree or test whether a file contains text (e.g. conflict markers `<<<<<<<`) → **Grep**. **Scope Glob to source dirs** (`app/`, `components/`, `lib/`, `prisma/`, `.claude/` …) — **never a root-level `**/\*`** (it descends `node_modules`and times out); for locating files/content prefer **Grep** (gitignore-aware → skips`node_modules`), using Glob only with a narrow `path`/prefix.
-- **Run every command bare — never prefix it with `cd …`.** You run read-only in the main repo; a `cd … && <cmd>` starts with `cd` and fails the permission allowlist (which matches from the start of the command). Run `gh …` directly. The command must also **start with the allowlisted binary and parse cleanly**, or it prompts: **never an `ENV=val` prefix**; **quote every path argument** (route groups `(…)` and dynamic segments `[…]` are shell-special and break parsing); **cwd-relative paths only** — never an absolute `C:\…` / `/c/…` path.
-- **Files:** use the **Write tool** with cwd-relative paths for `.temp/` payloads. **Never** build a file with shell redirection (`cat >`, `printf … >`, `echo … >`, heredocs), and **never** an absolute path (`.claude/worktrees/…`, `C:\…`, or the session scratchpad). You do not edit source.
-- **JSON/data:** extract from `gh` output with `gh … --json … --jq '…'` or read the plain text — never pipe to `python3` / `node -e` / external interpreters.
-- **When blocked / auto-denied:** disallowed commands are **auto-denied silently** (no human prompt — you run in `dontAsk` mode). Do **not** retry or improvise around a denial. For blocking ambiguities **STOP** and emit `QUESTIONS FOR HUMAN:` (below); if a denied command blocks you, end with `BLOCKED: <the exact denied command>`. **Never spawn subagents.**
+Follow the shared **Operating rules (all stage agents)** in `.claude/docs/PIPELINE.md` in full — tools (Read/Grep/Glob) not shell, bare commands, quoted cwd-relative paths, file-based GitHub I/O (`.temp/` + `--body-file`/`--jq`), `BLOCKED:` on auto-deny, no subagents. Plan-agent specifics:
+
+- **Read-only on source** — you research the code and write only the issue body (Write `.temp/plan-N.md` → `gh issue edit --body-file`); never edit source. Glob may include `.claude/` when researching.
+- **Never guess on a blocker** — for blocking ambiguities STOP and emit `QUESTIONS FOR HUMAN:` (below) rather than `BLOCKED:`; reserve `BLOCKED:` for a denied command that halts you.
 
 ## Pre-flight
 
@@ -69,14 +68,12 @@ Construct the **full new issue body** (original ticket description preserved on 
 gh issue edit N --repo SGAOperations/aplio --body-file .temp/plan-N.md
 ```
 
-The plan is a **product/UX design, not just a file checklist** — think through how the feature should actually work and look. It must include:
+**Use the fixed structure** in `.claude/docs/PIPELINE.md` → "Implementation plan" — the canonical section list, order, and writing style. Think through how the feature should actually work and look (it's a product/UX design, not just a file checklist), but write it tight: bullets, short sentences, **don't restate the ticket**, omit sections that don't apply. The plan must still _decide_ the substance — even though it's brief:
 
-- **UX/product spec** — the user flows (happy path **and** unhappy/edge paths), the layout & component hierarchy of each screen, key interactions, sensible defaults, and the **copy** (labels, empty-state and error messaging). **Design** each state; don't just list that it exists.
-- **Architecture decisions** — files to create/modify (server actions in `prisma/actions/`, queries in `prisma/data/`, components, shared `lib/` types/constants) and why.
-- **Implementation checklist** as GitHub checkboxes (`- [ ]`).
-- **Edge cases & constraints** · **Schema changes** (Prisma) · **Validation & auth** (zod + authorization scoping per action).
-- **Error model per action** — for **each** server action, list its **expected user-facing failures with the exact `{ error: '…' }` copy** the user should see, and state that everything else **throws** (unexpected → generic toast in an action / global boundary in render). Apply the §4 decision test ("would you show this exact sentence to the user, and can they act on it? yes → `{ error }`, no → throw"). This is a contract impl builds to and review checks against.
-- **Test/validation plan** (written as **human-runnable manual steps** — feeds the PR's Testing plan; see `.claude/docs/PIPELINE.md` → "Pipeline output formats").
+- **Design each UX state** (happy + unhappy/edge), layout/hierarchy, key interactions, and the actual **copy** — in the **## UX states** section (only if there's UI).
+- **Files to create/modify** with reasons (server actions in `prisma/actions/`, queries in `prisma/data/`, components, shared `lib/` types) — in **## Changes**; the ordered `- [ ]` work goes in **## Implementation**.
+- **Schema, validation & the per-action error model** — in **## Data & contracts** (only if schema/actions change): Prisma changes; per action, zod + auth scoping and the exact `{ error: '…' }` copy vs. throw via the §4 decision test ("would you show this sentence to the user, and can they act on it? yes → `{ error }`, no → throw"). This is the contract impl builds to and review checks against.
+- **Human-runnable manual steps** in **## Testing** (feeds the PR's Testing plan).
 
 ## Handoff
 

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -15,11 +15,10 @@ You are the Review agent (Stage 3) of the pipeline in `.claude/docs/PIPELINE.md`
 
 ## Operating rules (read first)
 
-- **Reading/searching:** use the **Read / Grep / Glob** tools for all file inspection. **Never** shell out to `cat`/`head`/`tail`/`grep`/`find`/`ls` — nor to `python3`/`node -e`/`perl`/`awk`/`sed`/`wc` — for **anything** (not just JSON); they are intentionally not on the allowlist, so a denial there means _use the tool_, not retry. **Map the need to a tool:** list a directory → **Glob `<dir>/*`**; read/inspect/count a file → **Read**; search the tree or test whether a file contains text (e.g. conflict markers `<<<<<<<`) → **Grep**. **Scope Glob to source dirs** (`app/`, `components/`, `lib/`, `prisma/` …) — never a root-level `**/*` (it descends `node_modules` and times out); prefer **Grep** (gitignore-aware → skips `node_modules`) to locate files/content.
-- **Run every command bare — never prefix it with `cd …`.** You run read-only in the main repo; a `cd … && <cmd>` starts with `cd` and fails the permission allowlist (which matches from the start of the command). Run `gh …` directly. The command must also **start with the allowlisted binary and parse cleanly**, or it prompts: **never an `ENV=val` prefix**; **quote every path argument** (route groups `(…)` and dynamic segments `[…]` are shell-special and break parsing); **cwd-relative paths only** — never an absolute `C:\…` / `/c/…` path.
-- **Files:** use the **Write tool** with cwd-relative paths for `.temp/` payloads (e.g. the review JSON at `.temp/review-<pr>.json`). **Never** build a file with shell redirection (`cat >`, `printf … >`, `echo … >`, heredocs), and **never** an absolute path (`.claude/worktrees/…`, `C:\…`, or the session scratchpad). You do not edit source.
-- **JSON/data:** use `gh … --json … --jq '…'` — never pipe to `python3` / `node -e` / interpreters.
-- **When blocked / auto-denied:** disallowed commands are **auto-denied silently** (no human prompt — you run in `dontAsk` mode). Do **not** retry or improvise around a denial: **STOP** and post the partial review with what you have, noting the exact denied command. **Never spawn subagents.**
+Follow the shared **Operating rules (all stage agents)** in `.claude/docs/PIPELINE.md` in full — tools (Read/Grep/Glob) not shell, bare commands, quoted cwd-relative paths, file-based GitHub I/O (`.temp/` + `--body-file`/`--input`/`--jq`), `BLOCKED:` on auto-deny, no subagents. Review-agent specifics:
+
+- **Read-only on source** — you review and post a GitHub review; never edit source. Build the review payload with the Write tool at `.temp/review-<pr>.json` and submit with `--input`.
+- **On auto-deny, don't lose work** — post the partial review with what you have, noting the exact denied command, rather than retrying.
 
 ## Pre-flight
 
@@ -87,46 +86,46 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "ready for revi
    - **Conventions** — named exports (except route files); no API routes except `/api/auth`; **server actions in `prisma/actions/`, queries in `prisma/data/`, shared types/constants in `lib/`**; Tailwind/tokens; mobile-first; **no `useEffect` — empty-deps especially**; shadcn/Radix primitives over raw elements; role-gated nav; sensible abstraction / reused `lib` types (no over-abstraction).
    - **Type safety** (no `any`) · **performance** (revalidate after mutations, N+1) · **completeness** (loading + empty states) · **no dead scaffolding/shims**.
 
-3. **Post a real GitHub PR review** — inline line comments + a summary body (see `.claude/docs/PIPELINE.md` → "Pipeline output formats").
+3. **Post a real GitHub PR review** — findings inline, a one-line body (format: `.claude/docs/PIPELINE.md` → "PR reviews & revisions").
 
    **Pick the event** by self-authorship (GitHub forbids `REQUEST_CHANGES`/`APPROVE` on your own PR):
    - `gh api user --jq .login` **equals** the PR `author.login` (the common case — same account) → **`event: "COMMENT"`**.
    - otherwise → `REQUEST_CHANGES` if any Critical/Medium, else `APPROVE`.
 
-   The pipeline **label** (set in Handoff) is the real control signal regardless of the event.
+   The pipeline **label** (Handoff) is the real control signal regardless of the event.
 
-   **Anchor inline comments correctly — do this before building the payload, or GitHub 422s the whole review ("Line could not be resolved").** An inline comment is only accepted on a line that is part of the diff. From the hunk headers in `gh pr diff <pr-number>` (`@@ -<oldStart>,<oldLen> +<newStart>,<newLen> @@`), walk each hunk to map lines:
-   - **Added / unchanged-context lines** (diff prefix `+` or ` `) → `"side": "RIGHT"`, `"line"` = the line number in the file's **new** version.
-   - **Deleted lines** (diff prefix `-`) → `"side": "LEFT"`, `"line"` = the line number in the file's **old** version.
-   - A finding **not** on any such line (unchanged code outside the diff, a whole-file/architectural point) is **not** inline — put it in `body` with a `blob/<headRefOid>` permalink. Do not guess a line number; only emit `comments[]` for lines you mapped from a hunk.
-   - **Inline `comments[]` are NEW actionable findings only.** Never post resolution/status ("resolved", "fixed", "still open", "confirmed") as an inline comment — that belongs **only** in the `body`'s `### Resolved since last review` / `### Still open` sections. (A fixed finding is acknowledged by _resolving its thread_, per revise-agent — not by a new inline comment.)
+   **Anchor each inline comment to a diff line** (or GitHub 422s the whole review "Line could not be resolved"). From the hunk headers in `gh pr diff <pr-number>` (`@@ -<oldStart>,<oldLen> +<newStart>,<newLen> @@`):
+   - **Added / context lines** (`+` / ` `) → `"side":"RIGHT"`, `"line"` = new-version line number.
+   - **Deleted lines** (`-`) → `"side":"LEFT"`, `"line"` = old-version line number.
+   - A finding **off the diff** (unchanged code, whole-file/architectural) has no thread → put it in `body` with a `blob/<headRefOid>` permalink. Don't guess line numbers; only emit `comments[]` for mapped lines.
+   - Inline comments are **new findings only** — never status ("resolved"/"fixed"/"still open"); resolution is the revise-agent resolving the thread.
 
-   Build the payload **with the Write tool** at the cwd-relative path `.temp/review-<pr>.json` — **never** assemble it with `printf`/`echo`/`cat >`/heredocs/shell redirection, never write it to an absolute or scratchpad path, and **never** pass the body inline via `--field body="…"` (the `##`/em-dash/newline content fails to parse and triggers a prompt). Always submit the file with `--input`:
+   **Body = title + one counts line only** — no per-finding list, no provenance, no footer, no Resolved/Still-open sections. Thread state is the truth, so delta reviews look the same (prior resolved threads already show what's done).
+
+   Build the payload **with the Write tool** at `.temp/review-<pr>.json` (never `printf`/`echo`/`cat >`/heredocs, never inline `--field body="…"`), then submit with `--input`:
 
    ```bash
    gh api repos/SGAOperations/aplio/pulls/<pr-number>/reviews --input .temp/review-<pr>.json
    ```
 
-   **If it still returns 422 (a line couldn't be resolved), do not lose the review:** resubmit with `comments` set to `[]` (summary `body` only) so the review always lands, and append a note to the body that inline anchoring failed and findings are listed inline-in-body with permalinks. A single bad line must never sink the whole review.
-
-   Shape — `body` = the summary (cycle-numbered title, IDs, suggested fixes, status sections on delta reviews, and any **preexisting/non-diff** findings as `blob/<headRefOid>` permalinks); `comments[]` = **inline** findings on lines **in the diff** only (mapped as above):
-
    ```json
    {
      "event": "COMMENT",
-     "body": "## Code Review — Cycle <n>\n\n_review-agent · PR #<pr> · against plan in #<issue>_\n\n### Resolved since last review (later reviews only)\n- **R<prev>-<id>** — confirmed fixed\n\n### 🔴 Critical\n- **R<n>-C1** — <problem>. Suggested fix: …\n### 🟠 Medium\n…\n\n---\n_Posted by the agent pipeline._",
+     "body": "## Code Review — Cycle <n> · needs revision\n2 open — 1 🔴 Critical, 1 🟠 Medium (see inline)",
      "comments": [
        {
          "path": "path/file.ts",
          "line": 42,
          "side": "RIGHT",
-         "body": "**R<n>-M1** 🟠 Medium — <problem>. Suggested fix: …"
+         "body": "**R<n>-M1** 🟠 Medium — <problem>. Fix: …"
        }
      ]
    }
    ```
 
-   `<n>` = prior review count + 1 (from pre-flight). Use the colored-circle severities (🔴/🟠/🟡/⚪). Inline `comments[]` must target lines **in the diff**; everything else goes in `body` with permalinks.
+   `<n>` = prior review count + 1; the title verdict = `needs revision`/`approved` (matches Handoff, computed from the bar below). Severities 🔴/🟠/🟡/⚪.
+
+   **If it 422s ("Line could not be resolved"), don't lose the review:** resubmit with `comments: []` (body only) and list those findings in the body with `blob/<headRefOid>` permalinks. A single bad line must never sink the whole review.
 
 ## Handoff — escalating bar
 

--- a/.claude/agents/revise-agent.md
+++ b/.claude/agents/revise-agent.md
@@ -17,17 +17,11 @@ You are the Revise agent (Stage 4) of the pipeline in `.claude/docs/PIPELINE.md`
 
 ## Operating rules (read first)
 
-- **You are already in your own isolated git worktree (your cwd).** Do **all** work in-place with **cwd-relative paths**. **Never** `cd` out of it (including to the base repo), use `git -C`, run `git worktree list/add/remove/prune`, use `--ignore-other-worktrees`, or force anything. If a branch is locked to another worktree, **STOP + `BLOCKED:`** — never force or remove worktrees.
-- **Run every command bare and in-place — never prefix it with `cd …`.** A `cd <path> && <cmd>` both leaves your worktree and starts with `cd`, so it fails the permission allowlist (which matches from the start of the command) and gets denied. Run `npm …`, `git …`, `npx …` directly. The command must also **start with the allowlisted binary and parse cleanly**, or it prompts: **never an `ENV=val` prefix** (`GIT_EDITOR=true git …` misses `Bash(git *)` — for a non-interactive git editor use **`git -c core.editor=true …`**, which still starts with `git`); **quote every path argument** because route groups `(…)` and dynamic segments `[…]` are shell-special (`git add "app/(main)/(auth)/applications/[id]/page.tsx"`); **cwd-relative paths only** — never an absolute `C:\…` / `/c/…` or base-repo path.
-- **Reading/searching:** use the **Read / Grep / Glob** tools. **Never** shell out to `cat`/`head`/`tail`/`grep`/`find`/`ls` — nor to `python3`/`node -e`/`perl`/`awk`/`sed`/`wc` — for **anything** (not just JSON); they are intentionally not on the allowlist, so a denial there means _use the tool_, not retry. **Map the need to a tool:** list a directory → **Glob `<dir>/*`**; read/inspect/count a file → **Read**; search the tree or test whether a file contains text (e.g. conflict markers `<<<<<<<`) → **Grep**. **Scope Glob to source dirs** (`app/`, `components/`, `lib/`, `prisma/` …) — **never a root-level `**/\*`** (it descends your worktree's `node_modules`and times out); prefer **Grep** (gitignore-aware → skips`node_modules`) to locate files/content.
-- **Files:** use the **Write/Edit tools** with cwd-relative paths. **Never** create a file with shell redirection — no `cat >`, `printf … >`, `echo … >`, or heredocs (use the Write tool). **Delete tracked files with `git rm <path>`** (there is no raw `rm` allow).
-- **shadcn components:** add with **`npx shadcn@latest add <component> --yes`** (bare, in-place). Do **not** invoke the shadcn Skill — the `Skill` tool isn't in your scope and is auto-denied.
-- **Toolchain via `npm run` (never `npx`, except shadcn):** run prettier/eslint/tsc/Prisma/tsx through their scripts — `npm run prettier:check`, `npm run eslint:check`, `npm run tsc:check`, `npm run prisma:generate`, `npm run prisma:migrate -- --name <name>`. **Never** `npx prettier` / `npx prisma` / `npx tsx` (npx is allow-listed for shadcn only, so others auto-deny).
-- **JSON/data:** use `gh … --json … --jq '…'` (or plain `--comments`) — never pipe to `python3` / `node -e` / interpreters.
-- **Dependencies:** add/remove/upgrade with `npm install <pkg>` / `npm uninstall <pkg>`. Do **not** hand-edit `package.json` or `package-lock.json` to route around anything — edit them by hand only when npm genuinely cannot express the change.
-- **Sync first:** before anything else, `git fetch origin` and rebase your branch onto the PR's **base branch** (step 2) — never work from stale state.
-- **Clean code only:** no dead scaffolding, shims, or transitional re-exports; don't reintroduce issues from the **Pre-PR self-check** in `.claude/docs/ENGINEERING.md`.
-- **When blocked / auto-denied:** disallowed commands are **auto-denied silently** (no human prompt — you run in `dontAsk` mode), so a denied tool call just returns an error. Do **not** retry it or improvise a workaround: **STOP and emit `BLOCKED: <the exact denied command + what you needed>`** so the cockpit can surface it. **Never spawn subagents.**
+Follow the shared **Operating rules (all stage agents)** in `.claude/docs/PIPELINE.md` in full — tools (Read/Grep/Glob) not shell, bare commands (no `cd`/`ENV=val` prefix; `git -c core.editor=true …` for a non-interactive editor), quoted cwd-relative paths, file-based GitHub I/O, `BLOCKED:` on auto-deny, no subagents. Revise-agent specifics:
+
+- **Stay in your worktree.** You run in your own isolated git worktree (your cwd) — do all work in-place. **Never** `cd` out of it, use `git -C`, run `git worktree list/add/remove/prune`, `--ignore-other-worktrees`, or force anything. If a branch is locked to another worktree, **STOP + `BLOCKED:`**.
+- **Toolchain via `npm run`, never `npx`** (except shadcn): `npm run prettier:check` / `eslint:check` / `tsc:check` / `prisma:generate` / `prisma:migrate -- --name <name>`. Add shadcn with `npx shadcn@latest add <component> --yes` (bare). Manage deps with `npm install`/`uninstall`, not hand-edits to `package.json`/`package-lock.json`. Edit/create files with Write/Edit; delete tracked files with `git rm`.
+- **Sync first, clean code only** — `git fetch origin` and rebase onto the PR's base branch before anything (step 2); no dead scaffolding/shims, and don't reintroduce **Pre-PR self-check** issues from `.claude/docs/ENGINEERING.md`.
 
 ## Pre-flight
 
@@ -112,23 +106,14 @@ gh pr edit <pr-number> --repo SGAOperations/aplio --remove-label "needs revision
 
    Match threads to findings by the **finding ID** (`R<c>-<id>`) the review-agent put in each inline comment. Resolve only what you actually fixed.
 
-7. **Post the summary (file-based).** Write to `.temp/revision-<pr>.md` (Write tool), then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/revision-<pr>.md`. Follow the **Revision Summary format** in `.claude/docs/PIPELINE.md` → "Pipeline output formats": title it `## Revision Summary — Cycle <n>` (the cycle of the review you addressed), reference each review **finding ID** (e.g. `R2-M1`), and use clickable line permalinks. Format (omit empty sections):
+7. **Post one short revision note** (or none) — the resolved threads (step 6) are the log, so don't re-summarize findings. Write `.temp/revision-<pr>.md` (Write tool), then `gh pr comment <pr-number> --repo SGAOperations/aplio --body-file .temp/revision-<pr>.md`. One line (format: `.claude/docs/PIPELINE.md` → "PR reviews & revisions"):
 
    ```
-   ## Revision Summary — Cycle <n>
-
-   ### Rebase conflicts resolved
-   - `path/to/file.ts` — strategy used (e.g. "accepted both imports", "kept ours — their change was whitespace-only")
-
-   ### Fixed
-   - **R<c>-<id>** [`path/to/file.ts:42`](permalink) — what changed and why
-
-   ### Skipped (not an issue)
-   - **R<c>-<id>** [`path/to/file.ts:15`](permalink) — why this is not actually a problem
-
-   ### Preexisting issues — suggested for future tickets
-   - description + suggested ticket scope
+   ## Revision — Cycle <n>
+   fixed R<c>-C1, R<c>-M1 · skipped R<c>-L1 · <sha>
    ```
+
+   `<n>` = the cycle of the review you addressed. Append `· rebase: <file> (<strategy>)` if you auto-resolved a rebase conflict (step 2). Drop `fixed`/`skipped` when empty. No Fixed/Skipped/Preexisting sections — those live on the threads. A preexisting issue worth tracking → a one-line `follow-up:` note here, or file a new issue.
 
 ## Handoff
 

--- a/.claude/docs/PIPELINE.md
+++ b/.claude/docs/PIPELINE.md
@@ -45,16 +45,18 @@ We **allow broad dev-command categories** (`gh`/`git`/`npm`) — with **`npx` sc
 
 Agents never pass large markdown (plans, reviews, comments) as an inline `--body "..."` argument — shell quoting of backticks/code-fences fails cross-platform. They write the payload to `.temp/` (gitignored) and use `gh ... --body-file`. The same applies to the cockpit's escalation comments.
 
-### Command form (why the allowlist sometimes "doesn't work")
+### Operating rules (all stage agents)
 
-A Bash command only matches the `permissions.allow` list if it **starts with an allowlisted binary AND parses cleanly** — otherwise it falls through to a prompt (which a background agent auto-denies). So agents must:
+Canonical rules every stage agent follows — each agent file points here and restates only its specifics. A Bash command matches the `permissions.allow` list only if it **starts with an allowlisted binary AND parses cleanly**; otherwise it falls through to a prompt that a background agent auto-denies.
 
-- **No prefixes** — never `cd … && …` and never an `ENV=val cmd` assignment; both move the start token off the binary (`GIT_EDITOR=true git …` misses `Bash(git *)`). For a non-interactive git editor use `git -c core.editor=true …`.
-- **Quote every path argument** — Next.js route groups `(…)` and dynamic segments `[…]` are shell-special and break parsing; `git add -A` avoids enumerating them.
-- **cwd-relative paths**, forward slashes — never an absolute `C:\…` / `/c/…` or base-repo path.
-- **Inspect via the Read/Grep/Glob tools**, never `cat`/`ls`/`grep`/`python3`/`wc` (not on the allowlist by design; the tool is the route).
+- **Inspect with tools, not the shell** — Read / Grep / Glob for all file reading, searching, and listing; **never** `cat`/`head`/`tail`/`grep`/`find`/`ls` nor `python3`/`node -e`/`awk`/`sed`/`wc` (not allow-listed by design — a denial means _use the tool_, not retry). Scope Glob to source dirs; prefer Grep (gitignore-aware, skips `node_modules`) over a root-level `**/*`.
+- **Run commands bare** — no `cd … && …` and no `ENV=val cmd` prefix (both move the start token off the binary; `GIT_EDITOR=true git …` misses `Bash(git *)`). For a non-interactive git editor use `git -c core.editor=true …`.
+- **Quote every path argument** — route groups `(…)` and dynamic segments `[…]` are shell-special; use cwd-relative paths with forward slashes, never an absolute `C:\…` / `/c/…` or base-repo path. `git add -A` avoids enumerating them.
+- **Write files with the Write/Edit tools** at cwd-relative paths — never shell redirection (`cat >`, `printf >`, `echo >`, heredocs). Delete tracked files with `git rm`.
+- **GitHub I/O is file-based** — large markdown goes to `.temp/` (gitignored) via `gh … --body-file`/`--input`, never inline `--body "…"`. Extract data with `gh … --json … --jq '…'`, never piped to an interpreter.
+- **When auto-denied, stop — don't improvise.** A denied command just errors (no prompt, under `dontAsk`). Don't retry or route around it: **emit `BLOCKED: <exact denied command + what you needed>`** so the cockpit surfaces it. Never spawn subagents.
 
-This is enforced in each agent's "Operating rules"; it's documented here so the rationale isn't re-debugged.
+Documented once here so the rationale isn't re-debugged; agent files restate only the rules unique to them.
 
 ## Label lifecycle
 
@@ -120,19 +122,42 @@ Permission mode: every stage agent runs **`permissionMode: dontAsk`** (auto-deny
 
 Defined once here; the stage agents follow these exactly.
 
-### PR comments & reviews (review, revise, escalation; blockers on the issue)
+### Writing style (every output)
 
-The **code review is a real GitHub PR review** (`gh api …/pulls/<pr>/reviews --input`) — a summary body **plus inline line comments** on changed lines — not a plain comment. **Event:** `COMMENT` when the reviewer is the PR author (common case — same account; GitHub forbids `REQUEST_CHANGES`/`APPROVE` on your own PR), else `REQUEST_CHANGES` (Critical/Medium) or `APPROVE`. The pipeline **label** is the real control signal regardless. Revision summaries, escalations, and blockers use `gh … --body-file`.
+Every plan, review, summary, and comment is written for a human scanning fast:
 
-- **Title (no emoji, cycle-numbered):** `## Code Review — Cycle <n>` · `## Revision Summary — Cycle <n>` · `## Pipeline Escalation` (and `## Blocker` on issues). `<n>` = prior review count + 1. Keep the literal `Code Review` text — the cockpit's cycle-cap counts it.
-- **Provenance line** under the title: `_<stage> · PR #<pr> · against plan in #<issue>_`.
-- **Findings** carry a **stable ID** (`R<cycle>-<sev><n>`) and a **clickable permalink to the exact line(s)**: ``[`path/file.ts:42`](https://github.com/SGAOperations/aplio/blob/<headRefOid>/path/file.ts#L42)`` (range `#L42-L48`); get `<headRefOid>` from `gh pr view <pr> --json headRefOid`.
-- **Severity headers use colored circles:** `### 🔴 Critical` · `### 🟠 Medium` · `### 🟡 Low` · `### ⚪ Nit`. Each finding ends with **`Suggested fix:`** (+ an alternative where useful).
-- **Escalating bar — what blocks rises with the review cycle** (so the first pass polishes everything and later passes converge): **cycle 1** any finding (incl. Nit) → `needs revision`; **cycle 2** Low+ blocks (Nit doesn't); **cycle 3+** Critical/Medium only. A nit introduced during a revision can't re-trigger at cycle ≥2. The cockpit cycle-cap (5 with Critical/Medium still open → `needs human`) is unchanged.
-- **Later (delta) reviews** open with `### Resolved since last review` / `### Still open` (referencing prior IDs) before the new findings.
-- **Inline-comment anchoring:** a `comments[]` entry is only accepted on a line **in the diff** — map it from `gh pr diff` hunk headers (added/context → `side:"RIGHT"`, new-version line number; deletions → `side:"LEFT"`, old-version line number). Findings off the diff go in the body as permalinks. If the reviews API still 422s ("Line could not be resolved"), **resubmit with `comments:[]`** (body only) so a review always lands. **Inline comments are NEW actionable findings only** — resolution/status ("resolved", "fixed", "still open") goes in the body's status sections, never as an inline comment.
-- **Thread resolution (revise):** after pushing fixes, revise replies `Fixed in <sha> (R<c>-<id>)` to each addressed inline-comment thread and resolves it via GraphQL (`addPullRequestReviewThreadReply` + `resolveReviewThread`), matching threads to findings by ID; genuinely-skipped threads stay open. Keeps unresolved conversations from blocking merge.
-- **Footer:** `_Posted by the agent pipeline._`
+- **Bullets and short sentences over paragraphs** — one idea per bullet.
+- **Never restate context the reader already has** (the ticket, a prior review, the diff) — reference it.
+- **Omit empty sections** — no "N/A" / "Not applicable" / "None" filler; if a section doesn't apply, leave it out.
+- **No meta-commentary** — don't describe the document itself ("This section records…", "For completeness…").
+- **Say it once** — never repeat a point across sections, or across body + inline + summary.
+
+### Implementation plan (plan-agent writes it into the issue body)
+
+Appended below the ticket under a `---` then `## Implementation Plan`; revision mode replaces only that block. **Do not restate the ticket** — reference it. Fixed sections in this order; the conditional ones appear **only when they apply** (omit otherwise — no stub):
+
+- **## Overview** — 2–4 sentences: what, why, the approach.
+- **## Changes** — files to create/modify, one bullet each: `` `path` — one-line reason ``.
+- **## Implementation** — ordered `- [ ]` checkboxes, one line each; fold validation / states / error-model notes into the step they belong to.
+- **## Data & contracts** _(only if schema or server actions change)_ — Prisma changes; per action: zod + auth scoping and the exact `{ error: '…' }` copy vs. throw (§4 decision test).
+- **## UX states** _(only if there's UI)_ — loading / empty / error + key copy, as bullets.
+- **## Testing** — human-runnable manual steps as `- [ ]` (feeds the PR Testing plan).
+- **## Risks / notes** _(optional)_ — only real, non-obvious ones.
+
+Most plans fit on one screen. No "Nature of this ticket" preamble, no restated Goal/Files, no N/A sections.
+
+### PR reviews & revisions
+
+The **code review is a real GitHub PR review** (`gh api …/pulls/<pr>/reviews --input`): **inline line comments carry the findings**; the body is a one-line verdict. **Event:** `COMMENT` when the reviewer is the PR author (common case — same account; GitHub forbids `REQUEST_CHANGES`/`APPROVE` on your own PR), else `REQUEST_CHANGES` (Critical/Medium) or `APPROVE`. The pipeline **label** is the real control signal regardless.
+
+**Findings live on the threads, not in a summary.** A resolved review thread _is_ the log entry — collapsed and out of the way until expanded. So a finding is never re-narrated cycle after cycle, and "what's still open" is GitHub's unresolved-conversation count.
+
+- **Review body = title + one line.** `## Code Review — Cycle <n> · <verdict>` (keep the literal `Code Review` — the cockpit cycle-cap counts it; `<verdict>` = `needs revision`/`approved`; `<n>` = prior review count + 1), then a single counts line, e.g. `2 open — 1 🔴 Critical, 1 🟠 Medium (see inline)`. Nothing else — no per-finding list, no provenance line, no footer, no Resolved/Still-open sections (thread state is the truth). **Only exception:** a finding that can't anchor to a diff line (architectural / off-diff) has no thread, so it goes in the body with a `blob/<headRefOid>` permalink (get `<headRefOid>` from `gh pr view <pr> --json headRefOid`).
+- **Each finding = one inline comment** on a diff line: `**R<n>-<sev><id>** <emoji> — <problem>. Fix: <one line>.` Stable ID `R<cycle>-<sev><id>` (e.g. `R2-M1`); severities 🔴 Critical · 🟠 Medium · 🟡 Low · ⚪ Nit. Inline comments are **new actionable findings only** — never status ("fixed"/"still open").
+- **Escalating bar — what blocks rises with the cycle** (pass 1 polishes everything, later passes converge): **cycle 1** any finding → `needs revision`; **cycle 2** Low+ blocks (Nit doesn't); **cycle 3+** Critical/Medium only. A nit introduced during a revision can't re-trigger at cycle ≥2. Cockpit cycle-cap (5 with Critical/Medium still open → `needs human`) unchanged.
+- **Inline anchoring:** a `comments[]` entry is accepted only on a line **in the diff** — map it from `gh pr diff` hunk headers (added/context → `side:"RIGHT"`, new-version line; deletions → `side:"LEFT"`, old-version line). If the reviews API 422s ("Line could not be resolved"), **resubmit with `comments:[]`** (body only) and list those findings in the body with permalinks, so a review always lands.
+- **Revision — resolve threads, don't summarize.** After pushing fixes, for each finding **fixed**: reply `Fixed in <sha>` on its thread and resolve it via GraphQL (`addPullRequestReviewThreadReply` + `resolveReviewThread`), matched by ID; **genuinely-skipped** threads get a one-line reason and stay open. Then one short PR comment per cycle (or none): `## Revision — Cycle <n>` + a single line `fixed <ids> · skipped <ids> · <sha>` (append `· rebase: <file> (<strategy>)` if a conflict was auto-resolved). No Fixed/Skipped/Preexisting sections. A preexisting issue worth tracking → a one-line `follow-up:` note or a new issue, not a summary block.
+- **Other comments:** `## Pipeline Escalation` (revise — ambiguous rebase) and `## Blocker` (impl — on the issue) stay short: what's blocked + the decision needed, via `--body-file`.
 
 ### PR description (impl writes it via `gh pr create --body-file`)
 


### PR DESCRIPTION
Closes #200

## Summary

Cuts pipeline verbosity by changing what the agents are told to write — shorter plans, reviews, and revision notes — and by deduping the instruction docs. The aim: a human can scan any pipeline artifact fast and always know what's still open.

## Changes

- **Plans — fixed concise structure.** `plan-agent.md` + PIPELINE "Implementation plan" now define one section set: always **Overview · Changes · Implementation · Testing**; conditional **Data & contracts** (only if schema/actions) and **UX states** (only if UI), **omitted when N/A** (no stubs). Plans no longer restate the ticket; bullets and short sentences only.
- **Reviews — findings inline, one-line body.** Each finding is a single inline comment with its stable ID; the review body shrinks to `## Code Review — Cycle <n> · <verdict>` + one counts line. No per-finding list, provenance, footer, or Resolved/Still-open sections.
- **Revisions — threads are the log.** Revise resolves each fixed thread (`Fixed in <sha>`) and posts at most a one-line `## Revision — Cycle <n>` note; the big Fixed/Skipped/Preexisting summary is gone. "What's still open" = GitHub's unresolved-conversation count; the full history is the collapsed resolved threads — hidden until expanded.
- **Global writing-style standard.** A short "Writing style (every output)" block in PIPELINE.md that all agents inherit (bullets > prose, don't restate context, omit empty sections, no meta-commentary, say it once).
- **Deduped operating rules.** The repeated ~5-bullet operating rules across the four agent files collapse to a pointer to PIPELINE.md → "Operating rules (all stage agents)" + each agent's specifics only.

## Files

- `.claude/docs/PIPELINE.md` — writing-style block, plan structure, rewritten "PR reviews & revisions" format, canonical "Operating rules (all stage agents)".
- `.claude/agents/plan-agent.md` · `review-agent.md` · `revise-agent.md` — trimmed operating rules to a pointer + specifics; updated their output-format sections to the new minimal formats.

## Testing plan

- [ ] Read PIPELINE.md end-to-end: plan structure, review/revise formats, and operating rules are internally consistent and the four agents point to them without contradiction
- [ ] Run a real ticket through plan → review → revise and confirm the plan uses only the fixed sections (no N/A filler, no restated ticket), the review body is one line with findings inline, and revise resolves threads + posts a one-line note
- [ ] Confirm an unresolved finding shows as a GitHub "unresolved conversation" and a fixed one collapses after revise resolves its thread

## Notes

- Docs-only / pipeline-process change — no application runtime impact; markdown isn't covered by tsc/eslint. All four files pass `prettier --check`.
- Behavioral validation is best done on a live pipeline run after merge; the pre-merge gate is the consistency read-through + prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
