### PR TITLE
#207 Rename Migrate-Production Workflow To Migrate-Db And Scope To Migration File Changes

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -1,4 +1,4 @@
-# Migrate Production DB — deploy pending migrations to long-lived environments
+# Migrate DB — deploy pending migrations to long-lived environments
 #
 # Required secrets (GitHub → Settings → Secrets and variables → Actions):
 #   PRODUCTION_DATABASE_URL — direct/unpooled Postgres connection string for the
@@ -14,11 +14,13 @@
 # Failure model: a failed migration fails this workflow loudly (no continue-on-error).
 # There is no automated rollback — manual intervention is required on failure.
 
-name: Migrate Production DB
+name: Migrate DB
 
 on:
   push:
     branches: [main, dev]
+    paths:
+      - 'prisma/migrations/**'
 
 concurrency:
   group: migrate-db-${{ github.ref }}


### PR DESCRIPTION
Closes #207

## Summary

- Rename `.github/workflows/migrate-production.yml` to `.github/workflows/migrate-db.yml` via `git mv` (preserves file history)
- Update `name:` field from `Migrate Production DB` to `Migrate DB` and align the header comment
- Add `paths: ['prisma/migrations/**']` filter so the workflow only runs when a Prisma migration file actually changed

## Changes

- `.github/workflows/migrate-production.yml` → `.github/workflows/migrate-db.yml` — renamed; all other content (concurrency, permissions, job steps, dual-branch DATABASE_URL selection) is untouched
- `name: Migrate DB` — updated from `Migrate Production DB`
- `on.push.paths` — added `prisma/migrations/**` filter; `branches: [main, dev]` kept as-is

## Testing plan

- [x] Confirm `migrate-db.yml` exists and `migrate-production.yml` is gone (`git log --diff-filter=R --summary` shows a rename, not add + delete)
- [ ] GitHub Actions tab shows the workflow named `Migrate DB` after merge
- [ ] Push a commit to `dev`/`main` that touches **no** file under `prisma/migrations/` — the `Migrate DB` workflow does **not** trigger
- [ ] Push a commit to `dev`/`main` that adds or edits a file under `prisma/migrations/` — the workflow triggers and the migrate job runs to completion
- [ ] Other workflows (linting-check, prettier-check, tsc-check, neon-preview-branch) are unaffected by this change

## Automated checks

No app code changed; prettier/eslint/tsc are not applicable to YAML workflow files.

## Notes

The live workflow already targeted `branches: [main, dev]` (not `main`-only as the ticket's "from" snippet showed). The `paths` filter is added under the existing `on.push` block and applies to both branches uniformly, which matches the ticket's intent (only run when a migration changed) without regressing the `dev` environment path.
