### PR TITLE
#206 Favicon Missing On Anonymous Pages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -52,7 +52,9 @@ export default function middleware(request: NextRequest) {
 export const config = {
   // Exclude Next internals, public metadata/icon assets, and static images so
   // they load on unauthenticated routes without being redirected to login.
+  // `icon` covers the dynamic app/icon.tsx route served at /icon (and
+  // /icon?<contentHash>); `apple-icon` covers app/apple-icon.tsx similarly.
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|icon.svg|logo-dark.svg|apple-icon|sitemap.xml|robots.txt).*)',
+    '/((?!_next/static|_next/image|favicon.ico|icon|logo-dark.svg|apple-icon|sitemap.xml|robots.txt).*)',
   ],
 };


### PR DESCRIPTION
Closes #206

## Summary

- The middleware matcher excluded `icon.svg` (a non-existent static file) but not `/icon`, the path Next.js serves for the dynamic `app/icon.tsx` edge function.
- On unauthenticated pages, `neonAuthMiddleware` intercepted the `/icon?<contentHash>` request and redirected it to `/login`, so the browser never received the favicon image.
- Fix: replace `icon.svg` with `icon` in the matcher's negative-lookahead, consistent with how `apple-icon` (serving `app/apple-icon.tsx`) is already handled.

## Changes

- `middleware.ts` — replace `icon.svg` with `icon` in the matcher exclusion group; update the explanatory comment to name both dynamic icon routes (`/icon` from `app/icon.tsx`, `/apple-icon` from `app/apple-icon.tsx`).

## Testing plan

- [ ] Run `npm run dev`; open `/login` in an incognito window (no auth or bypass cookie) — favicon appears in the browser tab.
- [ ] Open `/login/bypass` in the same incognito window — favicon appears.
- [ ] Open a `(legal)` page (e.g. `/privacy` or `/terms`) in the incognito window — favicon appears.
- [ ] DevTools → Network on `/login`: the `/icon?…` request returns `200 image/png`, not a `307` redirect to the login URL.
- [ ] Sign in (or pick a bypass role) and navigate to an authenticated route — favicon still appears (no regression).
- [ ] Confirm `/apple-icon` still returns its image and other static assets (`logo-dark.svg`) remain accessible on unauthenticated routes.

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

The query-string hash (`/icon?<contentHash>`) is irrelevant to the matcher; it operates on the pathname only (`/icon`), so no special handling is needed for the hash suffix.
