### PR TITLE
#255 Update Sign-In Language To Communicate Sign-Up For New Users

### DIFF
--- a/app/(legal)/privacy/page.tsx
+++ b/app/(legal)/privacy/page.tsx
@@ -161,8 +161,8 @@ export default function PrivacyPolicyPage() {
           Terms of Service
         </Link>
         <span aria-hidden>·</span>
-        <Link href="/login" className="hover:text-foreground hover:underline">
-          Back to sign in
+        <Link href="/" className="hover:text-foreground hover:underline">
+          Back to home
         </Link>
       </footer>
     </article>

--- a/app/(legal)/terms/page.tsx
+++ b/app/(legal)/terms/page.tsx
@@ -117,8 +117,8 @@ export default function TermsOfServicePage() {
           Terms of Service
         </Link>
         <span aria-hidden>·</span>
-        <Link href="/login" className="hover:text-foreground hover:underline">
-          Back to sign in
+        <Link href="/" className="hover:text-foreground hover:underline">
+          Back to home
         </Link>
       </footer>
     </article>

--- a/app/(main)/positions/[id]/page.tsx
+++ b/app/(main)/positions/[id]/page.tsx
@@ -91,7 +91,7 @@ export default async function PublicPositionDetailPage({
             ) : (
               <Button asChild>
                 <Link href={`/login?redirectTo=/positions/${id}/apply`}>
-                  Sign in to apply
+                  Apply
                 </Link>
               </Button>
             )}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -60,7 +60,7 @@ export default async function SignInPage({
               }
             : {
                 SIGN_IN_DESCRIPTION:
-                  "Enter your email to sign in. We'll send you a one-time code.",
+                  "Enter your email to sign in or create an account. We'll send you a one-time code.",
                 EMAIL_OTP: '',
               }
         }

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -85,7 +85,7 @@ export function PositionCard({
                     <Link
                       href={`/login?redirectTo=/positions/${position.id}/apply`}
                     >
-                      Sign in to apply
+                      Apply
                     </Link>
                   )}
                 </Button>


### PR DESCRIPTION
Closes #255

## Summary

- Updated the login page description (non-apply branch) to say "sign in or create an account" so first-time visitors understand they can register here.
- Changed unauthenticated apply CTAs from "Sign in to apply" to plain "Apply" (the redirect to `/login?redirectTo=…/apply` is unchanged, so the behavior is identical).
- Retargeted the footer "Back to sign in" link on `/terms` and `/privacy` to `href="/"` with text "Back to home", as the nav destination is more accurately the home page (which redirects signed-out users to login and signed-in users to the dashboard).

## Changes

- `app/login/page.tsx` — `SIGN_IN_DESCRIPTION` in the non-apply localization branch updated to include "or create an account".
- `components/features/position-card.tsx` — unauthenticated apply button text changed from "Sign in to apply" to "Apply".
- `app/(main)/positions/[id]/page.tsx` — unauthenticated apply button text changed from "Sign in to apply" to "Apply".
- `app/(legal)/terms/page.tsx` — footer link text "Back to sign in" → "Back to home", `href="/login"` → `href="/"`.
- `app/(legal)/privacy/page.tsx` — footer link text "Back to sign in" → "Back to home", `href="/login"` → `href="/"`.

## Testing plan

- [ ] Signed out, open `/login` (no `redirectTo`): description reads "Enter your email to sign in or create an account. We'll send you a one-time code."; heading and submit button are unchanged.
- [ ] Signed out, open `/login?redirectTo=/positions/<id>/apply`: still shows the unchanged "Continue Your Application" copy (apply-context branch untouched).
- [ ] Signed out, desktop >= md: sidebar bottom CTA still reads "Sign in" (no change).
- [ ] Signed out, mobile < md: open the menu drawer; bottom CTA still reads "Sign in" (no change).
- [ ] Signed out, on an open position card: apply CTA reads "Apply" and still links to `/login?redirectTo=…/apply`.
- [ ] Signed out, on a position detail page: unauthenticated apply button reads "Apply" and still links to `/login?redirectTo=…/apply`.
- [ ] Open `/terms`: footer link reads "Back to home"; clicking it navigates to `/` (anonymous → redirected to `/login`; signed-in → dashboard).
- [ ] Open `/privacy`: footer link reads "Back to home"; clicking it navigates to `/`.
- [ ] Signed in: nav shows user menu; apply buttons read "Apply" / "Apply now" — no regression.

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

This is a copy-only change. No schema, server actions, data fetching, or component structure was modified. The sidebar and mobile-nav sign-in buttons are explicitly left unchanged per the revised plan.
