### PR TITLE
#246 Fix Neon Endpoint Not Found Error And SSL Connection Warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-DATABASE_URL=
-DIRECT_URL=
+# Use sslmode=verify-full to avoid the pg v9 deprecation warning for legacy
+# aliases (require/prefer/verify-ca). Neon requires SSL; verify-full is the
+# correct long-term form.
+DATABASE_URL=postgresql://user:password@host/dbname?sslmode=verify-full
+DIRECT_URL=postgresql://user:password@host/dbname?sslmode=verify-full
 
 NEON_AUTH_BASE_URL=
 NEON_AUTH_COOKIE_SECRET=

--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -201,6 +201,17 @@ jobs:
           branch: preview/${{ github.head_ref }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
+      - name: Log Neon branch teardown result
+        # Surfaces the outcome regardless of continue-on-error so teardown is
+        # auditable in the run log. A failed delete is non-fatal (stale branches
+        # can be cleaned up manually), but it should be visible.
+        run: |
+          if [ "${{ steps.delete_branch.outcome }}" = "success" ]; then
+            echo "Neon branch preview/${{ github.head_ref }} deleted successfully."
+          else
+            echo "::warning::Neon branch preview/${{ github.head_ref }} delete failed or was already absent (outcome: ${{ steps.delete_branch.outcome }})."
+          fi
+
       # ── Vercel cleanup (resilient — skipped if secrets absent) ─────────────
 
       - name: Check Vercel secrets
@@ -244,7 +255,7 @@ jobs:
             "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env/$EXISTING_ID?teamId=$VERCEL_ORG_ID")
 
           if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
-            echo "Vercel DELETE returned HTTP $HTTP_STATUS; failing job."
+            echo "::error::Vercel DELETE returned HTTP $HTTP_STATUS for branch $GIT_BRANCH; failing job."
             exit 1
           fi
-          echo "Removed branch-scoped DATABASE_URL for branch $GIT_BRANCH."
+          echo "Removed branch-scoped DATABASE_URL for Vercel preview branch $GIT_BRANCH."

--- a/.github/workflows/neon-preview-branch.yml
+++ b/.github/workflows/neon-preview-branch.yml
@@ -176,7 +176,7 @@ jobs:
 
           # A non-2xx from a configured Vercel integration is a real error — fail the job.
           if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
-            echo "Vercel API returned HTTP $HTTP_STATUS; failing job."
+            echo "::error::Vercel API returned HTTP $HTTP_STATUS for branch $GIT_BRANCH; failing job."
             exit 1
           fi
 

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { getCurrentUser, getIsBypass } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import type { NavIdentity } from '@/lib/types';
 
 import { AppFooter } from '@/components/layouts/app-footer';

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { cache } from 'react';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 export const authServer = createAuthServer();
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -4,17 +4,43 @@ import { PrismaClient } from '@/prisma/client';
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
+/**
+ * Normalize legacy sslmode aliases to verify-full so pg/pg-connection-string
+ * does not emit the v9 deprecation warning. The require/prefer/verify-ca modes
+ * are treated identically to verify-full by Neon and current pg versions; this
+ * rewrite makes that explicit and silences the warning before it becomes a
+ * breaking change in pg v9.
+ */
+function normalizeConnectionString(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const sslmode = parsed.searchParams.get('sslmode');
+    if (
+      sslmode === 'require' ||
+      sslmode === 'prefer' ||
+      sslmode === 'verify-ca'
+    ) {
+      parsed.searchParams.set('sslmode', 'verify-full');
+      return parsed.toString();
+    }
+    return url;
+  } catch {
+    // Not a valid URL — return as-is so the downstream driver surfaces the error.
+    return url;
+  }
+}
+
 const createPrismaClient = () => {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl)
     throw new Error('DATABASE_URL environment variable is not set');
 
-  const adapter = new PrismaPg({ connectionString: databaseUrl });
+  const adapter = new PrismaPg({
+    connectionString: normalizeConnectionString(databaseUrl),
+  });
   return new PrismaClient({ adapter });
 };
 
-const prisma = globalForPrisma.prisma || createPrismaClient();
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
-
-export default prisma;

