### PR TITLE
#282 Show Page Name In Browser Tab Title

### DIFF
--- a/app/(main)/(auth)/applications/[id]/page.tsx
+++ b/app/(main)/(auth)/applications/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { getApplicationForReview } from '@/prisma/data/applications';
@@ -19,6 +20,16 @@ import {
 
 interface ApplicationDetailPageProps {
   params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ApplicationDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const user = await getCurrentUser();
+  const application = await getApplicationForReview(id, user);
+  if (!application) return {};
+  return { title: application.user.name ?? application.user.email };
 }
 
 export default async function ApplicationDetailPage({

--- a/app/(main)/(auth)/applications/page.tsx
+++ b/app/(main)/(auth)/applications/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 
 import {
@@ -19,6 +20,8 @@ import type {
 
 import { ApplicationsTable } from '@/components/features/applications-table';
 import { ApplicationsToolbar } from '@/components/features/applications-toolbar';
+
+export const metadata: Metadata = { title: 'Applications' };
 
 interface ApplicationsPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/app/(main)/(auth)/global-questions/page.tsx
+++ b/app/(main)/(auth)/global-questions/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 
 import { getGlobalQuestions } from '@/prisma/data/global-questions';
@@ -8,6 +9,8 @@ import { GlobalQuestionDialog } from '@/components/features/global-question-dial
 import { GlobalQuestionsTable } from '@/components/features/global-questions-table';
 import { PageHeader } from '@/components/layouts/page-header';
 import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = { title: 'Global Questions' };
 
 export default async function GlobalQuestionsPage() {
   const user = await getCurrentUser();

--- a/app/(main)/(auth)/my-applications/page.tsx
+++ b/app/(main)/(auth)/my-applications/page.tsx
@@ -1,9 +1,13 @@
+import type { Metadata } from 'next';
+
 import { getMyApplications } from '@/prisma/data/applications';
 
 import { getCurrentUser } from '@/lib/auth/server';
 
 import { MyApplicationsTable } from '@/components/features/my-applications-table';
 import { PageHeader } from '@/components/layouts/page-header';
+
+export const metadata: Metadata = { title: 'My Applications' };
 
 export default async function MyApplicationsPage() {
   const user = await getCurrentUser();

--- a/app/(main)/(auth)/positions/[id]/apply/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/apply/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
@@ -12,6 +13,17 @@ import { ApplicationStepper } from '@/components/features/application-stepper';
 import { PageHeader } from '@/components/layouts/page-header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const position = await getPositionForApply(id);
+  if (!position) return {};
+  return { title: `Apply: ${position.title}` };
+}
 
 export default async function ApplyPage({
   params,

--- a/app/(main)/(auth)/positions/[id]/apply/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/apply/page.tsx
@@ -14,22 +14,20 @@ import { PageHeader } from '@/components/layouts/page-header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
+interface ApplyPageProps {
+  params: Promise<{ id: string }>;
+}
+
 export async function generateMetadata({
   params,
-}: {
-  params: Promise<{ id: string }>;
-}): Promise<Metadata> {
+}: ApplyPageProps): Promise<Metadata> {
   const { id } = await params;
   const position = await getPositionForApply(id);
   if (!position) return {};
   return { title: `Apply: ${position.title}` };
 }
 
-export default async function ApplyPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+export default async function ApplyPage({ params }: ApplyPageProps) {
   const { id } = await params;
   const user = await getCurrentUser();
   if (!user) redirect('/sign-in');

--- a/app/(main)/(auth)/positions/[id]/edit/page.tsx
+++ b/app/(main)/(auth)/positions/[id]/edit/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 
 import { getPositionForEdit } from '@/prisma/data/positions';
@@ -12,6 +13,15 @@ import { PageHeader } from '@/components/layouts/page-header';
 
 interface EditPositionPageProps {
   params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: EditPositionPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const position = await getPositionForEdit(id);
+  if (!position) return {};
+  return { title: `Edit: ${position.title}` };
 }
 
 export default async function EditPositionPage({

--- a/app/(main)/(auth)/users/page.tsx
+++ b/app/(main)/(auth)/users/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 
 import { getUsersForAdmin } from '@/prisma/data/users';
@@ -6,6 +7,8 @@ import { getCurrentUser } from '@/lib/auth/server';
 
 import { UsersTable } from '@/components/features/users-table';
 import { PageHeader } from '@/components/layouts/page-header';
+
+export const metadata: Metadata = { title: 'Users' };
 
 export default async function UsersPage() {
   const user = await getCurrentUser();

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 import { Briefcase } from 'lucide-react';
 
 import { getPositionApplicationStats } from '@/prisma/data/applications';
@@ -14,6 +16,8 @@ import type { PositionApplicationStats } from '@/lib/types';
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
 import { EmptyState } from '@/components/ui/empty-state';
+
+export const metadata: Metadata = { title: 'Positions' };
 
 export default async function PositionsPage() {
   const user = await getOptionalUser();

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,9 +1,13 @@
+import type { Metadata } from 'next';
+
 import { getProfileData } from '@/prisma/data/profile';
 
 import { getCurrentUser } from '@/lib/auth/server';
 
 import { ProfileForm } from '@/components/features/profile-form';
 import { PageHeader } from '@/components/layouts/page-header';
+
+export const metadata: Metadata = { title: 'Profile' };
 
 export default async function ProfilePage() {
   const user = await getCurrentUser();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import './globals.css';
 const inter = Inter({ variable: '--font-sans', subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: { default: 'Aplio', template: 'Aplio - %s' },
+  title: { default: 'Aplio', template: 'Aplio • %s' },
   description: 'A student government application management system.',
   icons: [
     // Light-mode favicon: white/light background logo

--- a/app/login/bypass/page.tsx
+++ b/app/login/bypass/page.tsx
@@ -1,8 +1,11 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { loginAsBypassUser } from '@/prisma/services/dev-bypass';
 
 import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = { title: 'Dev Login' };
 
 export default function BypassLoginPage() {
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
@@ -5,6 +6,8 @@ import { AuthView } from '@neondatabase/auth/react/ui';
 
 import { getOptionalUser } from '@/lib/auth/server';
 import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
+
+export const metadata: Metadata = { title: 'Sign In' };
 
 // Constrain redirectTo to a same-origin relative path — accept only values
 // starting with a single "/" and not "//" to prevent open-redirect attacks.


### PR DESCRIPTION
Closes #282

## Summary

- Changed the root `metadata.title.template` separator from `-` to the bullet `•` (U+2022)
- Added `metadata` exports to every static page that was missing one (positions, applications, my-applications, users, global-questions, profile, login, dev-login)
- Added `generateMetadata` functions to three dynamic `[id]` pages (application detail, position apply, position edit) so each tab shows a record-specific title
- Left the dashboard page untouched — it correctly falls back to the bare `Aplio` default

## Changes

- `app/layout.tsx` — change template separator from `-` to `•`
- `app/(main)/positions/page.tsx` — add `metadata.title = 'Positions'`
- `app/(main)/(auth)/applications/page.tsx` — add `metadata.title = 'Applications'`
- `app/(main)/(auth)/my-applications/page.tsx` — add `metadata.title = 'My Applications'`
- `app/(main)/(auth)/users/page.tsx` — add `metadata.title = 'Users'`
- `app/(main)/(auth)/global-questions/page.tsx` — add `metadata.title = 'Global Questions'`
- `app/(main)/profile/page.tsx` — add `metadata.title = 'Profile'`
- `app/login/page.tsx` — add `metadata.title = 'Sign In'`
- `app/login/bypass/page.tsx` — add `metadata.title = 'Dev Login'`
- `app/(main)/(auth)/applications/[id]/page.tsx` — add `generateMetadata` returning applicant name; falls back to `{}` when not found
- `app/(main)/(auth)/positions/[id]/apply/page.tsx` — add `generateMetadata` returning `Apply: <title>`; falls back to `{}` when not found
- `app/(main)/(auth)/positions/[id]/edit/page.tsx` — add `generateMetadata` returning `Edit: <title>`; falls back to `{}` when not found

## Testing plan

- [ ] Run `npm run dev` and open each route, confirming browser tab text:
  - [ ] `/` (dashboard) → exactly `Aplio` (no suffix, no separator)
  - [ ] `/positions` → `Aplio • Positions`
  - [ ] `/applications` (as admin/manager) → `Aplio • Applications`
  - [ ] `/my-applications` → `Aplio • My Applications`
  - [ ] `/users` (as admin) → `Aplio • Users`
  - [ ] `/global-questions` (as admin) → `Aplio • Global Questions`
  - [ ] `/profile` → `Aplio • Profile`
  - [ ] `/login` → `Aplio • Sign In`
  - [ ] `/login/bypass` → `Aplio • Dev Login`
  - [ ] `/positions/<id>` (public detail) → `Aplio • <Position Title>`
  - [ ] `/positions/<id>/apply` → `Aplio • Apply: <Position Title>`
  - [ ] `/positions/<id>/edit` (as admin/manager) → `Aplio • Edit: <Position Title>`
  - [ ] `/applications/<id>` (as admin/manager) → `Aplio • <Applicant Name>`
- [ ] Verify the separator renders as `•` (bullet), not a hyphen or pipe
- [ ] Navigate to a non-existent `/positions/<bad-id>` → tab falls back to `Aplio` (default), page shows not-found
- [ ] Navigate to a non-existent `/applications/<bad-id>` → tab falls back to `Aplio` (default), page shows not-found

## Automated checks

- prettier: pass
- eslint: pass
- tsc: pass

## Notes

The bullet character `•` is U+2022 written literally in `app/layout.tsx`; it is distinct from a hyphen-minus or pipe. The dynamic `generateMetadata` functions reuse the same data-fetch calls the page already makes — Next.js/React request deduplication collapses identical fetches within a single request, so there is no extra DB cost.
