### PR TITLE
#245 Auth State Changes Must Take Effect On Affected User's Next Page Load

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -8,6 +8,11 @@ import { AppFooter } from '@/components/layouts/app-footer';
 import { MobileNav } from '@/components/layouts/mobile-nav';
 import { Sidebar } from '@/components/layouts/sidebar';
 
+// Force every route under this layout to re-render on each request so that
+// auth state changes (deactivation, admin toggle) take effect on the affected
+// user's very next navigation — no 30-second router-cache window.
+export const dynamic = 'force-dynamic';
+
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const user = await getCurrentUser();
 

--- a/app/(main)/(auth)/layout.tsx
+++ b/app/(main)/(auth)/layout.tsx
@@ -6,6 +6,11 @@ import { getProfileCompleteness } from '@/prisma/data/profile';
 
 import { getCurrentUser } from '@/lib/auth/server';
 
+// Force every route under this auth-gate to re-render on each request so that
+// auth state changes (deactivation, admin toggle) take effect on the affected
+// user's very next navigation — no 30-second router-cache window.
+export const dynamic = 'force-dynamic';
+
 export default async function AuthGateLayout({
   children,
 }: {

--- a/prisma/actions/users.ts
+++ b/prisma/actions/users.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import { z } from 'zod/v4';
 
-import { getCurrentUser } from '@/lib/auth/server';
+import { authServer, getCurrentUser } from '@/lib/auth/server';
 import { prisma } from '@/lib/prisma';
 
 const toggleAdminSchema = z.object({
@@ -40,7 +40,9 @@ export async function toggleUserAdmin(
   if (result.count === 0)
     throw new Error('User not found or already deactivated');
 
-  revalidatePath('/users');
+  // Bust all cached route segments so the affected user's gated layout re-runs
+  // getCurrentUser() on their next navigation — not just the admin's /users page.
+  revalidatePath('/', 'layout');
 }
 
 export async function deactivateUser(
@@ -58,14 +60,25 @@ export async function deactivateUser(
   if (userId === user.id)
     return { error: 'You cannot deactivate your own account.' };
 
-  const result = await prisma.user.updateMany({
+  // Single round-trip: update returns neonAuthId for the revocation step below.
+  // P2025 (record not found) propagates as an unexpected throw — not reachable
+  // from the freshly-rendered admin list where deletedAt was already null.
+  const updated = await prisma.user.update({
     where: { id: userId, deletedAt: null },
     data: { deletedAt: new Date(), deletedById: user.id },
+    select: { neonAuthId: true },
   });
 
-  // Not reachable from the freshly-rendered admin list → unexpected → throw.
-  if (result.count === 0)
-    throw new Error('User not found or already deactivated');
+  // Bust all cached route segments so the deactivated user's gated layout
+  // re-runs getCurrentUser() on their next navigation.
+  revalidatePath('/', 'layout');
 
-  revalidatePath('/users');
+  // Best-effort: revoke all Neon Auth sessions for the deactivated user so a
+  // hard reload can't ride a live session either. Swallow on failure — the
+  // revalidatePath + getCurrentUser block is the guaranteed enforcement.
+  try {
+    await authServer.admin.revokeUserSessions({ userId: updated.neonAuthId });
+  } catch (err) {
+    console.error('Session revocation failed for deactivated user:', err);
+  }
 }


### PR DESCRIPTION
Closes #245

## Summary

- Replace `revalidatePath('/users')` with `revalidatePath('/', 'layout')` in both `toggleUserAdmin` and `deactivateUser` so the affected user's gated layout re-runs `getCurrentUser()` on their next client-side navigation, not just the admin's `/users` list.
- In `deactivateUser`, convert `updateMany` to `update` (single round-trip, returns `neonAuthId`) and add a best-effort call to `authServer.admin.revokeUserSessions` so a hard reload cannot ride a live Neon Auth session cookie after deactivation. Revocation failures are swallowed and logged — the cache-bust + `getCurrentUser` block is the guaranteed enforcement.

## Changes

- `prisma/actions/users.ts` — widened revalidation target in `toggleUserAdmin`; widened revalidation target, switched to `prisma.user.update` with `select: { neonAuthId: true }`, and added session revocation in `deactivateUser`.

## Testing plan

- [ ] As admin on `/users`, deactivate a non-admin user — row leaves the list, success toast fires (unchanged behavior).
- [ ] In a second browser tab logged in as the deactivated user, click a client-side nav link (not a hard reload) — should be redirected to `/login` (or `/login/bypass` in dev), not served a cached page.
- [ ] Same setup, deactivated user does a full hard reload — also redirected to login; no live session keeps them in.
- [ ] As admin, toggle another active user's admin role to "admin" and then back — in that user's browser tab, the next client-side navigation should reflect the admin-level change (admin nav appears / disappears) without requiring a hard reload.
- [ ] Confirm the self-guard is intact: an admin cannot deactivate themselves or change their own admin role — action returns `{ error }` and toast shows the specific message; buttons are disabled in the UI.
- [ ] (Code inspection / deployment) Confirm `authServer.admin.revokeUserSessions` is called after a deactivation; if the Neon Auth admin plugin is unavailable, verify the cache-bust alone still blocks the deactivated user on next navigation.
- [ ] Reactivate a deactivated user by clearing `deletedAt` in the DB — that user regains access on their next navigation without needing a hard reload.

## Automated checks

- prettier: pass
- eslint: pass (0 warnings)
- tsc: pass

## Notes

`revalidatePath('/', 'layout')` is intentionally broad — it invalidates every cached segment for all users since we cannot target only the affected user's cache from the admin's server action. These are infrequent admin operations so the global revalidation cost is acceptable. Session revocation depends on the better-auth admin plugin being enabled on the Neon Auth instance; the action never fails on a revocation miss.
