### PR TITLE
#267 Destructive Dropdown Items Should Use variant='destructive' So Icons Inherit The Color

### DIFF
--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -140,9 +140,10 @@ export function UserMenu({
         </DropdownMenuSub>
         <DropdownMenuSeparator />
         <DropdownMenuItem
+          variant="destructive"
           disabled={pending}
           onSelect={handleLogout}
-          className="text-destructive cursor-pointer text-sm"
+          className="cursor-pointer text-sm"
         >
           <LogOut className="size-4" aria-hidden />
           Log out


### PR DESCRIPTION
Closes #267

## Summary

- Replaced manual `className="text-destructive"` on the Log out `DropdownMenuItem` with the component's built-in `variant="destructive"` prop so the `LogOut` icon inherits the correct color via the component's `!text-destructive` SVG rule

## Changes

- `components/layouts/user-menu.tsx` — Log out item: removed `text-destructive` from `className`, added `variant="destructive"` prop; kept `cursor-pointer text-sm`

## Testing plan

- [ ] Open the user menu (sidebar variant) — confirm the Log out label and LogOut icon are both destructive-colored (red), not muted
- [ ] Open the user menu (header/mobile variant) — same check
- [ ] Hover/focus the Log out item — confirm it shows the destructive focus background (`data-[variant=destructive]:focus:bg-destructive/10`) with destructive text and icon
- [ ] Toggle light theme and dark theme — verify destructive color holds in both
- [ ] Tab/arrow-key to the Log out item and press Enter — confirm sign-out triggers as before (no behavior regression)
- [ ] Confirm no other `DropdownMenuItem` element in the codebase has a stray `text-destructive` className (audit result: none)

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

Codebase audit confirmed only one affected call site: `components/layouts/user-menu.tsx`. All other `text-destructive` usages are on non-dropdown elements (form labels, plain buttons, spans) and are correct as-is.
