### PR TITLE
#214 Empty State On Profile Page When No Global Questions Exist

### DIFF
--- a/components/features/profile-form.tsx
+++ b/components/features/profile-form.tsx
@@ -2,10 +2,13 @@
 
 import { useState } from 'react';
 
+import { ListChecks } from 'lucide-react';
+
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
 
 import { ProfileQuestion } from '@/components/features/profile-question';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
 
 interface ProfileFormProps {
   profileData: { question: GlobalQuestion; answer: GlobalAnswer | null }[];
@@ -13,6 +16,15 @@ interface ProfileFormProps {
 
 export function ProfileForm({ profileData }: ProfileFormProps) {
   const [isEditing, setIsEditing] = useState(false);
+
+  if (profileData.length === 0)
+    return (
+      <EmptyState
+        icon={ListChecks}
+        title="No profile questions yet"
+        description="Questions added by an admin will appear here for you to answer."
+      />
+    );
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
Closes #214

## Summary

- Adds a designed empty state to `ProfileForm` when no global questions exist, replacing the previous blank container with an Edit button above empty content.
- Uses the shared `EmptyState` component with `ListChecks` icon and copy that sets the correct expectation: questions are created by an admin.
- The non-empty path (Edit/Done toggle + question list) is completely unchanged.

## Changes

- `components/features/profile-form.tsx` — early-return `<EmptyState>` when `profileData.length === 0`; imports `ListChecks` from lucide-react and `EmptyState` from `@/components/ui/empty-state`.

## Testing plan

- [ ] Visit `/profile` as a user when global questions exist — Edit button and question list render as before (non-empty path unchanged).
- [ ] Delete all global questions in the admin global-questions screen (or use a fresh DB with no questions), then visit `/profile` — the `EmptyState` card renders with the `ListChecks` icon, title "No profile questions yet", and description "Questions added by an admin will appear here for you to answer." No Edit button is visible.
- [ ] After adding the first global question as admin, reload `/profile` — the empty state is replaced by the Edit button and question list.
- [ ] Verify no console errors on either path.

## Automated checks

- prettier: pass
- eslint: pass
- tsc: pass

## Notes

Pure presentational change to a single client component. No data, schema, server-action, or route changes. Follows the early-return empty-state pattern used by `GlobalQuestionsTable` and `MyApplicationsTable`.
