### PR TITLE
#262 Animate User Menu Chevron To Point Down When Open

### DIFF
--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -66,7 +66,7 @@ export function UserMenu({
   const triggerClassName =
     variant === 'header'
       ? 'group flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors bg-transparent hover:bg-muted'
-      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors';
+      : 'group flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground';
 
   function handleLogout() {
     startTransition(async () => {

--- a/components/layouts/user-menu.tsx
+++ b/components/layouts/user-menu.tsx
@@ -65,8 +65,8 @@ export function UserMenu({
 
   const triggerClassName =
     variant === 'header'
-      ? 'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors bg-transparent hover:bg-muted'
-      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors';
+      ? 'group flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors bg-transparent hover:bg-muted'
+      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors';
 
   function handleLogout() {
     startTransition(async () => {
@@ -97,7 +97,7 @@ export function UserMenu({
             <p className="text-muted-foreground text-xs">{roleLabel}</p>
           </div>
           <ChevronUp
-            className="text-muted-foreground size-4 shrink-0"
+            className="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-data-[state=open]:rotate-180"
             aria-hidden
           />
         </button>


### PR DESCRIPTION
Closes #262

## Summary

- Add `group` class to the `UserMenu` trigger `<button>` (both `sidebar` and `header` variants) so children can respond to the Radix `data-state` attribute
- Add `transition-transform duration-200 group-data-[state=open]:rotate-180` to the `ChevronUp` icon so it rotates 180° when the menu opens and reverses on close

## Changes

- `components/layouts/user-menu.tsx` — pure-CSS chevron animation driven by the Radix `data-state="open"` attribute; no JS state or new dependencies added

## Testing plan

- [ ] Open the user menu from the sidebar (`variant="sidebar"`) — chevron rotates to point down on open, back to up on close
- [ ] Repeat in the mobile nav drawer and any header usage (`variant="header"`) — same behavior in both variants
- [ ] Confirm the rotation animates smoothly (200ms, not an instant snap)
- [ ] Open with keyboard (Enter/Space on the trigger) — chevron animates the same as with a click
- [ ] Close with Escape — chevron rotates back to pointing up
- [ ] Verify no regression on existing focus ring, hover color transition, or `aria-label` on the trigger

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

`transition-transform` is scoped to the `transform` property only, so it does not conflict with the trigger button's existing `transition-colors`. The chevron is `aria-hidden`; open/closed state is already conveyed to screen readers via Radix's `aria-expanded` on the trigger.
