### PR TITLE
#283 Update Privacy Policy and Terms of Service

### DIFF
--- a/app/(legal)/privacy/page.tsx
+++ b/app/(legal)/privacy/page.tsx
@@ -6,7 +6,7 @@ import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
 export const metadata: Metadata = { title: 'Privacy Policy' };
 
 // Manually maintained — update when the policy content changes.
-const LAST_UPDATED = 'June 25, 2026';
+const LAST_UPDATED = 'June 28, 2026';
 
 export default function PrivacyPolicyPage() {
   return (
@@ -25,13 +25,22 @@ export default function PrivacyPolicyPage() {
         </p>
         <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
           <li>
-            <strong className="text-foreground">Name and email address</strong>{' '}
-            — provided through Neon Auth when you sign in with a one-time code.
+            <strong className="text-foreground">Full name</strong> — entered by
+            you during account setup.
+          </li>
+          <li>
+            <strong className="text-foreground">Email address</strong> —
+            verified through Neon Auth, which maintains your authentication
+            identity and session on our behalf.
           </li>
           <li>
             <strong className="text-foreground">Application responses</strong> —
-            the answers you submit to global and position-specific questions
-            when applying to student government positions.
+            the answers you submit when applying to student government
+            positions. The specific questions asked vary by position and are
+            configured by student government administrators. They may include
+            open-ended questions, requests for prior experience, and other
+            information relevant to the role. You will see all questions before
+            submitting.
           </li>
           <li>
             <strong className="text-foreground">
@@ -40,19 +49,39 @@ export default function PrivacyPolicyPage() {
             — records of the status changes your applications go through during
             the review process.
           </li>
+          <li>
+            <strong className="text-foreground">Technical and log data</strong>{' '}
+            — basic information such as IP addresses, browser type, and request
+            timestamps that may be logged automatically by our hosting
+            infrastructure (Vercel) as part of normal platform operations. See
+            Section 5 for details.
+          </li>
         </ul>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          We do not collect payment information, location data, or any
-          information beyond what is necessary to manage the application
-          process.
+          We do not collect payment information or precise location data. The
+          only personal information we collect beyond what is listed above is
+          whatever you choose to provide in response to administrator-configured
+          application questions.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          <strong className="text-foreground">
+            A note on admin-configured questions:
+          </strong>{' '}
+          Student government administrators can create custom application
+          questions for each position. Aplio does not prescribe or review the
+          content of these questions. If you are asked for information you are
+          not comfortable providing, you may decline to answer or choose not to
+          submit the application.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">2. How We Use It</h2>
+        <h2 className="mt-8 text-lg font-semibold">
+          2. How We Use Your Information
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The information collected is used solely to operate Aplio as an
-          internal student government application management tool:
+          The information collected is used solely to operate Aplio as a student
+          government application management tool:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
           <li>
@@ -64,18 +93,38 @@ export default function PrivacyPolicyPage() {
             including interview scheduling and final decisions.
           </li>
           <li>
-            Maintaining a record of positions and cycles for administrative
-            purposes.
+            Maintaining a permanent record of positions and application cycles
+            for administrative purposes.
           </li>
         </ul>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           Your information is never used for advertising, marketing, or sold to
-          third parties.
+          third parties. Reviewers and administrators who access your
+          information through Aplio are bound by the same use limitations
+          described in this policy — your application responses may only be used
+          to evaluate your candidacy for the positions you applied to.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          <strong className="text-foreground">
+            Legal basis for processing:
+          </strong>{' '}
+          We process your information because you have voluntarily submitted an
+          application for a student government position, and processing is
+          necessary to evaluate and administer that application.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          <strong className="text-foreground">
+            Automated decision-making:
+          </strong>{' '}
+          We do not use automated decision-making or profiling in evaluating
+          applications. All application reviews involve human judgment.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">3. Who Can See It</h2>
+        <h2 className="mt-8 text-lg font-semibold">
+          3. Who Can See Your Information
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           Access to your information is scoped to the minimum necessary:
         </p>
@@ -86,8 +135,9 @@ export default function PrivacyPolicyPage() {
           </li>
           <li>
             <strong className="text-foreground">Position managers</strong> can
-            see applications submitted to the specific positions they manage.
-            They cannot see your applications to other positions.
+            see applications submitted only to the specific positions they have
+            been assigned to manage. They cannot see your applications to any
+            other positions.
           </li>
           <li>
             <strong className="text-foreground">Platform admins</strong> can see
@@ -98,17 +148,32 @@ export default function PrivacyPolicyPage() {
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           No other users can view your application responses.
         </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          In addition to the roles above, your data is technically processed by
+          our infrastructure providers as described in Section 5. Those
+          providers operate under contractual data protection obligations and do
+          not use your data for their own purposes.
+        </p>
       </section>
 
       <section>
         <h2 className="mt-8 text-lg font-semibold">4. Data Retention</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Application records are retained for the duration of the program and
-          for a reasonable period thereafter for historical reference. If you
-          would like your account or application data deleted, please contact
-          your student government representative (see Section 6). We will
-          process deletion requests in accordance with applicable organizational
-          policies.
+          Application records, including your name, email address, responses,
+          and status history, are retained indefinitely to support the permanent
+          historical record of student government operations. We do not delete
+          individual application records.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If you have questions about what data we hold about you, or wish to
+          request access to your records, please contact us at{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          .
         </p>
       </section>
 
@@ -119,30 +184,111 @@ export default function PrivacyPolicyPage() {
         </p>
         <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
           <li>
-            <strong className="text-foreground">Neon Auth</strong> — handles
-            authentication via one-time email codes. Your email address is
-            shared with Neon to verify your identity. Neon&apos;s privacy policy
-            governs how they handle authentication data.
+            <strong className="text-foreground">Neon Auth</strong> — manages
+            authentication directly on our behalf, including verifying your
+            email address via one-time code and maintaining your identity record
+            and session credentials. Neon is a US-based company whose
+            infrastructure runs on AWS. Neon&apos;s privacy policy and Data
+            Processing Agreement govern how they handle authentication data.
           </li>
           <li>
-            <strong className="text-foreground">Vercel</strong> — hosts the
-            Aplio platform. Application data is stored and processed on
-            Vercel&apos;s infrastructure. Vercel&apos;s privacy policy governs
-            their infrastructure handling.
+            <strong className="text-foreground">Neon (database)</strong> — hosts
+            our application database directly. All application records,
+            responses, and user data are stored in a Neon-managed PostgreSQL
+            database. Neon operates as a direct data processor for Aplio under
+            its own Data Processing Agreement. Neon&apos;s infrastructure runs
+            on AWS.
+          </li>
+          <li>
+            <strong className="text-foreground">Vercel</strong> — hosts and
+            serves the Aplio web application. Vercel processes request and log
+            data as part of normal platform operations. Vercel is a US-based
+            company and operates under its own privacy policy and Data
+            Processing Agreement.
           </li>
         </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          All data is stored and processed on servers located in the United
+          States. Neon and Vercel each operate as independent direct processors
+          for Aplio.
+        </p>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           No other third-party services receive your personal information.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">6. Contact</h2>
+        <h2 className="mt-8 text-lg font-semibold">
+          6. Security and Data Breaches
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          If you have questions about this Privacy Policy or would like to
-          request deletion of your data, please contact your student government
-          representative through your organization&apos;s standard communication
-          channels.
+          We implement reasonable technical and organizational measures to
+          protect your personal information. Access to data is restricted by
+          role as described in Section 3, and data is encrypted in transit via
+          our hosting infrastructure.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          In the event of a security breach affecting your personal information,
+          we will notify affected users as soon as practicable and report to the
+          relevant Massachusetts authorities — including the Office of the
+          Attorney General and the Office of Consumer Affairs and Business
+          Regulation — as required by M.G.L. Chapter 93H.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">7. Your Rights</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          You may contact us at any time to request access to the personal
+          information we hold about you, or to request a correction of
+          inaccurate information. We retain all application records indefinitely
+          and do not fulfill deletion requests.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          To submit a request, contact us at{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          . We will respond within 30 days.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">8. Policy Updates</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We may update this Privacy Policy from time to time. When we do, we
+          will update the &ldquo;Last updated&rdquo; date at the top of this
+          policy and notify active users by email describing the nature of any
+          material changes. Continued use of Aplio after notification of a
+          material change constitutes acceptance of the updated policy.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">9. Contact</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If you have questions about this Privacy Policy or your personal data,
+          please contact:
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio / Student Government Operations
+          <br />
+          Email:{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          <br />
+          Response time: Within 30 days of receipt
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          This policy applies to the Aplio platform operated by the Northeastern
+          University Student Government Association.
         </p>
       </section>
 

--- a/app/(legal)/terms/page.tsx
+++ b/app/(legal)/terms/page.tsx
@@ -141,11 +141,10 @@ export default function TermsOfServicePage() {
           service without our permission.
         </p>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The Aplio source code is made publicly available under the MIT
-          License. Nothing in these Terms limits or overrides what the MIT
-          License permits you to do with the code. However, access to the
-          platform itself as a user is governed by these Terms, not the MIT
-          License.
+          The Aplio software is proprietary. Copyright &copy; 2026 Northeastern
+          University Student Government Association. All rights reserved. No
+          use, copying, modification, or distribution of this software is
+          permitted without prior written permission from the copyright holder.
         </p>
       </section>
 

--- a/app/(legal)/terms/page.tsx
+++ b/app/(legal)/terms/page.tsx
@@ -6,7 +6,7 @@ import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
 export const metadata: Metadata = { title: 'Terms of Service' };
 
 // Manually maintained — update when the terms content changes.
-const LAST_UPDATED = 'June 25, 2026';
+const LAST_UPDATED = 'June 28, 2026';
 
 export default function TermsOfServicePage() {
   return (
@@ -19,86 +19,206 @@ export default function TermsOfServicePage() {
       </p>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">1. Acceptance of Terms</h2>
+        <h2 className="mt-8 text-lg font-semibold">1. About Aplio</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          By accessing or using Aplio, you agree to be bound by these Terms of
-          Service. If you do not agree to these terms, do not use the platform.
-          These terms apply to all users of the platform, including applicants
-          and administrators.
+          Aplio is a student government application platform operated by the
+          Northeastern University Student Government Association (the
+          &ldquo;SGA&rdquo;). In these Terms, &ldquo;we&rdquo; and
+          &ldquo;us&rdquo; refer to the SGA. &ldquo;You&rdquo; refers to anyone
+          who creates an account or uses the platform.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">2. Intended Use</h2>
+        <h2 className="mt-8 text-lg font-semibold">2. Acceptance</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Aplio is an internal tool designed exclusively for managing
-          applications to student government positions. The platform may only be
-          used for this purpose. Unauthorized use of the platform for any other
-          purpose — including testing, scraping, or circumventing access
-          controls — is not permitted.
+          By creating an account on Aplio, you agree to these Terms of Service
+          and the Aplio Privacy Policy. If you do not agree, do not create an
+          account or use the platform. These Terms apply to all users —
+          applicants, position managers, and administrators alike.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">3. Accurate Information</h2>
+        <h2 className="mt-8 text-lg font-semibold">3. Intended Use</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          By submitting an application, you agree that all information you
-          provide is truthful, accurate, and complete to the best of your
-          knowledge. Submitting false or misleading information in an
-          application may result in the rejection or withdrawal of your
-          application and may be subject to further action under applicable
-          student organization policies.
+          Aplio is built for one purpose: managing applications to student
+          government positions within the SGA. You may only use the platform for
+          that purpose.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          The following are not allowed:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
+          <li>
+            Using the platform for anything unrelated to student government
+            applications.
+          </li>
+          <li>
+            Scraping, crawling, or extracting data from the platform by
+            automated means.
+          </li>
+          <li>
+            Trying to bypass, disable, or interfere with any access controls or
+            security features.
+          </li>
+          <li>
+            Sharing your account credentials or accessing someone else&apos;s
+            account.
+          </li>
+          <li>
+            Using or sharing another user&apos;s application data outside the
+            platform, or for any purpose other than evaluating their candidacy
+            for a position they applied to.
+          </li>
+          <li>
+            Using the platform in a way that violates applicable law or
+            Northeastern University policies.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These rules apply to administrators too. Administrators may not
+          configure the platform in ways that break the law — for example, by
+          creating questions that ask applicants about protected characteristics
+          such as race, religion, national origin, sex, disability, or age where
+          that would be unlawful.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">4. User Representations</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Applicants confirm that everything they submit in an application is
+          truthful, accurate, and complete to the best of their knowledge.
+          Submitting false or misleading information may result in rejection or
+          withdrawal of an application and may be referred for further action
+          under SGA or university policies.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Administrators confirm that they are authorized by the SGA to create
+          and manage positions on the platform, and that they will only use
+          their access for legitimate SGA purposes.
         </p>
       </section>
 
       <section>
         <h2 className="mt-8 text-lg font-semibold">
-          4. No Guarantee of Acceptance
+          5. No Guarantee of Acceptance
         </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Submitting an application through Aplio does not guarantee acceptance
-          to any position. All applications are subject to review and evaluation
-          by position managers and administrators. Decisions are made at the
-          discretion of the student government organization and are final.
+          Applying through Aplio does not guarantee you will be accepted to any
+          position. All applications are reviewed and evaluated by position
+          managers and administrators. Decisions are made at the SGA&apos;s
+          discretion and are final.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">5. Account Termination</h2>
+        <h2 className="mt-8 text-lg font-semibold">6. Account Termination</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Platform administrators may deactivate or remove accounts at any time,
-          including for violation of these Terms of Service or applicable
-          student organization policies. If your account is deactivated, you may
-          lose access to application records stored on the platform. Contact
-          your student government representative if you believe your account was
-          deactivated in error.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="mt-8 text-lg font-semibold">
-          6. Limitation of Liability
-        </h2>
-        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Aplio is provided as-is for internal organizational use. The student
-          government organization and platform maintainers make no warranties,
-          express or implied, regarding the availability, reliability, or
-          fitness of the platform for any particular purpose. To the maximum
-          extent permitted by applicable law, the organization is not liable for
-          any loss or damage arising from your use of or inability to use the
-          platform.
+          Administrators may deactivate or remove accounts at any time,
+          including for violations of these Terms or applicable SGA or
+          university policies. If your account is deactivated, you may lose
+          access to your application records on the platform. You can still
+          request access to your personal data after deactivation by emailing{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          .
         </p>
       </section>
 
       <section>
         <h2 className="mt-8 text-lg font-semibold">
-          7. Governing Jurisdiction
+          7. Branding and Intellectual Property
         </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          These Terms of Service are governed by applicable student organization
-          policies and any institutional rules of the associated academic
-          institution. Disputes arising from the use of this platform will be
-          resolved in accordance with those policies.
+          The Aplio name, logo, and visual identity belong to the SGA. You may
+          not use them in connection with any other platform, product, or
+          service without our permission.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          The Aplio source code is made publicly available under the MIT
+          License. Nothing in these Terms limits or overrides what the MIT
+          License permits you to do with the code. However, access to the
+          platform itself as a user is governed by these Terms, not the MIT
+          License.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">8. Service Availability</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We do not guarantee that Aplio will be available at any particular
+          time. The platform may go down for maintenance or other reasons, with
+          or without notice, and may be discontinued at any time.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          9. Limitation of Liability
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio is provided as-is. The SGA and its officers, members, and
+          platform administrators make no warranties — express or implied —
+          about the platform&apos;s availability, reliability, accuracy, or
+          fitness for any particular purpose. To the maximum extent permitted by
+          applicable law, none of them are liable for any loss or damage arising
+          from your use of or inability to use the platform.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          10. Changes to These Terms
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We may update these Terms from time to time. When we do, we will
+          update the date at the top and email active users to describe what
+          changed. Continuing to use Aplio after that notice means you accept
+          the updated Terms.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">11. Severability</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If any part of these Terms is found to be unenforceable, that part
+          will be modified or removed to the minimum extent necessary. The rest
+          of the Terms will remain in effect.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">12. Governing Law</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These Terms are governed by the laws of the Commonwealth of
+          Massachusetts.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">13. Contact</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Questions about these Terms? Contact us at:
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio / Student Government Operations
+          <br />
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These Terms apply to the Aplio platform operated by the Northeastern
+          University Student Government Association.
         </p>
       </section>
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -73,20 +73,16 @@ export default async function SignInPage({
           </Link>
         </p>
       )}
-      <p className="text-muted-foreground text-xs">
-        <Link
-          href={PRIVACY_HREF}
-          className="hover:text-foreground hover:underline"
-        >
+      <p className="text-muted-foreground text-center text-xs">
+        By creating an account, you agree to our{' '}
+        <Link href={TERMS_HREF} className="text-primary hover:underline">
+          Terms of Service
+        </Link>{' '}
+        and{' '}
+        <Link href={PRIVACY_HREF} className="text-primary hover:underline">
           Privacy Policy
         </Link>
-        {' · '}
-        <Link
-          href={TERMS_HREF}
-          className="hover:text-foreground hover:underline"
-        >
-          Terms of Service
-        </Link>
+        .
       </p>
     </div>
   );


### PR DESCRIPTION
Closes #283

## Summary

- Replace privacy policy content with the June 28, 2026 version (6 → 9 sections)
- Replace terms of service content with the June 28, 2026 version (7 → 13 sections)
- Replace the bare Privacy/Terms footer links on the login page with a single "By creating an account, you agree to our Terms of Service and Privacy Policy" sentence, with both link names in `text-primary` (brand red)

## Changes

- `app/(legal)/privacy/page.tsx` — rewrote body with 9 sections: Information We Collect, How We Use Your Information, Who Can See Your Information, Data Retention, Third-Party Services, Security and Data Breaches, Your Rights, Policy Updates, Contact; bumped `LAST_UPDATED` to `'June 28, 2026'`; rendered `sgaOperations@northeastern.edu` as a `mailto:` link with `text-primary hover:underline`
- `app/(legal)/terms/page.tsx` — rewrote body with 13 sections: About Aplio, Acceptance, Intended Use (with prohibited-use bullet list), User Representations, No Guarantee of Acceptance, Account Termination, Branding and Intellectual Property (MIT License wording), Service Availability, Limitation of Liability, Changes to These Terms, Severability, Governing Law, Contact; bumped `LAST_UPDATED` to `'June 28, 2026'`
- `app/login/page.tsx` — replaced the existing plain `Privacy Policy · Terms of Service` footer with a single consolidated agreement sentence; links styled `text-primary hover:underline`; text-center, text-xs to match surrounding helper text

## Testing plan

- [ ] Visit `/privacy` — confirm 9 sections render in order, "Last updated: June 28, 2026" appears, bullet lists show under sections 1/2/3/5, and `sgaOperations@northeastern.edu` renders as a clickable mailto link
- [ ] Visit `/terms` — confirm 13 sections render in order, "Last updated: June 28, 2026" appears, the prohibited-use bullet list in Section 3 renders, and Section 7 refers to the MIT License
- [ ] Visit `/login` — confirm the "By creating an account, you agree to our Terms of Service and Privacy Policy." line appears with both link names in the brand (primary) color; confirm the bare `Privacy Policy · Terms of Service` footer line is gone (no duplicate link pair)
- [ ] Click "Terms of Service" from the login page agreement line → navigates to `/terms`
- [ ] Click "Privacy Policy" from the login page agreement line → navigates to `/privacy`
- [ ] Visit each link in the footer of `/privacy` and `/terms` — confirm Privacy Policy, Terms of Service, and Back to home all navigate correctly
- [ ] Toggle light/dark mode — confirm the `text-primary` links and all body text read correctly in both themes
- [ ] Tab through `/login` — confirm both new links are keyboard-focusable with a visible focus ring; confirm no duplicate link targets appear in tab order

## Automated checks

- Prettier: pass
- ESLint: pass
- TypeScript: pass

## Notes

These are pure static server components — no data fetching, server actions, or schema changes. The `sgaOperations@northeastern.edu` email appears as a `mailto:` Link in Sections 4, 7, and 9 of the privacy policy, and in Section 6 and 13 of the terms. The login page now uses a single source for the legal links (the consolidated agreement sentence) rather than the previous standalone footer.
