### PR TITLE
#251 Positions Page: Separate Open, Recently Closed, And Managed Sections

### DIFF
--- a/app/(main)/positions/loading.tsx
+++ b/app/(main)/positions/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function PositionsLoading() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-8">
       <div className="flex items-center justify-between gap-4">
         <Skeleton className="h-8 w-40" />
       </div>

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -69,6 +69,28 @@ export default async function PositionsPage() {
     <div className="flex flex-col gap-8">
       <h1 className="text-2xl font-semibold tracking-tight">Positions</h1>
 
+      {/* My Positions — shown first for managers; omitted when empty (non-manager or no relevant positions) */}
+      {showManagedSection && (
+        <section
+          aria-labelledby="my-positions-heading"
+          className="flex flex-col gap-4"
+        >
+          <h2 id="my-positions-heading" className="text-lg font-semibold">
+            My Positions
+          </h2>
+          <div className="flex flex-col gap-4">
+            {managedPositions.map((position) => (
+              <PositionCard
+                key={position.id}
+                position={position}
+                canManage={true}
+                isAuthenticated={isAuthenticated}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Open Positions — always rendered, even when empty */}
       <section
         aria-labelledby="open-positions-heading"
@@ -112,28 +134,6 @@ export default async function PositionsPage() {
                 key={position.id}
                 position={position}
                 canManage={managedIds.has(position.id)}
-                isAuthenticated={isAuthenticated}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Positions I Manage — omitted when empty (non-manager or no relevant positions) */}
-      {showManagedSection && (
-        <section
-          aria-labelledby="managed-positions-heading"
-          className="flex flex-col gap-4"
-        >
-          <h2 id="managed-positions-heading" className="text-lg font-semibold">
-            Positions I Manage
-          </h2>
-          <div className="flex flex-col gap-4">
-            {managedPositions.map((position) => (
-              <PositionCard
-                key={position.id}
-                position={position}
-                canManage={true}
                 isAuthenticated={isAuthenticated}
               />
             ))}

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -1,7 +1,11 @@
 import { Briefcase } from 'lucide-react';
 
-import { getManagedPositionIds } from '@/prisma/data/managers';
-import { getPositions } from '@/prisma/data/positions';
+import {
+  getAdminPositions,
+  getManagedPositions,
+  getOpenPositions,
+  getRecentlyClosedPositions,
+} from '@/prisma/data/positions';
 
 import { getOptionalUser } from '@/lib/auth/server';
 
@@ -12,45 +16,129 @@ import { EmptyState } from '@/components/ui/empty-state';
 export default async function PositionsPage() {
   const user = await getOptionalUser();
   const isAdmin = user?.isAdmin ?? false;
+
+  // Admin branch: unchanged layout — flat list with create action.
+  if (isAdmin) {
+    const positions = await getAdminPositions();
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-2xl font-semibold tracking-tight">Positions</h1>
+          <PositionCreateDialog />
+        </div>
+        {positions.length === 0 ? (
+          <EmptyState
+            icon={Briefcase}
+            title="No positions yet"
+            description="Create your first position to start accepting applications."
+            action={<PositionCreateDialog />}
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            {positions.map((position) => (
+              <PositionCard
+                key={position.id}
+                position={position}
+                canManage={true}
+                isAuthenticated={true}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   const isAuthenticated = user !== null;
-  const positions = await getPositions({ isAdmin, userId: user?.id ?? null });
-  const managedIds = isAdmin
-    ? new Set(positions.map((p) => p.id))
-    : user
-      ? await getManagedPositionIds(user.id)
-      : new Set<string>();
+
+  // Fetch open and recently-closed in parallel; fetch managed only when signed in.
+  const [openPositions, recentlyClosed, managedPositions] = await Promise.all([
+    getOpenPositions(),
+    getRecentlyClosedPositions(),
+    user ? getManagedPositions(user.id) : Promise.resolve([]),
+  ]);
+
+  // Build a set of managed IDs so canManage can be derived in O(1) per card.
+  const managedIds = new Set(managedPositions.map((p) => p.id));
+
+  // Show "Positions I Manage" only when the user actually manages at least one
+  // relevant position — non-managers get an empty array, so the section is omitted.
+  const showManagedSection = managedPositions.length > 0;
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {isAdmin ? 'Positions' : 'Open Positions'}
-        </h1>
-        {isAdmin && <PositionCreateDialog />}
-      </div>
+    <div className="flex flex-col gap-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Positions</h1>
 
-      {positions.length === 0 ? (
-        <EmptyState
-          icon={Briefcase}
-          title={isAdmin ? 'No positions yet' : 'No open positions'}
-          description={
-            isAdmin
-              ? 'Create your first position to start accepting applications.'
-              : 'Check back later for open positions.'
-          }
-          action={isAdmin ? <PositionCreateDialog /> : undefined}
-        />
-      ) : (
-        <div className="flex flex-col gap-4">
-          {positions.map((position) => (
-            <PositionCard
-              key={position.id}
-              position={position}
-              canManage={managedIds.has(position.id)}
-              isAuthenticated={isAuthenticated}
-            />
-          ))}
-        </div>
+      {/* Open Positions — always rendered, even when empty */}
+      <section
+        aria-labelledby="open-positions-heading"
+        className="flex flex-col gap-4"
+      >
+        <h2 id="open-positions-heading" className="text-lg font-semibold">
+          Open Positions
+        </h2>
+        {openPositions.length === 0 ? (
+          <EmptyState
+            icon={Briefcase}
+            title="No open positions"
+            description="Check back later for open positions."
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            {openPositions.map((position) => (
+              <PositionCard
+                key={position.id}
+                position={position}
+                canManage={managedIds.has(position.id)}
+                isAuthenticated={isAuthenticated}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recently Closed — omitted when empty (showing nothing is less noisy) */}
+      {recentlyClosed.length > 0 && (
+        <section
+          aria-labelledby="recently-closed-heading"
+          className="flex flex-col gap-4"
+        >
+          <h2 id="recently-closed-heading" className="text-lg font-semibold">
+            Recently Closed
+          </h2>
+          <div className="flex flex-col gap-4">
+            {recentlyClosed.map((position) => (
+              <PositionCard
+                key={position.id}
+                position={position}
+                canManage={managedIds.has(position.id)}
+                isAuthenticated={isAuthenticated}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Positions I Manage — omitted when empty (non-manager or no relevant positions) */}
+      {showManagedSection && (
+        <section
+          aria-labelledby="managed-positions-heading"
+          className="flex flex-col gap-4"
+        >
+          <h2 id="managed-positions-heading" className="text-lg font-semibold">
+            Positions I Manage
+          </h2>
+          <div className="flex flex-col gap-4">
+            {managedPositions.map((position) => (
+              <PositionCard
+                key={position.id}
+                position={position}
+                canManage={true}
+                isAuthenticated={isAuthenticated}
+              />
+            ))}
+          </div>
+        </section>
       )}
     </div>
   );

--- a/components/features/open-positions-widget.tsx
+++ b/components/features/open-positions-widget.tsx
@@ -2,9 +2,7 @@ import Link from 'next/link';
 
 import { ArrowRight, Briefcase } from 'lucide-react';
 
-import { getPositions } from '@/prisma/data/positions';
-
-import { formatDate, getPositionAvailability } from '@/lib/utils';
+import { getOpenPositions } from '@/prisma/data/positions';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -16,9 +14,8 @@ interface OpenPositionsWidgetProps {
 export async function OpenPositionsWidget({
   limit = 3,
 }: OpenPositionsWidgetProps) {
-  // isAdmin:false + userId:null → open-only positions; does not surface a
-  // manager's draft/closed positions in this "Open Positions" widget context.
-  const positions = await getPositions({ isAdmin: false, userId: null });
+  // getOpenPositions() returns only accepting positions (no upcoming/closed_by_date).
+  const positions = await getOpenPositions();
   const displayed = positions.slice(0, limit);
 
   return (
@@ -55,39 +52,26 @@ export async function OpenPositionsWidget({
           </div>
         ) : (
           <ul className="divide-y">
-            {displayed.map((position) => {
-              const availability = getPositionAvailability(position);
-              const isAccepting = availability === 'accepting';
-              return (
-                <li key={position.id} className="flex flex-col gap-1.5 p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium">
-                        {position.title}
+            {displayed.map((position) => (
+              <li key={position.id} className="flex flex-col gap-1.5 p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {position.title}
+                    </p>
+                    {position.description && (
+                      <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
+                        {position.description}
                       </p>
-                      {position.description && (
-                        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
-                          {position.description}
-                        </p>
-                      )}
-                    </div>
-                    {isAccepting ? (
-                      <Button asChild size="sm" className="shrink-0">
-                        <Link href={`/positions/${position.id}/apply`}>
-                          Apply
-                        </Link>
-                      </Button>
-                    ) : (
-                      <span className="text-muted-foreground shrink-0 text-xs">
-                        {availability === 'upcoming' && position.opensAt
-                          ? `Opens ${formatDate(position.opensAt)}`
-                          : 'Closed'}
-                      </span>
                     )}
                   </div>
-                </li>
-              );
-            })}
+                  {/* All positions from getOpenPositions() are accepting — always show Apply */}
+                  <Button asChild size="sm" className="shrink-0">
+                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
+                  </Button>
+                </div>
+              </li>
+            ))}
           </ul>
         )}
       </CardContent>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -122,6 +122,22 @@ export const UNRESOLVED_APPLICATION_STATUSES = [
   'reviewing',
 ] as const satisfies $Enums.ApplicationStatus[];
 
+// Non-terminal application statuses — all statuses except 'accepted', 'rejected',
+// and 'withdrawn'. Intentionally includes 'draft' (unlike UNRESOLVED_APPLICATION_STATUSES),
+// because a managed position with a draft-only applicant still warrants attention.
+// Used to determine whether a managed position is still relevant for managers.
+export const NON_TERMINAL_APPLICATION_STATUSES = [
+  'draft',
+  'applied',
+  'reached_out',
+  'interview_scheduled',
+  'reviewing',
+] as const satisfies $Enums.ApplicationStatus[];
+
+// Window (in days) for the "Recently Closed" positions section.
+// Positions closed within this window appear in that section.
+export const RECENTLY_CLOSED_WINDOW_DAYS = 7;
+
 export const STATUS_OPTIONS: { value: PositionStatus; label: string }[] = [
   { value: 'draft', label: 'Draft' },
   { value: 'open', label: 'Open' },

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -138,6 +138,11 @@ export const NON_TERMINAL_APPLICATION_STATUSES = [
 // Positions closed within this window appear in that section.
 export const RECENTLY_CLOSED_WINDOW_DAYS = 7;
 
+// Window (in days) for the managed/admin positions visibility filter.
+// Closed positions remain visible to managers and admins for longer than the
+// public "Recently Closed" section so they retain oversight during wrap-up.
+export const MANAGED_POSITIONS_WINDOW_DAYS = 30;
+
 export const STATUS_OPTIONS: { value: PositionStatus; label: string }[] = [
   { value: 'draft', label: 'Draft' },
   { value: 'open', label: 'Open' },

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -2,7 +2,11 @@ import 'server-only';
 
 import { cache } from 'react';
 
-import { UNRESOLVED_APPLICATION_STATUSES } from '@/lib/constants';
+import {
+  NON_TERMINAL_APPLICATION_STATUSES,
+  RECENTLY_CLOSED_WINDOW_DAYS,
+  UNRESOLVED_APPLICATION_STATUSES,
+} from '@/lib/constants';
 import { prisma } from '@/lib/prisma';
 import {
   type OpenPositionSummaryItem,
@@ -10,7 +14,7 @@ import {
   type PositionForEdit,
   type PositionWithQuestions,
 } from '@/lib/types';
-import { isAcceptingApplications } from '@/lib/utils';
+import { getPositionAvailability, isAcceptingApplications } from '@/lib/utils';
 
 // Shared select shape for PositionWithQuestions queries — extracted once so
 // every function returns the same type without duplicating the object literal.
@@ -35,28 +39,98 @@ const positionWithQuestionsSelect = {
   },
 } as const;
 
-// Manager-aware positions query.
-// Admin: all non-deleted positions.
-// Non-admin with userId: open positions ∪ positions the user manages (including drafts).
-// Non-admin without userId (public/anonymous): open positions only.
-export async function getPositions({
-  isAdmin,
-  userId,
-}: {
-  isAdmin: boolean;
-  userId: string | null;
-}): Promise<PositionWithQuestions[]> {
-  return prisma.position.findMany({
-    where: isAdmin
-      ? { deletedAt: null }
-      : userId
-        ? {
-            deletedAt: null,
-            OR: [{ status: 'open' }, { managers: { some: { id: userId } } }],
-          }
-        : { deletedAt: null, status: 'open' },
+// Public: positions currently accepting applications (status 'open', non-deleted).
+// Post-fetch filter via isAcceptingApplications drops 'upcoming' and 'closed_by_date'
+// rows — the end-of-day-inclusive closesAt math cannot be expressed cleanly in a
+// Prisma where clause, so filtering post-fetch keeps one source of truth.
+export async function getOpenPositions(): Promise<PositionWithQuestions[]> {
+  const positions = await prisma.position.findMany({
+    where: { status: 'open', deletedAt: null },
     select: positionWithQuestionsSelect,
     orderBy: { title: 'asc' },
+  });
+  return positions.filter((p) => isAcceptingApplications(p));
+}
+
+// Public: positions closed within the last RECENTLY_CLOSED_WINDOW_DAYS days.
+// Three OR branches cover the different ways a position can be "recently closed":
+//   1. status:'closed' with an explicit closesAt within the window
+//   2. status:'closed' with no closesAt — fall back to updatedAt recency
+//   3. status:'open' with a closesAt in the past (within the window) — closed_by_date
+// Post-fetch filter keeps only rows that are actually closed (status:'closed' or
+// availability:'closed_by_date') so a still-accepting or upcoming open row never lands here.
+export async function getRecentlyClosedPositions(): Promise<
+  PositionWithQuestions[]
+> {
+  const now = new Date();
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - RECENTLY_CLOSED_WINDOW_DAYS);
+
+  const positions = await prisma.position.findMany({
+    where: {
+      deletedAt: null,
+      OR: [
+        // Explicitly closed, close date within the window
+        { status: 'closed', closesAt: { gte: cutoff } },
+        // Closed without an explicit close date — use updatedAt as a proxy
+        { status: 'closed', closesAt: null, updatedAt: { gte: cutoff } },
+        // Still 'open' in the DB but past its closesAt within the window
+        { status: 'open', closesAt: { gte: cutoff, lte: now } },
+      ],
+    },
+    select: positionWithQuestionsSelect,
+    orderBy: [{ closesAt: 'desc' }, { title: 'asc' }],
+  });
+
+  // Keep only rows that are genuinely closed — drops any open row that is
+  // still accepting or upcoming (should not happen given the where, but
+  // ensures correctness if closesAt end-of-day math creates an edge case).
+  return positions.filter((p) => {
+    if (p.status === 'closed') return true;
+    const availability = getPositionAvailability(p);
+    return availability === 'closed_by_date';
+  });
+}
+
+// Manager-facing: positions the user manages that still warrant attention.
+// A managed position is included when any of these hold:
+//   - status is 'open' (always active)
+//   - status is 'closed' and closesAt is within the last 30 days
+//   - status is 'closed' and closesAt is null, but updatedAt is within 30 days
+//   - has at least one application in a non-terminal status (including 'draft')
+// Long-dead managed positions (closed >30 days ago, all applications resolved) are hidden.
+// The 30-day window deliberately differs from RECENTLY_CLOSED_WINDOW_DAYS (7 days)
+// so managers retain visibility for longer while the public "Recently Closed" section
+// stays concise.
+export async function getManagedPositions(
+  userId: string,
+): Promise<PositionWithQuestions[]> {
+  const cutoff30 = new Date();
+  cutoff30.setDate(cutoff30.getDate() - 30);
+
+  return prisma.position.findMany({
+    where: {
+      managers: { some: { id: userId } },
+      deletedAt: null,
+      OR: [
+        { status: 'open' },
+        // Recently closed via explicit close date (30-day window)
+        { status: 'closed', closesAt: { gte: cutoff30 } },
+        // Recently closed fallback when closesAt is null — use updatedAt recency
+        { status: 'closed', closesAt: null, updatedAt: { gte: cutoff30 } },
+        // Closed but still has non-terminal applications
+        {
+          applications: {
+            some: {
+              deletedAt: null,
+              status: { in: [...NON_TERMINAL_APPLICATION_STATUSES] },
+            },
+          },
+        },
+      ],
+    },
+    select: positionWithQuestionsSelect,
+    orderBy: [{ status: 'asc' }, { title: 'asc' }],
   });
 }
 

--- a/prisma/data/positions.ts
+++ b/prisma/data/positions.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { cache } from 'react';
 
 import {
+  MANAGED_POSITIONS_WINDOW_DAYS,
   NON_TERMINAL_APPLICATION_STATUSES,
   RECENTLY_CLOSED_WINDOW_DAYS,
   UNRESOLVED_APPLICATION_STATUSES,
@@ -106,7 +107,7 @@ export async function getManagedPositions(
   userId: string,
 ): Promise<PositionWithQuestions[]> {
   const cutoff30 = new Date();
-  cutoff30.setDate(cutoff30.getDate() - 30);
+  cutoff30.setDate(cutoff30.getDate() - MANAGED_POSITIONS_WINDOW_DAYS);
 
   return prisma.position.findMany({
     where: {
@@ -144,7 +145,7 @@ export async function getManagedPositions(
 // Returns cross-position data — must only be called from an admin-gated context.
 export async function getAdminPositions(): Promise<PositionWithQuestions[]> {
   const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - 30);
+  cutoff.setDate(cutoff.getDate() - MANAGED_POSITIONS_WINDOW_DAYS);
 
   return prisma.position.findMany({
     where: {


### PR DESCRIPTION
Closes #251

## Summary

- Replace the single `getPositions()` query with three intention-named data functions: `getOpenPositions()` (accepting-only, post-fetch filtered), `getRecentlyClosedPositions()` (7-day window), and `getManagedPositions()` (30-day relevance window for non-admin managers)
- Render the non-admin positions page as up to three labeled sections (`<h2>` under a single `<h1>`), with correct `aria-labelledby` accessibility wiring; admin branch is unchanged
- Repoint the dashboard `OpenPositionsWidget` to `getOpenPositions()` and simplify item rendering to always show the Apply button (no dead `upcoming`/`closed_by_date` branch)

## Changes

- `lib/constants.ts` — add `RECENTLY_CLOSED_WINDOW_DAYS = 7` and `NON_TERMINAL_APPLICATION_STATUSES` (all statuses except `accepted`/`rejected`/`withdrawn`, intentionally includes `draft`)
- `prisma/data/positions.ts` — remove `getPositions()`; add `getOpenPositions()`, `getRecentlyClosedPositions()`, `getManagedPositions(userId)`
- `app/(main)/positions/page.tsx` — three-section layout for non-admin; parallel `Promise.all` fetches; admin branch uses `getAdminPositions()` directly
- `components/features/open-positions-widget.tsx` — repointed to `getOpenPositions()`; simplified item rendering (Apply button always shown)

## Testing plan

- [ ] As an anonymous user, visit `/positions`: see "Open Positions" heading and "Recently Closed" section (if non-empty); no "Positions I Manage" section appears
- [ ] As an authenticated non-manager, visit `/positions`: identical to anonymous — "Open Positions" + "Recently Closed", no managed section
- [ ] Verify a position with `status:'open'` and a `closesAt` date in the past (within 7 days) is absent from "Open Positions" and appears under "Recently Closed"
- [ ] Verify a position with `status:'open'` and `closesAt` more than 7 days in the past does not appear in "Recently Closed"
- [ ] Verify a position with a future `opensAt` is absent from both "Open Positions" and "Recently Closed" for non-managers
- [ ] As a manager (non-admin), visit `/positions`: see all three sections. "Positions I Manage" includes: an open managed position, a managed position closed within 30 days, a managed position with a non-terminal application; it excludes a managed position closed >30 days ago whose applications are all `accepted`/`rejected`/`withdrawn`
- [ ] Verify a managed open position also appears in "Open Positions"; a managed position closed within 7 days also appears in "Recently Closed"
- [ ] As an admin, visit `/positions`: unchanged layout (flat list with "Positions" heading and Create button)
- [ ] On the dashboard, verify the "Open Positions" widget lists only accepting positions, each with an Apply button (no "Opens …" or "Closed" labels)
- [ ] When "Open Positions" has zero results, verify the empty state (Briefcase icon, "No open positions" title, "Check back later for open positions." description) renders instead of a blank container
- [ ] When "Recently Closed" has zero results, verify the section is omitted entirely
- [ ] When "Positions I Manage" has zero results (non-manager), verify the section is omitted entirely

## Automated checks

- Prettier: pass
- ESLint: pass
- TypeScript: pass

## Notes

- `NON_TERMINAL_APPLICATION_STATUSES` intentionally includes `draft` (unlike `UNRESOLVED_APPLICATION_STATUSES`) because a manager should see a position that has a draft application pending — per ticket spec "not accepted/rejected/withdrawn"
- The 30-day managed window deliberately differs from the 7-day recently-closed window; the two constants are independent so each can be tuned separately
- Post-fetch filtering in `getOpenPositions()` and `getRecentlyClosedPositions()` keeps the end-of-day-inclusive `closesAt` logic in one place (`getPositionAvailability` in `lib/utils.ts`) rather than duplicating timezone math in Prisma `where` clauses
