### PR TITLE
#263 Constrain Login Page Width To Match Bypass Login (max-w-sm)

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -34,12 +34,12 @@ export default async function SignInPage({
   const isDev = process.env.VERCEL_ENV !== 'production';
 
   return (
-    <div className="flex w-full flex-col items-center gap-4">
+    <div className="flex w-full max-w-sm flex-col items-center gap-4">
       <AuthView
         path="SIGN_IN"
         redirectTo={safeTo}
         classNames={{
-          base: 'max-w-xl',
+          base: 'w-full',
           content: 'w-full',
           form: { base: 'w-full', otpInputContainer: 'justify-center' },
         }}


### PR DESCRIPTION
Closes #263

## Summary

- Constrain the login page outer container to `w-full max-w-sm` (384px) to match the bypass login page width
- Change `AuthView` `classNames.base` from `max-w-xl` (576px) to `w-full` so the auth card fills the constrained parent instead of overriding it

## Changes

- `app/login/page.tsx` — two Tailwind class changes: outer div gets `max-w-sm`, `AuthView.classNames.base` changes from `max-w-xl` to `w-full`

## Testing plan

- [ ] Visit `/login`; confirm the auth card and footer links (Privacy/Terms, dev bypass) are constrained to ~384px
- [ ] Compare `/login` and `/login/bypass` side by side — card widths should be visually identical
- [ ] Resize to a narrow mobile viewport (~375px); confirm the card is full-width with no horizontal overflow or clipping
- [ ] Visit `/login?redirectTo=/positions/abc/apply` (apply context); confirm the OTP/email inputs render cleanly at the narrower width without truncation
- [ ] Confirm no layout change on wide viewports — content remains centered

## Automated checks

- prettier: clean
- eslint: clean
- tsc: clean

## Notes

CSS-only change. No data, server actions, or new states affected.
