### PR TITLE
#236 Neon Preview Branches Should Fork From Dev, Not Prod

### DIFF
--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -1,16 +1,15 @@
 # Neon Preview Branch — per-PR isolated database with auto-migration
 #
 # Required secrets (GitHub → Settings → Secrets and variables → Actions):
-#   NEON_API_KEY        — Neon API key with branch create/delete permissions
-#   NEON_PROJECT_ID     — Neon project ID (find in Neon console → Settings)
+#   NEON_API_KEY            — Neon API key with branch create/delete permissions
+#   NEON_PROJECT_ID         — Neon project ID (find in Neon console → Settings)
+#   NEON_PARENT_BRANCH_ID   — Neon branch ID of the *dev* branch (Neon console →
+#                             Branches → dev → Settings). REQUIRED — preview branches
+#                             must fork from dev (not prod). The check_neon step fails
+#                             loudly if this secret is absent.
 #   VERCEL_TOKEN        — Vercel personal access token (optional; skip var-wiring if absent)
 #   VERCEL_ORG_ID       — Vercel team/org ID (optional)
 #   VERCEL_PROJECT_ID   — Vercel project ID (optional)
-#
-# Neon parent branch assumption: the project's default branch (main/prod).
-# To use a non-default parent, set NEON_PARENT_BRANCH_ID as a repo secret/variable;
-# the create-branch step passes it as parent_branch and omits the input when the secret
-# is empty so the action falls back to the project default.
 
 name: Neon Preview Branch
 
@@ -62,16 +61,21 @@ jobs:
         id: check_neon
         # secrets.* cannot be evaluated directly in `if:` conditions, so we probe
         # via env and write a flag to GITHUB_OUTPUT.
+        # NEON_PARENT_BRANCH_ID is required — silently falling back to prod is wrong.
         env:
           HAS_KEY: ${{ secrets.NEON_API_KEY != '' }}
           HAS_PROJECT: ${{ secrets.NEON_PROJECT_ID != '' }}
+          HAS_PARENT: ${{ secrets.NEON_PARENT_BRANCH_ID != '' }}
         run: |
-          if [ "$HAS_KEY" = "true" ] && [ "$HAS_PROJECT" = "true" ]; then
-            echo "has_neon=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_neon=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::NEON_API_KEY or NEON_PROJECT_ID not configured; skipping Neon branch create and migration."
+          if [ "$HAS_KEY" != "true" ] || [ "$HAS_PROJECT" != "true" ]; then
+            echo "::error::NEON_API_KEY and NEON_PROJECT_ID are required secrets. Configure them in GitHub → Settings → Secrets and variables → Actions."
+            exit 1
           fi
+          if [ "$HAS_PARENT" != "true" ]; then
+            echo "::error::NEON_PARENT_BRANCH_ID is required. Set it to the Neon branch ID of the dev branch (Neon console → Branches → dev → Settings) so preview branches fork from dev, not prod."
+            exit 1
+          fi
+          echo "has_neon=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or reuse Neon branch
         id: create_branch
@@ -85,8 +89,8 @@ jobs:
           # (reuses an existing branch with the same name).
           branch_name: preview/${{ github.head_ref }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          # Optional: override the parent branch. When NEON_PARENT_BRANCH_ID is empty
-          # the action falls back to the project default branch.
+          # Required: fork from the dev branch, not prod. NEON_PARENT_BRANCH_ID must be
+          # set to the Neon branch ID of dev — enforced by the check_neon step above.
           parent_branch: ${{ secrets.NEON_PARENT_BRANCH_ID }}
 
       # Mask the URL so it never appears in subsequent log lines.


### PR DESCRIPTION
Closes #236

## Summary

- `NEON_PARENT_BRANCH_ID` is now a **required** secret in the Neon preview branch workflow — the `check_neon` step fails loudly (`::error::` + `exit 1`) when it is absent, preventing any silent fallback to prod
- The workflow header comment is updated to document `NEON_PARENT_BRANCH_ID` as required, with instructions pointing to the Neon console to find the dev branch ID
- The `parent_branch` inline comment is corrected from "optional" to "required"

Note: the secret value itself (the Neon dev branch ID) must be set in GitHub → Settings → Secrets and variables → Actions by the repo owner. Without it the workflow will fail on every PR open/sync until configured, which is the correct behavior — preview branches must fork from dev.

## Changes

- `.github/workflows/neon-preview-branch.yml` — add `HAS_PARENT` env probe to `check_neon` step; replace warn-and-continue logic with hard `exit 1` for missing `NEON_API_KEY`/`NEON_PROJECT_ID`/`NEON_PARENT_BRANCH_ID`; update header comment and `parent_branch` inline comment

## Testing plan

- [ ] After setting `NEON_PARENT_BRANCH_ID` in GitHub Secrets to the dev branch ID, open a new PR and verify the `Check Neon secrets` step passes and the created Neon branch shows `dev` as its parent in the Neon console
- [ ] Temporarily unset `NEON_PARENT_BRANCH_ID` from secrets and open/sync a PR — confirm the `Check Neon secrets` step fails with `::error::NEON_PARENT_BRANCH_ID is required…` and the workflow turns red (not yellow/skipped)
- [ ] Verify an existing PR that was opened before this change can be re-synced after the secret is set, and its preview branch forks correctly from dev
- [ ] Verify the cleanup job (PR close) still deletes the Neon branch and Vercel env var as before (no changes to the cleanup job, but confirm no regressions)
- [ ] Verify that missing `NEON_API_KEY` or `NEON_PROJECT_ID` also hard-fails (not warns) after this change

## Automated checks

No TypeScript, ESLint, or Prettier checks apply — this change is YAML only.

## Notes

This change is intentionally breaking for repos that currently rely on the silent prod fallback: any repo missing `NEON_PARENT_BRANCH_ID` will start getting hard CI failures until the secret is configured. That is the desired behavior — the old silent fallback was the bug.
