### PR TITLE
#222 Move Table Counts From Page Header Into Toolbar/Filter Row

### DIFF
--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 
 import {
   getApplications,
+  getApplicationsTotal,
   getReviewablePositions,
 } from '@/prisma/data/applications';
 import { isManager } from '@/prisma/data/managers';
@@ -78,33 +79,27 @@ export default async function ApplicationsPage({
     filters.sort
   );
 
-  const [applications, positions] = await Promise.all([
+  const [applications, positions, total] = await Promise.all([
     getApplications(user, filters),
     getReviewablePositions(user),
+    getApplicationsTotal(user),
   ]);
 
-  const count = applications.length;
-  // `getApplications` caps results at 100; show "100+" when the list may be
-  // truncated so the label is never misleadingly exact.
-  const countLabel =
-    count === 1
-      ? '1 application'
-      : count >= 100
-        ? '100+ applications'
-        : count > 0
-          ? `${count} applications`
-          : null;
+  const shownCapped = applications.length >= 100;
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6">
       <header>
         <h1 className="text-2xl font-semibold tracking-tight">Applications</h1>
-        {countLabel && (
-          <p className="text-muted-foreground mt-1 text-sm">{countLabel}</p>
-        )}
       </header>
 
-      <ApplicationsToolbar positions={positions} filters={filters} />
+      <ApplicationsToolbar
+        positions={positions}
+        filters={filters}
+        shown={applications.length}
+        total={total}
+        shownCapped={shownCapped}
+      />
 
       <ApplicationsTable
         applications={applications}

--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -85,7 +85,9 @@ export default async function ApplicationsPage({
     getApplicationsTotal(user),
   ]);
 
-  const shownCapped = applications.length >= 100;
+  // `total > applications.length` is true only when the take:100 cap actually
+  // truncated results — avoids a false positive when exactly 100 apps exist.
+  const shownCapped = total > applications.length;
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6">
@@ -99,6 +101,7 @@ export default async function ApplicationsPage({
         shown={applications.length}
         total={total}
         shownCapped={shownCapped}
+        hasActiveFilters={hasActiveFilters}
       />
 
       <ApplicationsTable

--- a/app/(main)/(auth)/users/page.tsx
+++ b/app/(main)/(auth)/users/page.tsx
@@ -15,10 +15,7 @@ export default async function UsersPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <PageHeader
-        title="Users"
-        description={`${users.length} ${users.length === 1 ? 'user' : 'users'}`}
-      />
+      <PageHeader title="Users" />
 
       <UsersTable users={users} currentUserId={user.id} />
     </div>

--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -7,6 +7,7 @@ import { X } from 'lucide-react';
 
 import { REVIEWER_APPLICATION_STATUS_OPTIONS } from '@/lib/constants';
 import type { ApplicationFilters } from '@/lib/types';
+import { formatTableCount } from '@/lib/utils';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -22,11 +23,17 @@ import {
 interface ApplicationsToolbarProps {
   positions: { id: string; title: string }[];
   filters: ApplicationFilters;
+  shown: number;
+  total: number;
+  shownCapped: boolean;
 }
 
 export function ApplicationsToolbar({
   positions,
   filters,
+  shown,
+  total,
+  shownCapped,
 }: ApplicationsToolbarProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -178,6 +185,13 @@ export function ApplicationsToolbar({
             Clear filters
           </Button>
         )}
+
+        <p
+          aria-live="polite"
+          className="text-muted-foreground self-end text-sm sm:ml-auto"
+        >
+          {formatTableCount({ shown, total, noun: 'application', shownCapped })}
+        </p>
       </div>
     </div>
   );

--- a/components/features/applications-toolbar.tsx
+++ b/components/features/applications-toolbar.tsx
@@ -26,6 +26,7 @@ interface ApplicationsToolbarProps {
   shown: number;
   total: number;
   shownCapped: boolean;
+  hasActiveFilters: boolean;
 }
 
 export function ApplicationsToolbar({
@@ -34,6 +35,7 @@ export function ApplicationsToolbar({
   shown,
   total,
   shownCapped,
+  hasActiveFilters: hasActiveFiltersProp,
 }: ApplicationsToolbarProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -51,13 +53,7 @@ export function ApplicationsToolbar({
   // typing (without waiting for the debounce to update the URL).
   const [searchValue, setSearchValue] = useState(filters.q ?? '');
 
-  const hasActiveFilters = !!(
-    filters.positionId ||
-    filters.status ||
-    filters.userId ||
-    filters.q ||
-    filters.sort
-  );
+  const hasActiveFilters = hasActiveFiltersProp;
 
   function updateParam(key: string, value: string | undefined) {
     const params = new URLSearchParams(searchParams.toString());
@@ -190,7 +186,13 @@ export function ApplicationsToolbar({
           aria-live="polite"
           className="text-muted-foreground self-end text-sm sm:ml-auto"
         >
-          {formatTableCount({ shown, total, noun: 'application', shownCapped })}
+          {formatTableCount({
+            shown,
+            total,
+            noun: 'application',
+            shownCapped,
+            isFiltered: hasActiveFilters,
+          })}
         </p>
       </div>
     </div>

--- a/components/features/users-table.tsx
+++ b/components/features/users-table.tsx
@@ -13,7 +13,7 @@ import {
   type SortableColumn,
   useSortableTable,
 } from '@/lib/use-sortable-table';
-import { formatDate } from '@/lib/utils';
+import { formatDate, formatTableCount } from '@/lib/utils';
 
 import { SortableHeader } from '@/components/features/sortable-header';
 import { Badge } from '@/components/ui/badge';
@@ -122,15 +122,28 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
   return (
     <>
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="users-search">Search</Label>
-          <Input
-            id="users-search"
-            placeholder="Search by name or email"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="max-w-sm"
-          />
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="users-search">Search</Label>
+            <Input
+              id="users-search"
+              placeholder="Search by name or email"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="max-w-sm"
+            />
+          </div>
+
+          <p
+            aria-live="polite"
+            className="text-muted-foreground self-end text-sm sm:ml-auto"
+          >
+            {formatTableCount({
+              shown: filtered.length,
+              total: users.length,
+              noun: 'user',
+            })}
+          </p>
         </div>
 
         <Card className="gap-0 p-0">

--- a/components/features/users-table.tsx
+++ b/components/features/users-table.tsx
@@ -142,6 +142,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
               shown: filtered.length,
               total: users.length,
               noun: 'user',
+              isFiltered: !!q,
             })}
           </p>
         </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -98,3 +98,39 @@ export function isAcceptingApplications(
 ): boolean {
   return getPositionAvailability(position, now) === 'accepting';
 }
+
+interface FormatTableCountOptions {
+  shown: number;
+  total: number;
+  /** Singular noun, e.g. "application". Pluralized by appending "s" unless `pluralNoun` is given. */
+  noun: string;
+  /** Override the plural form if it is not simply `noun + "s"`. */
+  pluralNoun?: string;
+  /**
+   * Set to true when the shown count is capped (e.g. `getApplications` caps at 100)
+   * so the display reads "100+" rather than a misleadingly exact number.
+   */
+  shownCapped?: boolean;
+}
+
+/**
+ * Formats a table row count for display in a toolbar.
+ *
+ * When shown === total returns "{total} {noun}" (no redundant x/x).
+ * When filtered returns "{shown} / {total} {noun}".
+ * When shownCapped and shown === total (capped threshold) uses "100+" for shown side.
+ */
+export function formatTableCount({
+  shown,
+  total,
+  noun,
+  pluralNoun,
+  shownCapped = false,
+}: FormatTableCountOptions): string {
+  const plural = pluralNoun ?? `${noun}s`;
+  const nounLabel = total === 1 && shown === total ? noun : plural;
+  const shownLabel = shownCapped ? '100+' : String(shown);
+
+  if (!shownCapped && shown === total) return `${total} ${nounLabel}`;
+  return `${shownLabel} / ${total} ${plural}`;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -111,14 +111,20 @@ interface FormatTableCountOptions {
    * so the display reads "100+" rather than a misleadingly exact number.
    */
   shownCapped?: boolean;
+  /**
+   * Whether any filters are currently active. When false (unfiltered), the
+   * function always collapses to "{total} {noun}" regardless of shown vs total —
+   * this matters when capping is in play (shown=100, total=250, no filters).
+   */
+  isFiltered?: boolean;
 }
 
 /**
  * Formats a table row count for display in a toolbar.
  *
- * When shown === total returns "{total} {noun}" (no redundant x/x).
+ * When unfiltered (isFiltered=false) returns "{total} {noun}" (no x/x).
  * When filtered returns "{shown} / {total} {noun}".
- * When shownCapped and shown === total (capped threshold) uses "100+" for shown side.
+ * When shownCapped uses "100+" for the shown side.
  */
 export function formatTableCount({
   shown,
@@ -126,11 +132,12 @@ export function formatTableCount({
   noun,
   pluralNoun,
   shownCapped = false,
+  isFiltered = false,
 }: FormatTableCountOptions): string {
   const plural = pluralNoun ?? `${noun}s`;
   const nounLabel = total === 1 ? noun : plural;
   const shownLabel = shownCapped ? '100+' : String(shown);
 
-  if (shown === total) return `${shownLabel} ${nounLabel}`;
+  if (!isFiltered) return `${total} ${nounLabel}`;
   return `${shownLabel} / ${total} ${nounLabel}`;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -128,9 +128,9 @@ export function formatTableCount({
   shownCapped = false,
 }: FormatTableCountOptions): string {
   const plural = pluralNoun ?? `${noun}s`;
-  const nounLabel = total === 1 && shown === total ? noun : plural;
+  const nounLabel = total === 1 ? noun : plural;
   const shownLabel = shownCapped ? '100+' : String(shown);
 
-  if (!shownCapped && shown === total) return `${total} ${nounLabel}`;
-  return `${shownLabel} / ${total} ${plural}`;
+  if (shown === total) return `${shownLabel} ${nounLabel}`;
+  return `${shownLabel} / ${total} ${nounLabel}`;
 }

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -293,6 +293,25 @@ export async function getMyRecentActivity(
   });
 }
 
+// Caller-scoped unfiltered count of non-draft applications, used for the
+// toolbar "shown / total" display. Shares the same baseWhere scope as
+// getApplications (admins: all non-draft; managers: own positions only).
+// No filters are applied — this is the denominator for the count display.
+export async function getApplicationsTotal(user: {
+  id: string;
+  isAdmin: boolean;
+}): Promise<number> {
+  const where = user.isAdmin
+    ? { deletedAt: null, status: { not: 'draft' as const } }
+    : {
+        deletedAt: null,
+        status: { not: 'draft' as const },
+        position: { managers: { some: { id: user.id } } },
+      };
+
+  return prisma.application.count({ where });
+}
+
 // Returns positions the caller may review — used to populate the Position filter
 // Select on /applications. Admins see all non-deleted; managers see their positions.
 export async function getReviewablePositions(user: {

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -20,6 +20,19 @@ const applicationSelect = {
   position: { select: { id: true, title: true } },
 } as const;
 
+// Shared scope guard: admins see all non-draft; managers see only their positions.
+// Used by both getApplications (filtered list) and getApplicationsTotal (denominator)
+// so the two always cover the same universe of rows.
+function buildBaseWhere(user: { id: string; isAdmin: boolean }) {
+  return user.isAdmin
+    ? { deletedAt: null, status: { not: 'draft' as const } }
+    : {
+        deletedAt: null,
+        status: { not: 'draft' as const },
+        position: { managers: { some: { id: user.id } } },
+      };
+}
+
 export async function getMyApplications(
   userId: string,
 ): Promise<MyApplicationListItem[]> {
@@ -155,13 +168,7 @@ export async function getApplications(
   user: { id: string; isAdmin: boolean },
   filters: ApplicationFilters,
 ): Promise<AdminApplicationListItem[]> {
-  const baseWhere = user.isAdmin
-    ? { deletedAt: null, status: { not: 'draft' as const } }
-    : {
-        deletedAt: null,
-        status: { not: 'draft' as const },
-        position: { managers: { some: { id: user.id } } },
-      };
+  const baseWhere = buildBaseWhere(user);
 
   // Build date-range clause when q looks like a year (e.g. "2026") or a
   // "Mon YYYY" string (e.g. "Jun 2026"). This lets reviewers search by date
@@ -294,22 +301,14 @@ export async function getMyRecentActivity(
 }
 
 // Caller-scoped unfiltered count of non-draft applications, used for the
-// toolbar "shown / total" display. Shares the same baseWhere scope as
-// getApplications (admins: all non-draft; managers: own positions only).
+// toolbar "shown / total" display. Shares the same scope as getApplications
+// via buildBaseWhere — the two always cover the same universe of rows.
 // No filters are applied — this is the denominator for the count display.
 export async function getApplicationsTotal(user: {
   id: string;
   isAdmin: boolean;
 }): Promise<number> {
-  const where = user.isAdmin
-    ? { deletedAt: null, status: { not: 'draft' as const } }
-    : {
-        deletedAt: null,
-        status: { not: 'draft' as const },
-        position: { managers: { some: { id: user.id } } },
-      };
-
-  return prisma.application.count({ where });
+  return prisma.application.count({ where: buildBaseWhere(user) });
 }
 
 // Returns positions the caller may review — used to populate the Position filter


### PR DESCRIPTION
Closes #222

## Summary

- Moves the application/user count out of page `<h1>` subtitles and into the existing filter/toolbar row, right-aligned
- Adds a shared `formatTableCount` helper in `lib/utils.ts` that collapses to `{total} {noun}` when unfiltered and expands to `{shown} / {total} {noun}` when filtered, handling the `100+` cap for applications
- Adds `getApplicationsTotal` to `prisma/data/applications.ts` — a caller-scoped unfiltered count that shares the same `baseWhere` as `getApplications` (no IDOR widening)

## Changes

- **`lib/utils.ts`** — new `formatTableCount({ shown, total, noun, pluralNoun?, shownCapped? })` export; collapses to `{total} {noun}` when `shown === total`, expands to `{shown} / {total} {noun}` when filtered, applies `100+` to the shown side when `shownCapped`
- **`prisma/data/applications.ts`** — new `getApplicationsTotal(user)`: `prisma.application.count` with the same caller-scoped `baseWhere` (admins: all non-draft; managers: own positions); no filters, returns a plain number
- **`app/(main)/(auth)/applications/page.tsx`** — adds `getApplicationsTotal` to the `Promise.all`; removes the `countLabel` / `<p>` under `<h1>`; passes `shown`, `total`, `shownCapped` props to `ApplicationsToolbar`
- **`components/features/applications-toolbar.tsx`** — accepts `shown`/`total`/`shownCapped`; renders the count via `formatTableCount` as the last flex child with `sm:ml-auto self-end text-muted-foreground text-sm` and `aria-live="polite"`
- **`app/(main)/(auth)/users/page.tsx`** — drops the `description` count prop from `PageHeader`
- **`components/features/users-table.tsx`** — wraps the search input in a flex row alongside the formatted count (`filtered.length` / `users.length`), `aria-live="polite"`

## Testing plan

- [ ] Applications (admin): with no filters active, confirm page header has no count subtitle and toolbar shows e.g. `47 applications` matching the table row count
- [ ] Applications: apply a status or position filter — toolbar updates to `{shown} / {total} applications` after the server re-fetch; clearing filters returns to `{total} applications`
- [ ] Applications: apply a search that returns zero results — toolbar shows `0 / {total} applications` and the table shows its no-match empty state
- [ ] Applications: in a dataset with ≥100 matching rows, confirm shown side reads `100+` and total reads the true DB count
- [ ] Applications (manager, non-admin): confirm total reflects only positions the manager owns — no other positions' applications bleed into the count
- [ ] Users (admin): page header shows no count; search row shows `{N} users` with no query; typing a query shows `{shown} / {total} users`; clearing returns to `{total} users`
- [ ] Users: search with no matches shows `0 / {total} users` above the existing "No users match your search." row
- [ ] Both pages: narrow viewport — count wraps below the controls and remains readable; no horizontal clipping of toolbar focus rings
- [ ] Singular form: with exactly 1 application/user and unfiltered, confirm `1 application` / `1 user` (not `1 applications`)

## Automated checks

- Prettier: pass
- ESLint: pass (0 warnings)
- TypeScript: pass

## Notes

No schema changes. No server action changes. `getApplicationsTotal` is read-only, authenticated only by the already-reviewer-gated page (admin or manager), and shares exact `baseWhere` with `getApplications` so scope can never drift.
