### PR TITLE
#258 Migrate Remaining Zod Imports To zod/v4 Across Actions Layer

### DIFF
--- a/prisma/actions/applications.ts
+++ b/prisma/actions/applications.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import type {
   Application,

--- a/prisma/actions/profile.ts
+++ b/prisma/actions/profile.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import type { GlobalAnswer } from '@/prisma/client';
 


### PR DESCRIPTION
Closes #258

## Summary

- Updated `prisma/actions/applications.ts` to import `z` from `'zod/v4'` instead of `'zod'`
- Updated `prisma/actions/profile.ts` to import `z` from `'zod/v4'` instead of `'zod'`

These were the only two remaining files in `prisma/actions/` using the bare `'zod'` import; all other action files and `lib/` already used `'zod/v4'`.

## Changes

- `prisma/actions/applications.ts` — line 5 `from 'zod'` → `from 'zod/v4'`
- `prisma/actions/profile.ts` — line 5 `from 'zod'` → `from 'zod/v4'`

## Testing plan

- [ ] `npm run tsc:check` passes with no new errors (verified locally — clean)
- [ ] `npm run eslint:check` passes (verified locally — clean)
- [ ] `npm run prettier:check` passes (verified locally — clean)
- [ ] Grep `from 'zod'` across `prisma/` and `lib/` returns no bare (non-`/v4`) matches
- [ ] Smoke test: update a profile field (e.g. display name) — action validates and saves correctly
- [ ] Smoke test: create or update an application answer — input validation accepts valid input and rejects invalid input as before

## Automated checks

- TypeScript: clean
- ESLint: clean (0 warnings)
- Prettier: all files formatted correctly

## Notes

No v4 breaking-change risk. Both files use only `z.object`, `z.string().min()`, `z.array`, `z.boolean`, `z.enum(...)`, and `.safeParse` — none of the surfaces changed between zod v3 and v4 (`.refine`/`.superRefine`, `errorMap`, constructor option shorthands). The `z.enum(REVIEWER_APPLICATION_STATUSES)` const-tuple pattern in `applications.ts` matches the already-migrated pattern in `lib/constants.ts`.
