### PR TITLE
#252 Show Application Stats On Position Cards For Admins And Managers

### DIFF
--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -18,9 +18,13 @@ export default async function PositionsPage() {
   const user = await getOptionalUser();
   const isAdmin = user?.isAdmin ?? false;
 
-  // Admin branch: unchanged layout — flat list with create action.
+  // Admin branch: flat list with create action and application stats on every card.
   if (isAdmin) {
     const positions = await getAdminPositions();
+    const adminStatsByPosition =
+      positions.length > 0
+        ? await getPositionApplicationStats(positions.map((p) => p.id))
+        : new Map<string, import('@/lib/types').PositionApplicationStats>();
     return (
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
@@ -42,6 +46,7 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={true}
                 isAuthenticated={true}
+                applicationStats={adminStatsByPosition.get(position.id)}
               />
             ))}
           </div>
@@ -122,6 +127,11 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={managedIds.has(position.id)}
                 isAuthenticated={isAuthenticated}
+                applicationStats={
+                  managedIds.has(position.id)
+                    ? statsByPosition.get(position.id)
+                    : undefined
+                }
               />
             ))}
           </div>
@@ -144,6 +154,11 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={managedIds.has(position.id)}
                 isAuthenticated={isAuthenticated}
+                applicationStats={
+                  managedIds.has(position.id)
+                    ? statsByPosition.get(position.id)
+                    : undefined
+                }
               />
             ))}
           </div>

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/prisma/data/positions';
 
 import { getOptionalUser } from '@/lib/auth/server';