--- a/prisma/actions/applications.ts
+++ b/prisma/actions/applications.ts
@@ -15,7 +15,7 @@ import type {
 
 import { getCurrentUser } from '@/lib/auth/server';
 import { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import { type DraftApplication } from '@/lib/types';
 import {
   type ResponseType,

--- a/prisma/actions/global-questions.ts
+++ b/prisma/actions/global-questions.ts
@@ -6,7 +6,7 @@ import { z } from 'zod/v4';
 
 import { getCurrentUser } from '@/lib/auth/server';
 import { CHOICE_TYPES, baseQuestionSchema } from '@/lib/constants';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 function validateOptions(
   data: { type: string; options: string[] },

--- a/prisma/actions/position-actions.ts
+++ b/prisma/actions/position-actions.ts
@@ -8,7 +8,7 @@ import { z } from 'zod/v4';
 import { checkPositionAccess, isManager } from '@/prisma/data/managers';
 
 import { getCurrentUser } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 // description is optional at the server boundary (defaults to '') to support creating
 // draft positions quickly; the plan spec intended required but UI allows empty drafts.

--- a/prisma/actions/position-question-actions.ts
+++ b/prisma/actions/position-question-actions.ts
@@ -7,7 +7,7 @@ import { z } from 'zod/v4';
 import { checkPositionAccess } from '@/prisma/data/managers';
 
 import { getCurrentUser } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 const questionTypeSchema = z.enum([
   'short_answer',

--- a/prisma/actions/profile.ts
+++ b/prisma/actions/profile.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import type { GlobalAnswer } from '@/prisma/client';
 
 import { getCurrentUser } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import { type ResponseType } from '@/lib/utils';
 
 const updateGlobalAnswerSchema = z.object({

--- a/prisma/actions/users.ts
+++ b/prisma/actions/users.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { z } from 'zod/v4';
 
 import { getCurrentUser } from '@/lib/auth/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 const toggleAdminSchema = z.object({
   userId: z.string().min(1),

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { $Enums } from '@/prisma/client';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import {
   type AdminApplicationListItem,
   type ApplicationFilters,

--- a/prisma/data/global-questions.ts
+++ b/prisma/data/global-questions.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 export async function getGlobalQuestions() {
   return prisma.globalQuestion.findMany({

--- a/prisma/data/managers.ts
+++ b/prisma/data/managers.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 // Single source of truth for global manager detection.
 // Returns true if the user manages at least one non-deleted position.

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { cache } from 'react';
 
 import { UNRESOLVED_APPLICATION_STATUSES } from '@/lib/constants';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import {
   type OpenPositionSummaryItem,
   type PositionDetail,

--- a/prisma/data/profile.ts
+++ b/prisma/data/profile.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import type { GlobalAnswer, GlobalQuestion } from '@/prisma/client';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import { type ProfileCompleteness } from '@/lib/types';
 
 export async function getProfileData(

--- a/prisma/data/users.ts
+++ b/prisma/data/users.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 import type { AdminUserListItem } from '@/lib/types';
 
 // Returns all active (non-deactivated) users for the admin /users page.

--- a/prisma/services/dev-bypass.ts
+++ b/prisma/services/dev-bypass.ts
@@ -3,7 +3,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 export type BypassRole = 'admin' | 'applicant' | 'position-manager';
 


### PR DESCRIPTION
Closes #246

## Summary

- Normalizes the `DATABASE_URL` SSL mode in `lib/prisma.ts` before constructing `PrismaPg`, silencing the pg v9 deprecation warning that fires for legacy `sslmode=require/prefer/verify-ca` aliases
- Converts `lib/prisma.ts` from a default export to a named export (following the project's named-exports rule) and updates all 14 importers
- Updates `.env.example` to document `sslmode=verify-full` as the canonical connection string form
- Hardens the Neon preview branch cleanup workflow with an explicit teardown log step so deletion outcome is auditable in CI run logs

## Changes

- `lib/prisma.ts` — adds `normalizeConnectionString()` helper that rewrites `sslmode=require|prefer|verify-ca` → `verify-full` using `URL`/`URLSearchParams`; switches from `default export` to `export const prisma`
- `lib/auth/server.ts`, `prisma/actions/*`, `prisma/data/*`, `prisma/services/dev-bypass.ts`, `app/(app)/layout.tsx` — update 14 import sites from `import prisma from` to `import { prisma } from`
- `.env.example` — documents `?sslmode=verify-full` on both `DATABASE_URL` and `DIRECT_URL` with an explanatory comment
- `.github/workflows/neon-preview-branch.yml` — adds a post-delete log step in the cleanup job that surfaces Neon branch teardown outcome (success or warning) regardless of `continue-on-error`; upgrades the Vercel cleanup error log to use a `::error::` annotation with branch name

## Testing plan

- [ ] Local: set `DATABASE_URL=...?sslmode=require`, run `npm run dev`, hit a DB-backed page (e.g. `/dashboard`), and confirm the `pg` SSL deprecation warning **no longer** appears in server logs
- [ ] Local: confirm the app still connects and queries succeed with the normalized `verify-full` mode (sign in, navigate to `/my-applications`)
- [ ] Local: confirm `normalizeConnectionString` leaves an already-correct `?sslmode=verify-full` URL unchanged (no double-rewrite)
- [ ] Local: set `DATABASE_URL` to a URL without any `sslmode` param and confirm no error is thrown and the URL passes through unchanged
- [ ] Local: set `DATABASE_URL` to a deliberately invalid/deleted endpoint, load a DB-backed page, and confirm no connection-string or credential leakage in the surfaced error
- [ ] Operational: verify each long-lived Vercel environment's `DATABASE_URL` points at a live Neon endpoint (dev, preview default, production) via the Vercel dashboard
- [ ] Operational: open a throwaway PR, confirm `neon-preview-branch.yml` upsert run creates the Neon branch and sets the Vercel `DATABASE_URL`; close the PR, confirm the cleanup run logs "Neon branch preview/<branch> deleted successfully" and removes the Vercel env var

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

The root cause of the "Endpoint Not Found" crash (stale Vercel preview pointing at a deleted Neon branch) is operational, not fixable in code. The code changes make the pg SSL warning go away and bring the export shape into compliance with project conventions. The operational remediation steps (verifying live endpoints, cleaning up stale previews) are captured in the testing plan as human-runnable steps.
