### PR TITLE
#250 Reduce Excessive Padding On Complete Your Profile Card

### DIFF
--- a/app/(main)/(auth)/positions/[id]/apply/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/apply/page.tsx
@@ -68,7 +68,7 @@ export default async function ApplyPage({
       </div>
 
       {!application ? (
-        <Card>
+        <Card className="gap-0 p-0">
           <CardContent className="flex flex-col gap-4 p-4">
             <div>
               <p className="font-medium">Complete your profile first</p>

--- a/components/features/profile-completeness-banner.tsx
+++ b/components/features/profile-completeness-banner.tsx
@@ -21,7 +21,7 @@ export async function ProfileCompletenessBanner({
   const questionWord = missingCount === 1 ? 'question' : 'questions';
 
   return (
-    <Card className="border-warning bg-warning/5">
+    <Card className="border-warning bg-warning/5 gap-0 p-0">
       <CardContent className="flex items-start gap-3 p-4">
         <CircleAlert
           className="text-warning mt-0.5 size-5 shrink-0"


### PR DESCRIPTION
Closes #250

## Summary

- Adds `gap-0 p-0` to the `Card` in `components/features/profile-completeness-banner.tsx` so that `CardContent`'s `p-4` is the sole source of inner spacing.
- Adds `gap-0 p-0` to the `Card` in `app/(main)/(auth)/positions/[id]/apply/page.tsx` for the same reason.

## Changes

- `components/features/profile-completeness-banner.tsx` — added `gap-0 p-0` to `Card` className, keeping the existing `border-warning bg-warning/5` classes and the `CardContent p-4`.
- `app/(main)/(auth)/positions/[id]/apply/page.tsx` — added `className="gap-0 p-0"` to the bare `<Card>`, keeping the `CardContent p-4`.

No logic, schema, or data-fetching changes were made.

## Testing plan

- [ ] Sign in as a user with an incomplete profile (at least one unanswered required global question) and load any page that renders the profile-completeness banner. Confirm the warning card's content sits ~16px (a single `p-4`) from the card border, not ~40px, with the warning border/tint and the "Complete profile" button intact.
- [ ] As the same incomplete-profile user, visit `/positions/<id>/apply` for an open position. Confirm the "Complete your profile first" card shows a single-layer of padding and the "Go to Profile" button still renders correctly.
- [ ] Visually compare both cards against another `gap-0 p-0` card elsewhere in the app to confirm consistent padding.
- [ ] Check both cards at a narrow (mobile) viewport — the banner's content should still stack/align correctly with no overflow.
- [ ] Verify that for users with complete profiles the banner is not shown and the apply page loads the application stepper as usual.

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

`gap-0` is included to match the established convention exactly (15 existing `gap-0 p-0` cards in the codebase). Both affected cards have a single child today so `gap-0` has no current visual effect, but it prevents a regression if a second child is added later.