+import type { PositionApplicationStats } from '@/lib/types';
 
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
@@ -24,7 +25,7 @@ export default async function PositionsPage() {
     const adminStatsByPosition =
       positions.length > 0
         ? await getPositionApplicationStats(positions.map((p) => p.id))
-        : new Map<string, import('@/lib/types').PositionApplicationStats>();
+        : new Map<string, PositionApplicationStats>();
     return (
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
@@ -72,7 +73,7 @@ export default async function PositionsPage() {
   const statsByPosition =
     managedIds.size > 0
       ? await getPositionApplicationStats([...managedIds])
-      : new Map<string, import('@/lib/types').PositionApplicationStats>();
+      : new Map<string, PositionApplicationStats>();
 
   // Show "Positions I Manage" only when the user actually manages at least one
   // relevant position — non-managers get an empty array, so the section is omitted.

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -1,5 +1,6 @@
 import { Briefcase } from 'lucide-react';
 
+import { getPositionApplicationStats } from '@/prisma/data/applications';
 import {
   getAdminPositions,
   getManagedPositions,
@@ -61,6 +62,13 @@ export default async function PositionsPage() {
   // Build a set of managed IDs so canManage can be derived in O(1) per card.
   const managedIds = new Set(managedPositions.map((p) => p.id));
 
+  // Fetch application stats for managed positions — stats are cross-user aggregates
+  // safe to show to managers (see getPositionApplicationStats() for the invariant).
+  const statsByPosition =
+    managedIds.size > 0
+      ? await getPositionApplicationStats([...managedIds])
+      : new Map<string, import('@/lib/types').PositionApplicationStats>();
+
   // Show "Positions I Manage" only when the user actually manages at least one
   // relevant position — non-managers get an empty array, so the section is omitted.
   const showManagedSection = managedPositions.length > 0;
@@ -85,6 +93,7 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={true}
                 isAuthenticated={isAuthenticated}
+                applicationStats={statsByPosition.get(position.id)}
               />
             ))}
           </div>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -111,27 +111,38 @@ export function PositionCard({
 
   return (
     <Card className="flex flex-col gap-0 p-0">
-      <CardHeader className="p-4 pb-2">
+      {/* Two-column layout: when applicationStats is present the outer div becomes a
+          flex row at sm+, with CardHeader + CardContent in the left column and the
+          stat cluster in a right column that reaches the card's top edge.
+          One-column view (no applicationStats): wrapper and column divs add no classes,
+          card renders exactly as before. */}
+      <div className={cn(applicationStats && 'sm:flex sm:flex-row')}>
+        {/* Left column — header + content stacked; grows to fill available width */}
         <div
           className={cn(
-            'flex items-center gap-2',
-            !applicationStats && 'justify-between',
+            applicationStats && 'sm:flex sm:min-w-0 sm:flex-1 sm:flex-col',
           )}
         >
-          <CardTitle className="text-lg leading-snug">
-            {position.title}
-          </CardTitle>
-          <PositionStatusBadge position={position} />
-        </div>
-      </CardHeader>
+          <CardHeader className="p-4 pb-2">
+            <div
+              className={cn(
+                'flex items-center gap-2',
+                !applicationStats && 'justify-between',
+              )}
+            >
+              <CardTitle className="text-lg leading-snug">
+                {position.title}
+              </CardTitle>
+              <PositionStatusBadge position={position} />
+            </div>
+          </CardHeader>
 
-      <CardContent className="px-4 pb-4">
-        {/* Two-column layout: left column grows and holds description + buttons pinned
-            to the bottom; right column is the stat cluster anchored to the top.
-            When applicationStats is absent the left column takes full width naturally. */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
-          {/* Left column — description, date label, then buttons pushed to the bottom */}
-          <div className="flex min-w-0 flex-1 flex-col">
+          <CardContent
+            className={cn(
+              'px-4 pb-4',
+              applicationStats && 'sm:flex sm:flex-1 sm:flex-col',
+            )}
+          >
             <p className="text-muted-foreground line-clamp-2 text-sm">
               {position.description}
             </p>
@@ -182,17 +193,17 @@ export function PositionCard({
                 </>
               )}
             </div>
-          </div>
-
-          {/* Right column — stat cluster anchored to the top-right of the card;
-              self-start keeps it at the natural top regardless of left-column height */}
-          {canManage && applicationStats && (
-            <div className="self-start">
-              <PositionStatCluster stats={applicationStats} />
-            </div>
-          )}
+          </CardContent>
         </div>
-      </CardContent>
+
+        {/* Right column — stat cluster top-aligned beside the full left column;
+            hidden on mobile so stats only appear in the wide two-column layout */}
+        {applicationStats && (
+          <div className="hidden sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
+            <PositionStatCluster stats={applicationStats} />
+          </div>
+        )}
+      </div>
     </Card>
   );
 }

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -88,7 +88,7 @@ function PositionStatCluster({ stats }: PositionStatClusterProps) {
 
 // Server component — flat summary card with always-visible truncated description
 // and a CTA row linking into the detail page. Managed cards (canManage=true) also
-// show a right-anchored application stats cluster on the same row as the buttons.
+// show a top-right-anchored application stats cluster when applicationStats is passed.
 export function PositionCard({
   position,
   canManage = false,
@@ -112,8 +112,7 @@ export function PositionCard({
   return (
     <Card className="flex flex-col gap-0 p-0">
       <CardHeader className="p-4 pb-2">
-        {/* Title row: status badge sits inline to the right of the title */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-start justify-between gap-2">
           <CardTitle className="text-lg leading-snug">
             {position.title}
           </CardTitle>
@@ -121,65 +120,71 @@ export function PositionCard({
         </div>
       </CardHeader>
 
-      <CardContent className="flex flex-col gap-3 px-4 pb-4">
-        {/* Description + date — unchanged, no stat cluster here */}
-        <div className="min-w-0">
-          <p className="text-muted-foreground line-clamp-2 text-sm">
-            {position.description}
-          </p>
-          {dateLabel && (
-            <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
-          )}
-        </div>
-
-        {/* Bottom row: action buttons on the left, stat cluster on the far right */}
-        <div className="flex items-center justify-between gap-4 pt-1">
-          <div className="flex flex-wrap items-center gap-2">
-            {canManage ? (
-              <>
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/positions/${position.id}`}>View Details</Link>
-                </Button>
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/positions/${position.id}/edit`}>
-                    <Pencil className="size-4" />
-                    Edit
-                  </Link>
-                </Button>
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/applications?positionId=${position.id}`}>
-                    <Inbox className="size-4" />
-                    Applications
-                  </Link>
-                </Button>
-              </>
-            ) : (
-              <>
-                {isAccepting && (
-                  <Button asChild size="sm">
-                    {isAuthenticated ? (
-                      <Link href={`/positions/${position.id}/apply`}>
-                        Apply
-                      </Link>
-                    ) : (
-                      <Link
-                        href={`/login?redirectTo=/positions/${position.id}/apply`}
-                      >
-                        Apply
-                      </Link>
-                    )}
-                  </Button>
-                )}
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/positions/${position.id}`}>View Details</Link>
-                </Button>
-              </>
+      <CardContent className="px-4 pb-4">
+        {/* Two-column layout: left column grows and holds description + buttons pinned
+            to the bottom; right column is the stat cluster anchored to the top.
+            When applicationStats is absent the left column takes full width naturally. */}
+        <div className="flex flex-row items-stretch gap-4">
+          {/* Left column — description, date label, then buttons pushed to the bottom */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <p className="text-muted-foreground line-clamp-2 text-sm">
+              {position.description}
+            </p>
+            {dateLabel && (
+              <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
             )}
+
+            {/* mt-auto ensures buttons always sit at the bottom of the left column */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-3">
+              {canManage ? (
+                <>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/positions/${position.id}`}>View Details</Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/positions/${position.id}/edit`}>
+                      <Pencil className="size-4" />
+                      Edit
+                    </Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/applications?positionId=${position.id}`}>
+                      <Inbox className="size-4" />
+                      Applications
+                    </Link>
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {isAccepting && (
+                    <Button asChild size="sm">
+                      {isAuthenticated ? (
+                        <Link href={`/positions/${position.id}/apply`}>
+                          Apply
+                        </Link>
+                      ) : (
+                        <Link
+                          href={`/login?redirectTo=/positions/${position.id}/apply`}
+                        >
+                          Apply
+                        </Link>
+                      )}
+                    </Button>
+                  )}
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/positions/${position.id}`}>View Details</Link>
+                  </Button>
+                </>
+              )}
+            </div>
           </div>
 
-          {/* Stat cluster — far right of bottom row, beside buttons (managed only) */}
+          {/* Right column — stat cluster anchored to the top-right of the card;
+              self-start keeps it at the natural top regardless of left-column height */}
           {canManage && applicationStats && (
-            <PositionStatCluster stats={applicationStats} />
+            <div className="self-start">
+              <PositionStatCluster stats={applicationStats} />
+            </div>
           )}
         </div>
       </CardContent>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -2,7 +2,16 @@ import Link from 'next/link';
 
 import { Inbox, Pencil } from 'lucide-react';
 
-import type { PositionWithQuestions } from '@/lib/types';
+import {
+  APPLICATION_STATUS_BADGE_VARIANT,
+  APPLICATION_STATUS_LABELS,
+  POSITION_CARD_STAT_STATUSES,
+  STATUS_BADGE_VARIANT_TO_DOT,
+} from '@/lib/constants';
+import type {
+  PositionApplicationStats,
+  PositionWithQuestions,
+} from '@/lib/types';
 import { formatDate, getPositionAvailability } from '@/lib/utils';
 
 import { PositionStatusBadge } from '@/components/features/status-badge';
@@ -13,14 +22,78 @@ interface PositionCardProps {
   position: PositionWithQuestions;
   canManage?: boolean;
   isAuthenticated?: boolean;
+  applicationStats?: PositionApplicationStats;
 }
 
-// Server component — accordion removed; flat summary card with always-visible
-// truncated description and a CTA row linking into the detail page.
+interface PositionStatClusterProps {
+  stats: PositionApplicationStats;
+}
+
+// Co-located server sub-component — compact count+label tiles for managed position cards.
+// Renders a "Total" lead tile and a 2x2 grid of the four key pipeline statuses.
+// Zero-count tiles are dimmed rather than hidden so the cluster shape is stable.
+function PositionStatCluster({ stats }: PositionStatClusterProps) {
+  return (
+    <div aria-label="Application stats" className="shrink-0">
+      {/* Total tile — col-span-2 lead row with hairline divider below */}
+      <div className="border-border mb-2 border-b pb-2">
+        <div className="flex items-center gap-1.5">
+          <span
+            className="bg-primary size-2 shrink-0 rounded-full"
+            aria-hidden="true"
+          />
+          <p className="text-muted-foreground text-[11px] leading-tight">
+            Total
+          </p>
+        </div>
+        <p className="mt-1 text-xl leading-none font-semibold tabular-nums">
+          {stats.total}
+        </p>
+      </div>
+
+      {/* 2x2 grid of key pipeline statuses */}
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+        {POSITION_CARD_STAT_STATUSES.map((status) => {
+          const count = stats.counts[status] ?? 0;
+          const isDimmed = count === 0;
+          const variant = APPLICATION_STATUS_BADGE_VARIANT[status];
+          const dotClass =
+            STATUS_BADGE_VARIANT_TO_DOT[variant] ?? 'bg-muted-foreground';
+
+          return (
+            <div key={status}>
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={`size-1.5 shrink-0 rounded-full ${dotClass} ${isDimmed ? 'opacity-40' : ''}`}
+                  aria-hidden="true"
+                />
+                <p
+                  className={`text-[11px] leading-tight ${isDimmed ? 'text-muted-foreground/60' : 'text-muted-foreground'}`}
+                >
+                  {APPLICATION_STATUS_LABELS[status]}
+                </p>
+              </div>
+              <p
+                className={`mt-0.5 text-xl leading-none font-semibold tabular-nums ${isDimmed ? 'text-muted-foreground/60' : ''}`}
+              >
+                {count}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Server component — flat summary card with always-visible truncated description
+// and a CTA row linking into the detail page. Managed cards (canManage=true) also
+// show a right-anchored application stats cluster when applicationStats is passed.
 export function PositionCard({
   position,
   canManage = false,
   isAuthenticated = false,
+  applicationStats,
 }: PositionCardProps) {
   const availability = getPositionAvailability(position);
   const isAccepting = availability === 'accepting';
@@ -48,13 +121,22 @@ export function PositionCard({
       </CardHeader>
 
       <CardContent className="flex flex-col gap-3 px-4 pb-4">
-        <p className="text-muted-foreground line-clamp-2 text-sm">
-          {position.description}
-        </p>
+        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row">
+          {/* Left: description + date — takes remaining width, truncates */}
+          <div className="min-w-0 flex-1">
+            <p className="text-muted-foreground line-clamp-2 text-sm">
+              {position.description}
+            </p>
+            {dateLabel && (
+              <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
+            )}
+          </div>
 
-        {dateLabel && (
-          <p className="text-muted-foreground text-xs">{dateLabel}</p>
-        )}
+          {/* Right: stats cluster — only for managed cards */}
+          {canManage && applicationStats && (
+            <PositionStatCluster stats={applicationStats} />
+          )}
+        </div>
 
         <div className="flex flex-wrap items-center gap-2 pt-1">
           {canManage ? (

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -196,10 +196,10 @@ export function PositionCard({
           </CardContent>
         </div>
 
-        {/* Right column — stat cluster top-aligned beside the full left column;
-            hidden on mobile so stats only appear in the wide two-column layout */}
+        {/* Right column — stat cluster; stacks below left column on mobile,
+            sits beside it at sm+ in a two-column layout */}
         {applicationStats && (
-          <div className="hidden sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
+          <div className="sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
             <PositionStatCluster stats={applicationStats} />
           </div>
         )}

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -88,7 +88,7 @@ function PositionStatCluster({ stats }: PositionStatClusterProps) {
 
 // Server component — flat summary card with always-visible truncated description
 // and a CTA row linking into the detail page. Managed cards (canManage=true) also
-// show a right-anchored application stats cluster when applicationStats is passed.
+// show a right-anchored application stats cluster on the same row as the buttons.
 export function PositionCard({
   position,
   canManage = false,
@@ -112,7 +112,8 @@ export function PositionCard({
   return (
     <Card className="flex flex-col gap-0 p-0">
       <CardHeader className="p-4 pb-2">
-        <div className="flex items-start justify-between gap-2">
+        {/* Title row: status badge sits inline to the right of the title */}
+        <div className="flex items-center gap-2">
           <CardTitle className="text-lg leading-snug">
             {position.title}
           </CardTitle>
@@ -121,61 +122,64 @@ export function PositionCard({
       </CardHeader>
 
       <CardContent className="flex flex-col gap-3 px-4 pb-4">
-        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row">
-          {/* Left: description + date — takes remaining width, truncates */}
-          <div className="min-w-0 flex-1">
-            <p className="text-muted-foreground line-clamp-2 text-sm">
-              {position.description}
-            </p>
-            {dateLabel && (
-              <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
-            )}
-          </div>
-
-          {/* Right: stats cluster — only for managed cards */}
-          {canManage && applicationStats && (
-            <PositionStatCluster stats={applicationStats} />
+        {/* Description + date — unchanged, no stat cluster here */}
+        <div className="min-w-0">
+          <p className="text-muted-foreground line-clamp-2 text-sm">
+            {position.description}
+          </p>
+          {dateLabel && (
+            <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
           )}
         </div>
 
-        <div className="flex flex-wrap items-center gap-2 pt-1">
-          {canManage ? (
-            <>
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/positions/${position.id}`}>View Details</Link>
-              </Button>
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/positions/${position.id}/edit`}>
-                  <Pencil className="size-4" />
-                  Edit
-                </Link>
-              </Button>
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/applications?positionId=${position.id}`}>
-                  <Inbox className="size-4" />
-                  Applications
-                </Link>
-              </Button>
-            </>
-          ) : (
-            <>
-              {isAccepting && (
-                <Button asChild size="sm">
-                  {isAuthenticated ? (
-                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
-                  ) : (
-                    <Link
-                      href={`/login?redirectTo=/positions/${position.id}/apply`}
-                    >
-                      Apply
-                    </Link>
-                  )}
+        {/* Bottom row: action buttons on the left, stat cluster on the far right */}
+        <div className="flex items-center justify-between gap-4 pt-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {canManage ? (
+              <>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/positions/${position.id}`}>View Details</Link>
                 </Button>
-              )}
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/positions/${position.id}`}>View Details</Link>
-              </Button>
-            </>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/positions/${position.id}/edit`}>
+                    <Pencil className="size-4" />
+                    Edit
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/applications?positionId=${position.id}`}>
+                    <Inbox className="size-4" />
+                    Applications
+                  </Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                {isAccepting && (
+                  <Button asChild size="sm">
+                    {isAuthenticated ? (
+                      <Link href={`/positions/${position.id}/apply`}>
+                        Apply
+                      </Link>
+                    ) : (
+                      <Link
+                        href={`/login?redirectTo=/positions/${position.id}/apply`}
+                      >
+                        Apply
+                      </Link>
+                    )}
+                  </Button>
+                )}
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/positions/${position.id}`}>View Details</Link>
+                </Button>
+              </>
+            )}
+          </div>
+
+          {/* Stat cluster — far right of bottom row, beside buttons (managed only) */}
+          {canManage && applicationStats && (
+            <PositionStatCluster stats={applicationStats} />
           )}
         </div>
       </CardContent>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -199,7 +199,7 @@ export function PositionCard({
         {/* Right column — stat cluster; stacks below left column on mobile,
             sits beside it at sm+ in a two-column layout */}
         {applicationStats && (
-          <div className="sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
+          <div className="px-4 pb-4 sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
             <PositionStatCluster stats={applicationStats} />
           </div>
         )}

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -124,7 +124,7 @@ export function PositionCard({
         {/* Two-column layout: left column grows and holds description + buttons pinned
             to the bottom; right column is the stat cluster anchored to the top.
             When applicationStats is absent the left column takes full width naturally. */}
-        <div className="flex flex-row items-stretch gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
           {/* Left column — description, date label, then buttons pushed to the bottom */}
           <div className="flex min-w-0 flex-1 flex-col">
             <p className="text-muted-foreground line-clamp-2 text-sm">

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -34,7 +34,7 @@ interface PositionStatClusterProps {
 // Zero-count tiles are dimmed rather than hidden so the cluster shape is stable.
 function PositionStatCluster({ stats }: PositionStatClusterProps) {
   return (
-    <div aria-label="Application stats" className="shrink-0">
+    <div role="region" aria-label="Application stats" className="shrink-0">
       {/* Total tile — col-span-2 lead row with hairline divider below */}
       <div className="border-border mb-2 border-b pb-2">
         <div className="flex items-center gap-1.5">

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -12,7 +12,7 @@ import type {
   PositionApplicationStats,
   PositionWithQuestions,
 } from '@/lib/types';
-import { formatDate, getPositionAvailability } from '@/lib/utils';
+import { cn, formatDate, getPositionAvailability } from '@/lib/utils';
 
 import { PositionStatusBadge } from '@/components/features/status-badge';
 import { Button } from '@/components/ui/button';
@@ -112,8 +112,13 @@ export function PositionCard({
   return (
     <Card className="flex flex-col gap-0 p-0">
       <CardHeader className="p-4 pb-2">
-        <div className="flex items-start justify-between gap-2">
-          <CardTitle className="text-lg leading-snug">
+        <div
+          className={cn(
+            'flex items-center gap-2',
+            applicationStats && 'justify-between',
+          )}
+        >
+          <CardTitle className="text-base font-semibold">
             {position.title}
           </CardTitle>
           <PositionStatusBadge position={position} />

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -115,10 +115,10 @@ export function PositionCard({
         <div
           className={cn(
             'flex items-center gap-2',
-            applicationStats && 'justify-between',
+            !applicationStats && 'justify-between',
           )}
         >
-          <CardTitle className="text-base font-semibold">
+          <CardTitle className="text-lg leading-snug">
             {position.title}
           </CardTitle>
           <PositionStatusBadge position={position} />

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -203,3 +203,14 @@ export const STATUS_BADGE_VARIANT_TO_DOT: Record<string, string> = {
   default: 'bg-primary',
   outline: 'bg-border',
 };
+
+// The four application statuses surfaced on position cards for admins/managers.
+// Ordered: Applied → Interview scheduled → Accepted → Rejected.
+// Shared between PositionStatCluster and any future per-position stat consumer
+// so the displayed set is a single source of truth (ENGINEERING §1: abstract at 2+).
+export const POSITION_CARD_STAT_STATUSES = [
+  'applied',
+  'interview_scheduled',
+  'accepted',
+  'rejected',
+] as const satisfies $Enums.ApplicationStatus[];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,7 @@ import type {
   PositionStatus,
   QuestionType,
 } from '@/prisma/client';
-import type { Prisma } from '@/prisma/client';
+import type { $Enums, Prisma } from '@/prisma/client';
 
 import type { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
 
@@ -229,6 +229,15 @@ export type AdminUserListItem = Prisma.UserGetPayload<{
     };
   };
 }>;
+
+// Per-position application stats for admin/manager position cards.
+// Aggregate read-only shape — never exposes individual applicant identity.
+// Must only be passed to cards for positions the caller manages.
+export type PositionApplicationStats = {
+  positionId: string;
+  counts: Partial<Record<$Enums.ApplicationStatus, number>>;
+  total: number;
+};
 
 // Identity shape passed to nav components so sidebar and mobile nav agree
 // on what to display in the user menu.

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -9,6 +9,7 @@ import {
   type ApplicationForReview,
   type MyApplicationListItem,
   type PositionApplicationListItem,
+  type PositionApplicationStats,
 } from '@/lib/types';
 
 const applicationSelect = {
@@ -326,4 +327,44 @@ export async function getReviewablePositions(user: {
     select: { id: true, title: true },
     orderBy: { title: 'asc' },
   });
+}
+
+// Returns non-draft/non-withdrawn application counts per status for a set of
+// position IDs, keyed by positionId. Returns cross-user aggregate data —
+// must be called with caller-managed position IDs only (admin = all positions;
+// manager = their assigned positions). Never call with arbitrary IDs from the client.
+export async function getPositionApplicationStats(
+  positionIds: string[],
+): Promise<Map<string, PositionApplicationStats>> {
+  if (positionIds.length === 0) return new Map();
+
+  const rows = await prisma.application.groupBy({
+    by: ['positionId', 'status'],
+    where: {
+      positionId: { in: positionIds },
+      deletedAt: null,
+      status: { notIn: ['draft', 'withdrawn'] },
+    },
+    _count: true,
+  });
+
+  const map = new Map<string, PositionApplicationStats>();
+
+  for (const row of rows) {
+    const existing = map.get(row.positionId) ?? {
+      positionId: row.positionId,
+      counts: {} as Partial<Record<$Enums.ApplicationStatus, number>>,
+      total: 0,
+    };
+    existing.counts[row.status] = row._count;
+    existing.total += row._count;
+    map.set(row.positionId, existing);
+  }
+
+  // Ensure every requested position has an entry (zero-count positions get an empty stats object).
+  for (const id of positionIds) {
+    if (!map.has(id)) map.set(id, { positionId: id, counts: {}, total: 0 });
+  }
+
+  return map;
 }


### PR DESCRIPTION
Closes #252

## Summary

- Adds a compact application stats cluster to position cards for admins and managers, showing Total plus Applied / Interview Scheduled / Accepted / Rejected counts inline
- Adds `getPositionApplicationStats()` data function using a single `groupBy` query (no N+1) and exposes it only to cards the caller manages
- Zero-count tiles are dimmed rather than hidden, keeping the cluster shape stable; stats stack below the description on mobile

## Changes

- `lib/types.ts` — added `PositionApplicationStats` type (`positionId`, `counts`, `total`)
- `lib/constants.ts` — added `POSITION_CARD_STAT_STATUSES` tuple (the 4 surfaced statuses in order)
- `prisma/data/applications.ts` — added `getPositionApplicationStats(positionIds)`: early-returns an empty Map when the list is empty, otherwise issues a single `groupBy(['positionId', 'status'])` query filtered to non-draft/non-withdrawn; folds rows into a `Map<string, PositionApplicationStats>`; ensures every requested position has an entry
- `components/features/position-card.tsx` — added optional `applicationStats` prop; restructured description region into left (description/date) + right (stats cluster) row with `flex-col sm:flex-row`; added co-located `PositionStatCluster` server sub-component with Total lead tile + 2×2 status grid using design-token dot colors from `STATUS_BADGE_VARIANT_TO_DOT`
- `app/(main)/positions/page.tsx` — fetches stats for managed position IDs after positions resolve; passes `applicationStats` only to cards where `canManage` is true

## Testing plan

- [ ] As an **admin**, open `/positions`: every position card shows the stats cluster on the right; Total equals the sum of the four shown statuses (cross-check against `/applications?positionId=<id>`)
- [ ] As a **manager** (non-admin), open `/positions`: only cards for positions you manage show the cluster; non-managed open positions show none
- [ ] As an **applicant / anonymous** user: no stats cluster on any card; description spans full width unchanged
- [ ] Seed a position with applications across statuses including some `draft` and `withdrawn`: confirm draft/withdrawn are excluded from both Total and the per-status tiles
- [ ] A managed position with zero submitted applications shows `Total 0` with all-dimmed status tiles (not a blank/missing cluster)
- [ ] Resize to mobile width (375px): stats stack below the description, tiles remain readable, no overflow or layout shift; description still truncates to two lines
- [ ] Confirm a single DB round-trip for stats (one `groupBy` query, not one per card) — check server logs or query count

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed (0 warnings)
- `npm run tsc:check` — passed

## Notes

- `getPositionApplicationStats` does not authenticate itself — it is a cross-user aggregate read that the page scopes to `managedIds` (admin = all positions, manager = assigned positions). A `// must be called with caller-managed position IDs only` comment is included matching the convention used by `getApplicationStatusCounts`.
- `PositionStatCluster` is kept as a co-located private sub-component (not exported) because it is only meaningful within `PositionCard`. If a second consumer appears, it should be promoted to `components/features/`.
- Dot colors are resolved via `APPLICATION_STATUS_BADGE_VARIANT[status]` → `STATUS_BADGE_VARIANT_TO_DOT[variant]`, the same chain used by `PipelineSummary` and `StatCard`.
