### PR TITLE
#212 Show Log Out Button For All Users

### DIFF
--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
 
-import { ChevronUp, UserCircle } from 'lucide-react';
+import { ChevronUp, LogOut, UserCircle } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { logoutBypassUser } from '@/prisma/services/dev-bypass';
 
+import { authClient } from '@/lib/auth/client';
 import type { NavIdentity } from '@/lib/types';
 
 import {
@@ -34,11 +37,28 @@ export function UserMenu({
   const { name, email, roleLabel, isBypass } = identity;
   const displayName = name ?? email;
   const [pending, startTransition] = useTransition();
+  const router = useRouter();
 
   const triggerClassName =
     variant === 'header'
       ? 'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors bg-transparent hover:bg-muted'
       : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors';
+
+  function handleLogout() {
+    startTransition(async () => {
+      if (isBypass) {
+        logoutBypassUser();
+        return;
+      }
+      try {
+        await authClient.signOut();
+        router.push('/login');
+        router.refresh();
+      } catch {
+        toast.error('Could not sign out. Please try again.');
+      }
+    });
+  }
 
   return (
     <DropdownMenu>
@@ -73,18 +93,15 @@ export function UserMenu({
             Profile
           </Link>
         </DropdownMenuItem>
-        {isBypass && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              disabled={pending}
-              onSelect={() => startTransition(() => logoutBypassUser())}
-              className="text-destructive cursor-pointer text-sm"
-            >
-              Log out
-            </DropdownMenuItem>
-          </>
-        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          disabled={pending}
+          onSelect={handleLogout}
+          className="text-destructive cursor-pointer text-sm"
+        >
+          <LogOut className="size-4" aria-hidden />
+          Log out
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -47,11 +47,12 @@ export function UserMenu({
   function handleLogout() {
     startTransition(async () => {
       if (isBypass) {
-        logoutBypassUser();
+        await logoutBypassUser();
         return;
       }
       try {
         await authClient.signOut();
+        toast.success('Signed out.');
         router.push('/login');
         router.refresh();
       } catch {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -237,6 +237,6 @@ export interface NavIdentity {
   email: string;
   roleLabel: string;
   // true only for bypass sessions on non-production environments;
-  // gates the Log out control which is bypass-only (real-auth sign-out is out of scope).
+  // routes the Log out handler to logoutBypassUser() instead of authClient.signOut().
   isBypass: boolean;
 }


### PR DESCRIPTION
Closes #212

## Summary

- Move the "Log out" `DropdownMenuItem` out of the `{isBypass && …}` gate so it renders for every authenticated user
- Branch the click handler: bypass sessions call `logoutBypassUser()` (unchanged behaviour, server-redirects to `/login/bypass`); real-auth sessions call `authClient.signOut()` then navigate to `/login` with `router.refresh()`
- Add `LogOut` icon (lucide-react) to match the Profile item's icon pattern
- Fix the stale comment on `NavIdentity.isBypass` in `lib/types.ts`

## Changes

- `components/layouts/user-menu.tsx` — add `useRouter`, `authClient`, `toast` (sonner), and `LogOut` icon imports; add `handleLogout` handler that branches on `isBypass`; render the Log out item unconditionally with a separator; wrap real-auth error in `try/catch` with `toast.error`
- `lib/types.ts` — update comment on `NavIdentity.isBypass` line 240 to reflect that the field routes the logout handler, not that real-auth sign-out is out of scope

## Testing plan

- [ ] As a real Neon Auth user, open the user menu — "Log out" is visible. Click it; you land on `/login` and are signed out (visiting a protected route redirects back to login).
- [ ] As a bypass user (`/login/bypass`), open the menu — "Log out" is visible; clicking lands on `/login/bypass` with the bypass cookie cleared (unchanged behaviour).
- [ ] Keyboard: open the menu with Enter/Space, arrow to "Log out", activate with Enter — same result as mouse click.
- [ ] Trigger the real-auth error path (e.g. network offline) — an error toast appears and you remain on the page, still signed in.
- [ ] Confirm the rest of the menu (name, role, Profile) is visually unchanged in both `sidebar` and `header` variants.
- [ ] Confirm the `LogOut` icon renders before the label and is `aria-hidden`, matching the Profile item's icon pattern.

## Automated checks

- Prettier: clean
- ESLint: no errors
- TypeScript: no errors

## Notes

`router.refresh()` after `signOut()` is required so server-rendered nav components re-read the now-empty session if the user navigates back before the full redirect resolves. The `/login` page's own `getOptionalUser()` guard is the backstop for any race.
