### PR TITLE
#284 Add LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,14 @@
+# License
+
+Copyright (c) 2026 Northeastern University Student Government Association
+
+All rights reserved.
+
+This software and its source code are proprietary and confidential. No part
+of this software may be used, copied, reproduced, modified, merged, published,
+distributed, sublicensed, or sold in any form or by any means without the
+prior written permission of the copyright holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.


### PR DESCRIPTION
Closes #284

## Summary

- Adds `LICENSE.md` to the repository root declaring a proprietary, all-rights-reserved license
- Copyright holder: Northeastern University Student Government Association, 2026
- No code, schema, UI, or runtime behavior changes — repo-hygiene / legal-metadata only

## Changes

- **`LICENSE.md`** (new file, repo root) — proprietary all-rights-reserved notice with the exact required copyright line and a no-use/copy/modify/distribute-without-written-permission clause

## Testing plan

- [ ] Confirm `LICENSE.md` exists at the repository root (sibling of `package.json`)
- [ ] Confirm the file contains the exact line `Copyright (c) 2026 Northeastern University Student Government Association`
- [ ] Confirm the all-rights-reserved clause is present (no use/copy/modification/distribution without written permission)
- [ ] Run `npm run prettier:check` — should pass with no formatting drift

## Automated checks

- `npm run prettier:check` — passed
- `npm run eslint:check` — passed
- `npm run tsc:check` — passed

## Notes

Adding an SPDX `license` field to `package.json` (e.g. `UNLICENSED`) is out of scope per the plan decision — the package is already `"private": true` and the field is not load-bearing for a private repo. Noted as a possible follow-up.
