### PR TITLE
#213 Remove Redundant Empty Message From Admin Pipeline Summary

### DIFF
--- a/components/features/pipeline-summary.tsx
+++ b/components/features/pipeline-summary.tsx
@@ -26,11 +26,6 @@ export async function PipelineSummary() {
 
   return (
     <section aria-label="Pipeline summary">
-      {total === 0 && (
-        <p className="text-muted-foreground mb-4 text-sm">
-          No applications submitted yet.
-        </p>
-      )}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-7">
         {/* Leading "Total" card — sum of all non-draft pipeline statuses */}
         <StatCard label="Total" value={total} dotClassName="bg-primary" />


### PR DESCRIPTION
Closes #213

## Summary

- Removes the `{total === 0 && (…)}` guard and its `<p>` from `PipelineSummary` — the all-zero stat grid already serves as the empty representation, making the prose redundant and visually misleading

## Changes

- `components/features/pipeline-summary.tsx` — delete the conditional `<p>No applications submitted yet.</p>` block (lines 29–33); the `total` computation and all `StatCard` renders are unchanged

## Testing plan

- [ ] On a clean DB or a cycle with zero non-draft applications, open the admin dashboard: the Pipeline summary shows the stat grid with all `0`s and **no** "No applications submitted yet." text above it
- [ ] With at least one application in each of a few statuses: counts render correctly and the layout is unchanged from before
- [ ] Verify the `aria-label="Pipeline summary"` on the `<section>` element is still present (screen-reader label unchanged)
- [ ] Verify CI is green: `npm run prettier:check`, `npm run eslint:check`, `npm run tsc:check`

## Automated checks

- `npm run prettier:check` — pass
- `npm run eslint:check` — pass
- `npm run tsc:check` — pass

## Notes

Pure JSX removal — no data, schema, action, or routing changes. The `total` variable is retained as it still feeds the "Total" `StatCard`.
