### PR TITLE
#217 Show User Email In Profile Dropdown Area

### DIFF
--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -61,6 +61,9 @@ export function UserMenu({
         <DropdownMenuLabel className="font-normal">
           <p className="truncate text-sm font-medium">{displayName}</p>
           <p className="text-muted-foreground text-xs">{roleLabel}</p>
+          {email !== displayName && (
+            <p className="text-muted-foreground truncate text-xs">{email}</p>
+          )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>


### PR DESCRIPTION
Closes #217

## Summary

- Adds the signed-in user's email as a third line inside the open `DropdownMenuLabel`, styled `text-muted-foreground text-xs truncate` (secondary, non-intrusive)
- Omits the email row when it equals `displayName` (i.e. the user has no name set and the name line already shows the email)
- Leaves the collapsed trigger button unchanged — email does not appear there

## Changes

- `components/layouts/user-menu.tsx` — one conditional `<p>` inside `DropdownMenuLabel`, after the role line; no prop, type, or data changes

## Testing plan

- [ ] Sign in as a user **with** a display name; open the profile dropdown — email appears on its own line under the role, in muted small text
- [ ] Paste a long email address and confirm it truncates with an ellipsis rather than widening or overflowing the `w-52` dropdown
- [ ] Confirm the collapsed trigger button still shows only name + role (no email visible)
- [ ] Use an account **without** a name set (name line shows the email); confirm the dedicated email row is omitted so the address appears exactly once
- [ ] Verify both `variant="sidebar"` and `variant="header"` render the email consistently

## Automated checks

- Prettier: pass
- ESLint: pass
- TypeScript: pass

## Notes

Pure presentational change. `email` is already a non-nullable `string` on `NavIdentity`, so no data layer or type changes were required.
