### PR TITLE
#242 Scope Neon Preview Branch Workflow To PRs Targeting Dev

### DIFF
--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -16,6 +16,8 @@ name: Neon Preview Branch
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    branches:
+      - dev
 
 # Cancel in-progress runs for the same PR so rapid pushes don't race on the
 # same Neon branch (create-vs-migrate overlap).


### PR DESCRIPTION
Closes #242

## Summary

- Add a `branches: [dev]` filter to the `pull_request` trigger in `.github/workflows/neon-preview-branch.yml` so the workflow only fires for PRs targeting `dev`

## Changes

- `.github/workflows/neon-preview-branch.yml` — add `branches: [dev]` under the `on.pull_request` trigger (after `types:`)

## Testing plan

- [ ] Open a PR targeting `main` (or any non-`dev` branch): confirm the "Neon Preview Branch" workflow does **not** appear in the PR checks / Actions tab
- [ ] Open a PR targeting `dev`: confirm the workflow runs and the `Create branch & migrate` job executes successfully
- [ ] Merge or close that `dev`-targeted PR: confirm the `Delete branch` (cleanup) job runs
- [ ] Close a `main`-targeted PR: confirm no cleanup run is triggered in the Actions tab

## Automated checks

- Prettier: pass
- ESLint: pass
- TypeScript: pass

## Notes

The `branches:` filter on a `pull_request` trigger matches the PR's **base** (target) branch. This single workflow-level filter gates both the `upsert` and `cleanup` jobs — no per-job changes are needed. The existing `if: github.event.action` guards on each job remain unchanged.
