### PR TITLE
Release v1.2.1

### DIFF
--- a/.claude/docs/nextjs-notes.md
+++ b/.claude/docs/nextjs-notes.md
@@ -16,6 +16,22 @@ What that means in practice:
 
 **If you ever enable Cache Components** (`cacheComponents: true`), the rules change substantially (PPR default, `use cache`/`cacheLife`/`cacheTag`, `updateTag`, "Uncached data accessed outside `<Suspense>`" build errors, `connection()` before non-deterministic ops). Read https://nextjs.org/docs/app/getting-started/caching first — and that is a deliberate architectural change, not a casual edit.
 
+## Proxy (formerly Middleware) — v16.0.0 breaking change
+
+`middleware.ts` is **deprecated** in Next.js 16. The file convention is now `proxy.ts` and the exported function must be named `proxy` (not `middleware`):
+
+```ts
+// proxy.ts — at the project root (or src/)
+export function proxy(request: NextRequest) { ... }
+export const config = { matcher: [...] }
+```
+
+- Rename `middleware.ts` → `proxy.ts`
+- Rename `export function middleware` → `export function proxy`
+- Type is `NextProxy` (not `NextMiddleware`)
+- Official codemod: `npx @next/codemod@canary middleware-to-proxy .`
+- `NextRequest`, `NextResponse`, `config.matcher` are all unchanged
+
 ## Stable rules (true regardless of caching model)
 
 - **Server vs Client Components** — server by default; `'use client'` only for interactivity/hooks/browser APIs, on the smallest leaf. Prisma/secrets never reach a client component. Ref: https://nextjs.org/docs/app/getting-started/server-and-client-components

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,14 @@
+# License
+
+Copyright (c) 2026 Northeastern University Student Government Association
+
+All rights reserved.
+
+This software and its source code are proprietary and confidential. No part
+of this software may be used, copied, reproduced, modified, merged, published,
+distributed, sublicensed, or sold in any form or by any means without the
+prior written permission of the copyright holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.

--- a/app/(legal)/privacy/page.tsx
+++ b/app/(legal)/privacy/page.tsx
@@ -6,7 +6,7 @@ import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
 export const metadata: Metadata = { title: 'Privacy Policy' };
 
 // Manually maintained — update when the policy content changes.
-const LAST_UPDATED = 'June 25, 2026';
+const LAST_UPDATED = 'June 28, 2026';
 
 export default function PrivacyPolicyPage() {
   return (
@@ -25,13 +25,22 @@ export default function PrivacyPolicyPage() {
         </p>
         <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
           <li>
-            <strong className="text-foreground">Name and email address</strong>{' '}
-            — provided through Neon Auth when you sign in with a one-time code.
+            <strong className="text-foreground">Full name</strong> — entered by
+            you during account setup.
+          </li>
+          <li>
+            <strong className="text-foreground">Email address</strong> —
+            verified through Neon Auth, which maintains your authentication
+            identity and session on our behalf.
           </li>
           <li>
             <strong className="text-foreground">Application responses</strong> —
-            the answers you submit to global and position-specific questions
-            when applying to student government positions.
+            the answers you submit when applying to student government
+            positions. The specific questions asked vary by position and are
+            configured by student government administrators. They may include
+            open-ended questions, requests for prior experience, and other
+            information relevant to the role. You will see all questions before
+            submitting.
           </li>
           <li>
             <strong className="text-foreground">
@@ -40,19 +49,39 @@ export default function PrivacyPolicyPage() {
             — records of the status changes your applications go through during
             the review process.
           </li>
+          <li>
+            <strong className="text-foreground">Technical and log data</strong>{' '}
+            — basic information such as IP addresses, browser type, and request
+            timestamps that may be logged automatically by our hosting
+            infrastructure (Vercel) as part of normal platform operations. See
+            Section 5 for details.
+          </li>
         </ul>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          We do not collect payment information, location data, or any
-          information beyond what is necessary to manage the application
-          process.
+          We do not collect payment information or precise location data. The
+          only personal information we collect beyond what is listed above is
+          whatever you choose to provide in response to administrator-configured
+          application questions.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          <strong className="text-foreground">
+            A note on admin-configured questions:
+          </strong>{' '}
+          Student government administrators can create custom application
+          questions for each position. Aplio does not prescribe or review the
+          content of these questions. If you are asked for information you are
+          not comfortable providing, you may decline to answer or choose not to
+          submit the application.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">2. How We Use It</h2>
+        <h2 className="mt-8 text-lg font-semibold">
+          2. How We Use Your Information
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The information collected is used solely to operate Aplio as an
-          internal student government application management tool:
+          The information collected is used solely to operate Aplio as a student
+          government application management tool:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
           <li>
@@ -64,18 +93,38 @@ export default function PrivacyPolicyPage() {
             including interview scheduling and final decisions.
           </li>
           <li>
-            Maintaining a record of positions and cycles for administrative
-            purposes.
+            Maintaining a permanent record of positions and application cycles
+            for administrative purposes.
           </li>
         </ul>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           Your information is never used for advertising, marketing, or sold to
-          third parties.
+          third parties. Reviewers and administrators who access your
+          information through Aplio are bound by the same use limitations
+          described in this policy — your application responses may only be used
+          to evaluate your candidacy for the positions you applied to.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          <strong className="text-foreground">
+            Legal basis for processing:
+          </strong>{' '}
+          We process your information because you have voluntarily submitted an
+          application for a student government position, and processing is
+          necessary to evaluate and administer that application.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          <strong className="text-foreground">
+            Automated decision-making:
+          </strong>{' '}
+          We do not use automated decision-making or profiling in evaluating
+          applications. All application reviews involve human judgment.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">3. Who Can See It</h2>
+        <h2 className="mt-8 text-lg font-semibold">
+          3. Who Can See Your Information
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           Access to your information is scoped to the minimum necessary:
         </p>
@@ -86,8 +135,9 @@ export default function PrivacyPolicyPage() {
           </li>
           <li>
             <strong className="text-foreground">Position managers</strong> can
-            see applications submitted to the specific positions they manage.
-            They cannot see your applications to other positions.
+            see applications submitted only to the specific positions they have
+            been assigned to manage. They cannot see your applications to any
+            other positions.
           </li>
           <li>
             <strong className="text-foreground">Platform admins</strong> can see
@@ -98,17 +148,32 @@ export default function PrivacyPolicyPage() {
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           No other users can view your application responses.
         </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          In addition to the roles above, your data is technically processed by
+          our infrastructure providers as described in Section 5. Those
+          providers operate under contractual data protection obligations and do
+          not use your data for their own purposes.
+        </p>
       </section>
 
       <section>
         <h2 className="mt-8 text-lg font-semibold">4. Data Retention</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Application records are retained for the duration of the program and
-          for a reasonable period thereafter for historical reference. If you
-          would like your account or application data deleted, please contact
-          your student government representative (see Section 6). We will
-          process deletion requests in accordance with applicable organizational
-          policies.
+          Application records, including your name, email address, responses,
+          and status history, are retained indefinitely to support the permanent
+          historical record of student government operations. We do not delete
+          individual application records.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If you have questions about what data we hold about you, or wish to
+          request access to your records, please contact us at{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          .
         </p>
       </section>
 
@@ -119,30 +184,111 @@ export default function PrivacyPolicyPage() {
         </p>
         <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
           <li>
-            <strong className="text-foreground">Neon Auth</strong> — handles
-            authentication via one-time email codes. Your email address is
-            shared with Neon to verify your identity. Neon&apos;s privacy policy
-            governs how they handle authentication data.
+            <strong className="text-foreground">Neon Auth</strong> — manages
+            authentication directly on our behalf, including verifying your
+            email address via one-time code and maintaining your identity record
+            and session credentials. Neon is a US-based company whose
+            infrastructure runs on AWS. Neon&apos;s privacy policy and Data
+            Processing Agreement govern how they handle authentication data.
           </li>
           <li>
-            <strong className="text-foreground">Vercel</strong> — hosts the
-            Aplio platform. Application data is stored and processed on
-            Vercel&apos;s infrastructure. Vercel&apos;s privacy policy governs
-            their infrastructure handling.
+            <strong className="text-foreground">Neon (database)</strong> — hosts
+            our application database directly. All application records,
+            responses, and user data are stored in a Neon-managed PostgreSQL
+            database. Neon operates as a direct data processor for Aplio under
+            its own Data Processing Agreement. Neon&apos;s infrastructure runs
+            on AWS.
+          </li>
+          <li>
+            <strong className="text-foreground">Vercel</strong> — hosts and
+            serves the Aplio web application. Vercel processes request and log
+            data as part of normal platform operations. Vercel is a US-based
+            company and operates under its own privacy policy and Data
+            Processing Agreement.
           </li>
         </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          All data is stored and processed on servers located in the United
+          States. Neon and Vercel each operate as independent direct processors
+          for Aplio.
+        </p>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           No other third-party services receive your personal information.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">6. Contact</h2>
+        <h2 className="mt-8 text-lg font-semibold">
+          6. Security and Data Breaches
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          If you have questions about this Privacy Policy or would like to
-          request deletion of your data, please contact your student government
-          representative through your organization&apos;s standard communication
-          channels.
+          We implement reasonable technical and organizational measures to
+          protect your personal information. Access to data is restricted by
+          role as described in Section 3, and data is encrypted in transit via
+          our hosting infrastructure.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          In the event of a security breach affecting your personal information,
+          we will notify affected users as soon as practicable and report to the
+          relevant Massachusetts authorities — including the Office of the
+          Attorney General and the Office of Consumer Affairs and Business
+          Regulation — as required by M.G.L. Chapter 93H.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">7. Your Rights</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          You may contact us at any time to request access to the personal
+          information we hold about you, or to request a correction of
+          inaccurate information. We retain all application records indefinitely
+          and do not fulfill deletion requests.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          To submit a request, contact us at{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          . We will respond within 30 days.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">8. Policy Updates</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We may update this Privacy Policy from time to time. When we do, we
+          will update the &ldquo;Last updated&rdquo; date at the top of this
+          policy and notify active users by email describing the nature of any
+          material changes. Continued use of Aplio after notification of a
+          material change constitutes acceptance of the updated policy.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">9. Contact</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If you have questions about this Privacy Policy or your personal data,
+          please contact:
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio / Student Government Operations
+          <br />
+          Email:{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          <br />
+          Response time: Within 30 days of receipt
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          This policy applies to the Aplio platform operated by the Northeastern
+          University Student Government Association.
         </p>
       </section>
 

--- a/app/(legal)/terms/page.tsx
+++ b/app/(legal)/terms/page.tsx
@@ -141,11 +141,10 @@ export default function TermsOfServicePage() {
           service without our permission.
         </p>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The Aplio source code is made publicly available under the MIT
-          License. Nothing in these Terms limits or overrides what the MIT
-          License permits you to do with the code. However, access to the
-          platform itself as a user is governed by these Terms, not the MIT
-          License.
+          The Aplio software is proprietary. Copyright &copy; 2026 Northeastern
+          University Student Government Association. All rights reserved. No
+          use, copying, modification, or distribution of this software is
+          permitted without prior written permission from the copyright holder.
         </p>
       </section>
 

--- a/app/(legal)/terms/page.tsx
+++ b/app/(legal)/terms/page.tsx
@@ -6,7 +6,7 @@ import { PRIVACY_HREF, TERMS_HREF } from '@/lib/constants';
 export const metadata: Metadata = { title: 'Terms of Service' };
 
 // Manually maintained — update when the terms content changes.
-const LAST_UPDATED = 'June 25, 2026';
+const LAST_UPDATED = 'June 28, 2026';
 
 export default function TermsOfServicePage() {
   return (
@@ -19,86 +19,206 @@ export default function TermsOfServicePage() {
       </p>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">1. Acceptance of Terms</h2>
+        <h2 className="mt-8 text-lg font-semibold">1. About Aplio</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          By accessing or using Aplio, you agree to be bound by these Terms of
-          Service. If you do not agree to these terms, do not use the platform.
-          These terms apply to all users of the platform, including applicants
-          and administrators.
+          Aplio is a student government application platform operated by the
+          Northeastern University Student Government Association (the
+          &ldquo;SGA&rdquo;). In these Terms, &ldquo;we&rdquo; and
+          &ldquo;us&rdquo; refer to the SGA. &ldquo;You&rdquo; refers to anyone
+          who creates an account or uses the platform.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">2. Intended Use</h2>
+        <h2 className="mt-8 text-lg font-semibold">2. Acceptance</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Aplio is an internal tool designed exclusively for managing
-          applications to student government positions. The platform may only be
-          used for this purpose. Unauthorized use of the platform for any other
-          purpose — including testing, scraping, or circumventing access
-          controls — is not permitted.
+          By creating an account on Aplio, you agree to these Terms of Service
+          and the Aplio Privacy Policy. If you do not agree, do not create an
+          account or use the platform. These Terms apply to all users —
+          applicants, position managers, and administrators alike.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">3. Accurate Information</h2>
+        <h2 className="mt-8 text-lg font-semibold">3. Intended Use</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          By submitting an application, you agree that all information you
-          provide is truthful, accurate, and complete to the best of your
-          knowledge. Submitting false or misleading information in an
-          application may result in the rejection or withdrawal of your
-          application and may be subject to further action under applicable
-          student organization policies.
+          Aplio is built for one purpose: managing applications to student
+          government positions within the SGA. You may only use the platform for
+          that purpose.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          The following are not allowed:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc pl-6 text-sm leading-relaxed">
+          <li>
+            Using the platform for anything unrelated to student government
+            applications.
+          </li>
+          <li>
+            Scraping, crawling, or extracting data from the platform by
+            automated means.
+          </li>
+          <li>
+            Trying to bypass, disable, or interfere with any access controls or
+            security features.
+          </li>
+          <li>
+            Sharing your account credentials or accessing someone else&apos;s
+            account.
+          </li>
+          <li>
+            Using or sharing another user&apos;s application data outside the
+            platform, or for any purpose other than evaluating their candidacy
+            for a position they applied to.
+          </li>
+          <li>
+            Using the platform in a way that violates applicable law or
+            Northeastern University policies.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These rules apply to administrators too. Administrators may not
+          configure the platform in ways that break the law — for example, by
+          creating questions that ask applicants about protected characteristics
+          such as race, religion, national origin, sex, disability, or age where
+          that would be unlawful.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">4. User Representations</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Applicants confirm that everything they submit in an application is
+          truthful, accurate, and complete to the best of their knowledge.
+          Submitting false or misleading information may result in rejection or
+          withdrawal of an application and may be referred for further action
+          under SGA or university policies.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Administrators confirm that they are authorized by the SGA to create
+          and manage positions on the platform, and that they will only use
+          their access for legitimate SGA purposes.
         </p>
       </section>
 
       <section>
         <h2 className="mt-8 text-lg font-semibold">
-          4. No Guarantee of Acceptance
+          5. No Guarantee of Acceptance
         </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Submitting an application through Aplio does not guarantee acceptance
-          to any position. All applications are subject to review and evaluation
-          by position managers and administrators. Decisions are made at the
-          discretion of the student government organization and are final.
+          Applying through Aplio does not guarantee you will be accepted to any
+          position. All applications are reviewed and evaluated by position
+          managers and administrators. Decisions are made at the SGA&apos;s
+          discretion and are final.
         </p>
       </section>
 
       <section>
-        <h2 className="mt-8 text-lg font-semibold">5. Account Termination</h2>
+        <h2 className="mt-8 text-lg font-semibold">6. Account Termination</h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Platform administrators may deactivate or remove accounts at any time,
-          including for violation of these Terms of Service or applicable
-          student organization policies. If your account is deactivated, you may
-          lose access to application records stored on the platform. Contact
-          your student government representative if you believe your account was
-          deactivated in error.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="mt-8 text-lg font-semibold">
-          6. Limitation of Liability
-        </h2>
-        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Aplio is provided as-is for internal organizational use. The student
-          government organization and platform maintainers make no warranties,
-          express or implied, regarding the availability, reliability, or
-          fitness of the platform for any particular purpose. To the maximum
-          extent permitted by applicable law, the organization is not liable for
-          any loss or damage arising from your use of or inability to use the
-          platform.
+          Administrators may deactivate or remove accounts at any time,
+          including for violations of these Terms or applicable SGA or
+          university policies. If your account is deactivated, you may lose
+          access to your application records on the platform. You can still
+          request access to your personal data after deactivation by emailing{' '}
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+          .
         </p>
       </section>
 
       <section>
         <h2 className="mt-8 text-lg font-semibold">
-          7. Governing Jurisdiction
+          7. Branding and Intellectual Property
         </h2>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          These Terms of Service are governed by applicable student organization
-          policies and any institutional rules of the associated academic
-          institution. Disputes arising from the use of this platform will be
-          resolved in accordance with those policies.
+          The Aplio name, logo, and visual identity belong to the SGA. You may
+          not use them in connection with any other platform, product, or
+          service without our permission.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          The Aplio source code is made publicly available under the MIT
+          License. Nothing in these Terms limits or overrides what the MIT
+          License permits you to do with the code. However, access to the
+          platform itself as a user is governed by these Terms, not the MIT
+          License.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">8. Service Availability</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We do not guarantee that Aplio will be available at any particular
+          time. The platform may go down for maintenance or other reasons, with
+          or without notice, and may be discontinued at any time.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          9. Limitation of Liability
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio is provided as-is. The SGA and its officers, members, and
+          platform administrators make no warranties — express or implied —
+          about the platform&apos;s availability, reliability, accuracy, or
+          fitness for any particular purpose. To the maximum extent permitted by
+          applicable law, none of them are liable for any loss or damage arising
+          from your use of or inability to use the platform.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">
+          10. Changes to These Terms
+        </h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          We may update these Terms from time to time. When we do, we will
+          update the date at the top and email active users to describe what
+          changed. Continuing to use Aplio after that notice means you accept
+          the updated Terms.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">11. Severability</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          If any part of these Terms is found to be unenforceable, that part
+          will be modified or removed to the minimum extent necessary. The rest
+          of the Terms will remain in effect.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">12. Governing Law</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These Terms are governed by the laws of the Commonwealth of
+          Massachusetts.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mt-8 text-lg font-semibold">13. Contact</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Questions about these Terms? Contact us at:
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Aplio / Student Government Operations
+          <br />
+          <Link
+            href="mailto:sgaOperations@northeastern.edu"
+            className="text-primary hover:underline"
+          >
+            sgaOperations@northeastern.edu
+          </Link>
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          These Terms apply to the Aplio platform operated by the Northeastern
+          University Student Government Association.
         </p>
       </section>
 

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -18,9 +18,13 @@ export default async function PositionsPage() {
   const user = await getOptionalUser();
   const isAdmin = user?.isAdmin ?? false;
 
-  // Admin branch: unchanged layout — flat list with create action.
+  // Admin branch: flat list with create action and application stats on every card.
   if (isAdmin) {
     const positions = await getAdminPositions();
+    const adminStatsByPosition =
+      positions.length > 0
+        ? await getPositionApplicationStats(positions.map((p) => p.id))
+        : new Map<string, import('@/lib/types').PositionApplicationStats>();
     return (
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
@@ -42,6 +46,7 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={true}
                 isAuthenticated={true}
+                applicationStats={adminStatsByPosition.get(position.id)}
               />
             ))}
           </div>
@@ -122,6 +127,11 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={managedIds.has(position.id)}
                 isAuthenticated={isAuthenticated}
+                applicationStats={
+                  managedIds.has(position.id)
+                    ? statsByPosition.get(position.id)
+                    : undefined
+                }
               />
             ))}
           </div>
@@ -144,6 +154,11 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={managedIds.has(position.id)}
                 isAuthenticated={isAuthenticated}
+                applicationStats={
+                  managedIds.has(position.id)
+                    ? statsByPosition.get(position.id)
+                    : undefined
+                }
               />
             ))}
           </div>

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/prisma/data/positions';
 
 import { getOptionalUser } from '@/lib/auth/server';
+import type { PositionApplicationStats } from '@/lib/types';
 
 import { PositionCard } from '@/components/features/position-card';
 import { PositionCreateDialog } from '@/components/features/position-create-dialog';
@@ -24,7 +25,7 @@ export default async function PositionsPage() {
     const adminStatsByPosition =
       positions.length > 0
         ? await getPositionApplicationStats(positions.map((p) => p.id))
-        : new Map<string, import('@/lib/types').PositionApplicationStats>();
+        : new Map<string, PositionApplicationStats>();
     return (
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
@@ -72,7 +73,7 @@ export default async function PositionsPage() {
   const statsByPosition =
     managedIds.size > 0
       ? await getPositionApplicationStats([...managedIds])
-      : new Map<string, import('@/lib/types').PositionApplicationStats>();
+      : new Map<string, PositionApplicationStats>();
 
   // Show "Positions I Manage" only when the user actually manages at least one
   // relevant position — non-managers get an empty array, so the section is omitted.

--- a/app/(main)/positions/page.tsx
+++ b/app/(main)/positions/page.tsx
@@ -1,5 +1,6 @@
 import { Briefcase } from 'lucide-react';
 
+import { getPositionApplicationStats } from '@/prisma/data/applications';
 import {
   getAdminPositions,
   getManagedPositions,
@@ -61,6 +62,13 @@ export default async function PositionsPage() {
   // Build a set of managed IDs so canManage can be derived in O(1) per card.
   const managedIds = new Set(managedPositions.map((p) => p.id));
 
+  // Fetch application stats for managed positions — stats are cross-user aggregates
+  // safe to show to managers (see getPositionApplicationStats() for the invariant).
+  const statsByPosition =
+    managedIds.size > 0
+      ? await getPositionApplicationStats([...managedIds])
+      : new Map<string, import('@/lib/types').PositionApplicationStats>();
+
   // Show "Positions I Manage" only when the user actually manages at least one
   // relevant position — non-managers get an empty array, so the section is omitted.
   const showManagedSection = managedPositions.length > 0;
@@ -85,6 +93,7 @@ export default async function PositionsPage() {
                 position={position}
                 canManage={true}
                 isAuthenticated={isAuthenticated}
+                applicationStats={statsByPosition.get(position.id)}
               />
             ))}
           </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -73,20 +73,16 @@ export default async function SignInPage({
           </Link>
         </p>
       )}
-      <p className="text-muted-foreground text-xs">
-        <Link
-          href={PRIVACY_HREF}
-          className="hover:text-foreground hover:underline"
-        >
+      <p className="text-muted-foreground text-center text-xs">
+        By creating an account, you agree to our{' '}
+        <Link href={TERMS_HREF} className="text-primary hover:underline">
+          Terms of Service
+        </Link>{' '}
+        and{' '}
+        <Link href={PRIVACY_HREF} className="text-primary hover:underline">
           Privacy Policy
         </Link>
-        {' · '}
-        <Link
-          href={TERMS_HREF}
-          className="hover:text-foreground hover:underline"
-        >
-          Terms of Service
-        </Link>
+        .
       </p>
     </div>
   );

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -111,27 +111,38 @@ export function PositionCard({
 
   return (
     <Card className="flex flex-col gap-0 p-0">
-      <CardHeader className="p-4 pb-2">
+      {/* Two-column layout: when applicationStats is present the outer div becomes a
+          flex row at sm+, with CardHeader + CardContent in the left column and the
+          stat cluster in a right column that reaches the card's top edge.
+          One-column view (no applicationStats): wrapper and column divs add no classes,
+          card renders exactly as before. */}
+      <div className={cn(applicationStats && 'sm:flex sm:flex-row')}>
+        {/* Left column — header + content stacked; grows to fill available width */}
         <div
           className={cn(
-            'flex items-center gap-2',
-            !applicationStats && 'justify-between',
+            applicationStats && 'sm:flex sm:min-w-0 sm:flex-1 sm:flex-col',
           )}
         >
-          <CardTitle className="text-lg leading-snug">
-            {position.title}
-          </CardTitle>
-          <PositionStatusBadge position={position} />
-        </div>
-      </CardHeader>
+          <CardHeader className="p-4 pb-2">
+            <div
+              className={cn(
+                'flex items-center gap-2',
+                !applicationStats && 'justify-between',
+              )}
+            >
+              <CardTitle className="text-lg leading-snug">
+                {position.title}
+              </CardTitle>
+              <PositionStatusBadge position={position} />
+            </div>
+          </CardHeader>
 
-      <CardContent className="px-4 pb-4">
-        {/* Two-column layout: left column grows and holds description + buttons pinned
-            to the bottom; right column is the stat cluster anchored to the top.
-            When applicationStats is absent the left column takes full width naturally. */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
-          {/* Left column — description, date label, then buttons pushed to the bottom */}
-          <div className="flex min-w-0 flex-1 flex-col">
+          <CardContent
+            className={cn(
+              'px-4 pb-4',
+              applicationStats && 'sm:flex sm:flex-1 sm:flex-col',
+            )}
+          >
             <p className="text-muted-foreground line-clamp-2 text-sm">
               {position.description}
             </p>
@@ -182,17 +193,17 @@ export function PositionCard({
                 </>
               )}
             </div>
-          </div>
-
-          {/* Right column — stat cluster anchored to the top-right of the card;
-              self-start keeps it at the natural top regardless of left-column height */}
-          {canManage && applicationStats && (
-            <div className="self-start">
-              <PositionStatCluster stats={applicationStats} />
-            </div>
-          )}
+          </CardContent>
         </div>
-      </CardContent>
+
+        {/* Right column — stat cluster top-aligned beside the full left column;
+            hidden on mobile so stats only appear in the wide two-column layout */}
+        {applicationStats && (
+          <div className="hidden sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
+            <PositionStatCluster stats={applicationStats} />
+          </div>
+        )}
+      </div>
     </Card>
   );
 }

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -88,7 +88,7 @@ function PositionStatCluster({ stats }: PositionStatClusterProps) {
 
 // Server component — flat summary card with always-visible truncated description
 // and a CTA row linking into the detail page. Managed cards (canManage=true) also
-// show a right-anchored application stats cluster on the same row as the buttons.
+// show a top-right-anchored application stats cluster when applicationStats is passed.
 export function PositionCard({
   position,
   canManage = false,
@@ -112,8 +112,7 @@ export function PositionCard({
   return (
     <Card className="flex flex-col gap-0 p-0">
       <CardHeader className="p-4 pb-2">
-        {/* Title row: status badge sits inline to the right of the title */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-start justify-between gap-2">
           <CardTitle className="text-lg leading-snug">
             {position.title}
           </CardTitle>
@@ -121,65 +120,71 @@ export function PositionCard({
         </div>
       </CardHeader>
 
-      <CardContent className="flex flex-col gap-3 px-4 pb-4">
-        {/* Description + date — unchanged, no stat cluster here */}
-        <div className="min-w-0">
-          <p className="text-muted-foreground line-clamp-2 text-sm">
-            {position.description}
-          </p>
-          {dateLabel && (
-            <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
-          )}
-        </div>
-
-        {/* Bottom row: action buttons on the left, stat cluster on the far right */}
-        <div className="flex items-center justify-between gap-4 pt-1">
-          <div className="flex flex-wrap items-center gap-2">
-            {canManage ? (
-              <>
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/positions/${position.id}`}>View Details</Link>
-                </Button>
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/positions/${position.id}/edit`}>
-                    <Pencil className="size-4" />
-                    Edit
-                  </Link>
-                </Button>
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/applications?positionId=${position.id}`}>
-                    <Inbox className="size-4" />
-                    Applications
-                  </Link>
-                </Button>
-              </>
-            ) : (
-              <>
-                {isAccepting && (
-                  <Button asChild size="sm">
-                    {isAuthenticated ? (
-                      <Link href={`/positions/${position.id}/apply`}>
-                        Apply
-                      </Link>
-                    ) : (
-                      <Link
-                        href={`/login?redirectTo=/positions/${position.id}/apply`}
-                      >
-                        Apply
-                      </Link>
-                    )}
-                  </Button>
-                )}
-                <Button asChild variant="outline" size="sm">
-                  <Link href={`/positions/${position.id}`}>View Details</Link>
-                </Button>
-              </>
+      <CardContent className="px-4 pb-4">
+        {/* Two-column layout: left column grows and holds description + buttons pinned
+            to the bottom; right column is the stat cluster anchored to the top.
+            When applicationStats is absent the left column takes full width naturally. */}
+        <div className="flex flex-row items-stretch gap-4">
+          {/* Left column — description, date label, then buttons pushed to the bottom */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <p className="text-muted-foreground line-clamp-2 text-sm">
+              {position.description}
+            </p>
+            {dateLabel && (
+              <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
             )}
+
+            {/* mt-auto ensures buttons always sit at the bottom of the left column */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-3">
+              {canManage ? (
+                <>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/positions/${position.id}`}>View Details</Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/positions/${position.id}/edit`}>
+                      <Pencil className="size-4" />
+                      Edit
+                    </Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/applications?positionId=${position.id}`}>
+                      <Inbox className="size-4" />
+                      Applications
+                    </Link>
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {isAccepting && (
+                    <Button asChild size="sm">
+                      {isAuthenticated ? (
+                        <Link href={`/positions/${position.id}/apply`}>
+                          Apply
+                        </Link>
+                      ) : (
+                        <Link
+                          href={`/login?redirectTo=/positions/${position.id}/apply`}
+                        >
+                          Apply
+                        </Link>
+                      )}
+                    </Button>
+                  )}
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/positions/${position.id}`}>View Details</Link>
+                  </Button>
+                </>
+              )}
+            </div>
           </div>
 
-          {/* Stat cluster — far right of bottom row, beside buttons (managed only) */}
+          {/* Right column — stat cluster anchored to the top-right of the card;
+              self-start keeps it at the natural top regardless of left-column height */}
           {canManage && applicationStats && (
-            <PositionStatCluster stats={applicationStats} />
+            <div className="self-start">
+              <PositionStatCluster stats={applicationStats} />
+            </div>
           )}
         </div>
       </CardContent>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -2,7 +2,16 @@ import Link from 'next/link';
 
 import { Inbox, Pencil } from 'lucide-react';
 
-import type { PositionWithQuestions } from '@/lib/types';
+import {
+  APPLICATION_STATUS_BADGE_VARIANT,
+  APPLICATION_STATUS_LABELS,
+  POSITION_CARD_STAT_STATUSES,
+  STATUS_BADGE_VARIANT_TO_DOT,
+} from '@/lib/constants';
+import type {
+  PositionApplicationStats,
+  PositionWithQuestions,
+} from '@/lib/types';
 import { formatDate, getPositionAvailability } from '@/lib/utils';
 
 import { PositionStatusBadge } from '@/components/features/status-badge';
@@ -13,14 +22,78 @@ interface PositionCardProps {
   position: PositionWithQuestions;
   canManage?: boolean;
   isAuthenticated?: boolean;
+  applicationStats?: PositionApplicationStats;
 }
 
-// Server component — accordion removed; flat summary card with always-visible
-// truncated description and a CTA row linking into the detail page.
+interface PositionStatClusterProps {
+  stats: PositionApplicationStats;
+}
+
+// Co-located server sub-component — compact count+label tiles for managed position cards.
+// Renders a "Total" lead tile and a 2x2 grid of the four key pipeline statuses.
+// Zero-count tiles are dimmed rather than hidden so the cluster shape is stable.
+function PositionStatCluster({ stats }: PositionStatClusterProps) {
+  return (
+    <div aria-label="Application stats" className="shrink-0">
+      {/* Total tile — col-span-2 lead row with hairline divider below */}
+      <div className="border-border mb-2 border-b pb-2">
+        <div className="flex items-center gap-1.5">
+          <span
+            className="bg-primary size-2 shrink-0 rounded-full"
+            aria-hidden="true"
+          />
+          <p className="text-muted-foreground text-[11px] leading-tight">
+            Total
+          </p>
+        </div>
+        <p className="mt-1 text-xl leading-none font-semibold tabular-nums">
+          {stats.total}
+        </p>
+      </div>
+
+      {/* 2x2 grid of key pipeline statuses */}
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+        {POSITION_CARD_STAT_STATUSES.map((status) => {
+          const count = stats.counts[status] ?? 0;
+          const isDimmed = count === 0;
+          const variant = APPLICATION_STATUS_BADGE_VARIANT[status];
+          const dotClass =
+            STATUS_BADGE_VARIANT_TO_DOT[variant] ?? 'bg-muted-foreground';
+
+          return (
+            <div key={status}>
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={`size-1.5 shrink-0 rounded-full ${dotClass} ${isDimmed ? 'opacity-40' : ''}`}
+                  aria-hidden="true"
+                />
+                <p
+                  className={`text-[11px] leading-tight ${isDimmed ? 'text-muted-foreground/60' : 'text-muted-foreground'}`}
+                >
+                  {APPLICATION_STATUS_LABELS[status]}
+                </p>
+              </div>
+              <p
+                className={`mt-0.5 text-xl leading-none font-semibold tabular-nums ${isDimmed ? 'text-muted-foreground/60' : ''}`}
+              >
+                {count}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Server component — flat summary card with always-visible truncated description
+// and a CTA row linking into the detail page. Managed cards (canManage=true) also
+// show a right-anchored application stats cluster when applicationStats is passed.
 export function PositionCard({
   position,
   canManage = false,
   isAuthenticated = false,
+  applicationStats,
 }: PositionCardProps) {
   const availability = getPositionAvailability(position);
   const isAccepting = availability === 'accepting';
@@ -48,13 +121,22 @@ export function PositionCard({
       </CardHeader>
 
       <CardContent className="flex flex-col gap-3 px-4 pb-4">
-        <p className="text-muted-foreground line-clamp-2 text-sm">
-          {position.description}
-        </p>
+        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row">
+          {/* Left: description + date — takes remaining width, truncates */}
+          <div className="min-w-0 flex-1">
+            <p className="text-muted-foreground line-clamp-2 text-sm">
+              {position.description}
+            </p>
+            {dateLabel && (
+              <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
+            )}
+          </div>
 
-        {dateLabel && (
-          <p className="text-muted-foreground text-xs">{dateLabel}</p>
-        )}
+          {/* Right: stats cluster — only for managed cards */}
+          {canManage && applicationStats && (
+            <PositionStatCluster stats={applicationStats} />
+          )}
+        </div>
 
         <div className="flex flex-wrap items-center gap-2 pt-1">
           {canManage ? (

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -196,10 +196,10 @@ export function PositionCard({
           </CardContent>
         </div>
 
-        {/* Right column — stat cluster top-aligned beside the full left column;
-            hidden on mobile so stats only appear in the wide two-column layout */}
+        {/* Right column — stat cluster; stacks below left column on mobile,
+            sits beside it at sm+ in a two-column layout */}
         {applicationStats && (
-          <div className="hidden sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
+          <div className="sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
             <PositionStatCluster stats={applicationStats} />
           </div>
         )}

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -88,7 +88,7 @@ function PositionStatCluster({ stats }: PositionStatClusterProps) {
 
 // Server component — flat summary card with always-visible truncated description
 // and a CTA row linking into the detail page. Managed cards (canManage=true) also
-// show a right-anchored application stats cluster when applicationStats is passed.
+// show a right-anchored application stats cluster on the same row as the buttons.
 export function PositionCard({
   position,
   canManage = false,
@@ -112,7 +112,8 @@ export function PositionCard({
   return (
     <Card className="flex flex-col gap-0 p-0">
       <CardHeader className="p-4 pb-2">
-        <div className="flex items-start justify-between gap-2">
+        {/* Title row: status badge sits inline to the right of the title */}
+        <div className="flex items-center gap-2">
           <CardTitle className="text-lg leading-snug">
             {position.title}
           </CardTitle>
@@ -121,61 +122,64 @@ export function PositionCard({
       </CardHeader>
 
       <CardContent className="flex flex-col gap-3 px-4 pb-4">
-        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row">
-          {/* Left: description + date — takes remaining width, truncates */}
-          <div className="min-w-0 flex-1">
-            <p className="text-muted-foreground line-clamp-2 text-sm">
-              {position.description}
-            </p>
-            {dateLabel && (
-              <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
-            )}
-          </div>
-
-          {/* Right: stats cluster — only for managed cards */}
-          {canManage && applicationStats && (
-            <PositionStatCluster stats={applicationStats} />
+        {/* Description + date — unchanged, no stat cluster here */}
+        <div className="min-w-0">
+          <p className="text-muted-foreground line-clamp-2 text-sm">
+            {position.description}
+          </p>
+          {dateLabel && (
+            <p className="text-muted-foreground mt-1 text-xs">{dateLabel}</p>
           )}
         </div>
 
-        <div className="flex flex-wrap items-center gap-2 pt-1">
-          {canManage ? (
-            <>
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/positions/${position.id}`}>View Details</Link>
-              </Button>
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/positions/${position.id}/edit`}>
-                  <Pencil className="size-4" />
-                  Edit
-                </Link>
-              </Button>
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/applications?positionId=${position.id}`}>
-                  <Inbox className="size-4" />
-                  Applications
-                </Link>
-              </Button>
-            </>
-          ) : (
-            <>
-              {isAccepting && (
-                <Button asChild size="sm">
-                  {isAuthenticated ? (
-                    <Link href={`/positions/${position.id}/apply`}>Apply</Link>
-                  ) : (
-                    <Link
-                      href={`/login?redirectTo=/positions/${position.id}/apply`}
-                    >
-                      Apply
-                    </Link>
-                  )}
+        {/* Bottom row: action buttons on the left, stat cluster on the far right */}
+        <div className="flex items-center justify-between gap-4 pt-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {canManage ? (
+              <>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/positions/${position.id}`}>View Details</Link>
                 </Button>
-              )}
-              <Button asChild variant="outline" size="sm">
-                <Link href={`/positions/${position.id}`}>View Details</Link>
-              </Button>
-            </>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/positions/${position.id}/edit`}>
+                    <Pencil className="size-4" />
+                    Edit
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/applications?positionId=${position.id}`}>
+                    <Inbox className="size-4" />
+                    Applications
+                  </Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                {isAccepting && (
+                  <Button asChild size="sm">
+                    {isAuthenticated ? (
+                      <Link href={`/positions/${position.id}/apply`}>
+                        Apply
+                      </Link>
+                    ) : (
+                      <Link
+                        href={`/login?redirectTo=/positions/${position.id}/apply`}
+                      >
+                        Apply
+                      </Link>
+                    )}
+                  </Button>
+                )}
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/positions/${position.id}`}>View Details</Link>
+                </Button>
+              </>
+            )}
+          </div>
+
+          {/* Stat cluster — far right of bottom row, beside buttons (managed only) */}
+          {canManage && applicationStats && (
+            <PositionStatCluster stats={applicationStats} />
           )}
         </div>
       </CardContent>

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -199,7 +199,7 @@ export function PositionCard({
         {/* Right column — stat cluster; stacks below left column on mobile,
             sits beside it at sm+ in a two-column layout */}
         {applicationStats && (
-          <div className="sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
+          <div className="px-4 pb-4 sm:flex sm:shrink-0 sm:items-start sm:p-6 sm:pl-0">
             <PositionStatCluster stats={applicationStats} />
           </div>
         )}

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -124,7 +124,7 @@ export function PositionCard({
         {/* Two-column layout: left column grows and holds description + buttons pinned
             to the bottom; right column is the stat cluster anchored to the top.
             When applicationStats is absent the left column takes full width naturally. */}
-        <div className="flex flex-row items-stretch gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
           {/* Left column — description, date label, then buttons pushed to the bottom */}
           <div className="flex min-w-0 flex-1 flex-col">
             <p className="text-muted-foreground line-clamp-2 text-sm">

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -34,7 +34,7 @@ interface PositionStatClusterProps {
 // Zero-count tiles are dimmed rather than hidden so the cluster shape is stable.
 function PositionStatCluster({ stats }: PositionStatClusterProps) {
   return (
-    <div aria-label="Application stats" className="shrink-0">
+    <div role="region" aria-label="Application stats" className="shrink-0">
       {/* Total tile — col-span-2 lead row with hairline divider below */}
       <div className="border-border mb-2 border-b pb-2">
         <div className="flex items-center gap-1.5">

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -12,7 +12,7 @@ import type {
   PositionApplicationStats,
   PositionWithQuestions,
 } from '@/lib/types';
-import { formatDate, getPositionAvailability } from '@/lib/utils';
+import { cn, formatDate, getPositionAvailability } from '@/lib/utils';
 
 import { PositionStatusBadge } from '@/components/features/status-badge';
 import { Button } from '@/components/ui/button';
@@ -112,8 +112,13 @@ export function PositionCard({
   return (
     <Card className="flex flex-col gap-0 p-0">
       <CardHeader className="p-4 pb-2">
-        <div className="flex items-start justify-between gap-2">
-          <CardTitle className="text-lg leading-snug">
+        <div
+          className={cn(
+            'flex items-center gap-2',
+            applicationStats && 'justify-between',
+          )}
+        >
+          <CardTitle className="text-base font-semibold">
             {position.title}
           </CardTitle>
           <PositionStatusBadge position={position} />

--- a/components/features/position-card.tsx
+++ b/components/features/position-card.tsx
@@ -115,10 +115,10 @@ export function PositionCard({
         <div
           className={cn(
             'flex items-center gap-2',
-            applicationStats && 'justify-between',
+            !applicationStats && 'justify-between',
           )}
         >
-          <CardTitle className="text-base font-semibold">
+          <CardTitle className="text-lg leading-snug">
             {position.title}
           </CardTitle>
           <PositionStatusBadge position={position} />

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -203,3 +203,14 @@ export const STATUS_BADGE_VARIANT_TO_DOT: Record<string, string> = {
   default: 'bg-primary',
   outline: 'bg-border',
 };
+
+// The four application statuses surfaced on position cards for admins/managers.
+// Ordered: Applied → Interview scheduled → Accepted → Rejected.
+// Shared between PositionStatCluster and any future per-position stat consumer
+// so the displayed set is a single source of truth (ENGINEERING §1: abstract at 2+).
+export const POSITION_CARD_STAT_STATUSES = [
+  'applied',
+  'interview_scheduled',
+  'accepted',
+  'rejected',
+] as const satisfies $Enums.ApplicationStatus[];

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const WINDOW_MS = 60_000;
+
+// Per-route caps (requests per WINDOW_MS per IP).
+// Order matters for route matching: more specific patterns must come first.
+const ROUTE_LIMITS: {
+  key: string;
+  limit: number;
+  matcher: (p: string) => boolean;
+}[] = [
+  {
+    key: '/api/auth/webhook',
+    limit: 100,
+    matcher: (p) => p === '/api/auth/webhook',
+  },
+  { key: '/api/auth', limit: 20, matcher: (p) => p.startsWith('/api/auth') },
+  { key: '/login', limit: 10, matcher: (p) => p === '/login' },
+];
+
+// Module-level hit store: `${routeKey}:${ip}` → sorted array of request timestamps.
+// Reused across middleware invocations within a single worker instance.
+// Not shared across instances — see PR notes for the per-instance limitation.
+const hits = new Map<string, number[]>();
+
+// Sweep threshold: when the map grows beyond this size, evict stale buckets so
+// abandoned IPs don't accumulate memory over the lifetime of the worker.
+const SWEEP_THRESHOLD = 5_000;
+
+function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) return realIp;
+  return 'unknown';
+}
+
+function selectRoute(pathname: string): { key: string; limit: number } | null {
+  for (const route of ROUTE_LIMITS) {
+    if (route.matcher(pathname)) return { key: route.key, limit: route.limit };
+  }
+  return null;
+}
+
+function maybeSweep(now: number): void {
+  if (hits.size < SWEEP_THRESHOLD) return;
+  for (const [bucket, timestamps] of hits) {
+    const newest = timestamps.at(-1);
+    if (newest === undefined || newest < now - WINDOW_MS) hits.delete(bucket);
+  }
+}
+
+export function applyRateLimit(request: NextRequest): NextResponse | null {
+  try {
+    const { pathname } = request.nextUrl;
+    const route = selectRoute(pathname);
+    if (!route) return null;
+
+    const ip = getClientIp(request);
+    const bucket = `${route.key}:${ip}`;
+    const now = Date.now();
+
+    maybeSweep(now);
+
+    const timestamps = hits.get(bucket) ?? [];
+    // Prune entries outside the current window.
+    const windowStart = now - WINDOW_MS;
+    const recent = timestamps.filter((t) => t >= windowStart);
+
+    if (recent.length >= route.limit) {
+      // Oldest timestamp in the current window determines when a slot next frees.
+      const oldest = recent[0]!;
+      const retryAfter = Math.max(
+        1,
+        Math.ceil((oldest + WINDOW_MS - now) / 1000),
+      );
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(retryAfter),
+            'X-RateLimit-Limit': String(route.limit),
+            'X-RateLimit-Remaining': '0',
+          },
+        },
+      );
+    }
+
+    recent.push(now);
+    hits.set(bucket, recent);
+    return null;
+  } catch {
+    // Fail open: an internal error in the gate must not block legitimate traffic.
+    return null;
+  }
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-// Three-tier rate limit caps (requests per minute per IP).
+// Per-tier rate limit caps (requests per minute per IP).
+// Webhook is matched before the /api/auth prefix so it gets the higher cap.
 const LIMITS = {
-  api: { windowMs: 60_000, max: 60 },
-  public: { windowMs: 60_000, max: 30 },
+  webhook: { windowMs: 60_000, max: 100 },
+  api: { windowMs: 60_000, max: 20 },
+  public: { windowMs: 60_000, max: 10 },
   private: { windowMs: 60_000, max: 120 },
 };
 
 function getLimit(pathname: string): { windowMs: number; max: number } {
+  if (pathname === '/api/auth/webhook') return LIMITS.webhook;
   if (pathname.startsWith('/api/')) return LIMITS.api;
   if (pathname === '/login' || pathname === '/') return LIMITS.public;
   return LIMITS.private;
@@ -41,6 +44,7 @@ function getClientIp(request: NextRequest): string {
 }
 
 function tierKey(pathname: string): string {
+  if (pathname === '/api/auth/webhook') return 'webhook';
   if (pathname.startsWith('/api/')) return 'api';
   if (pathname === '/login' || pathname === '/') return 'public';
   return 'private';

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,24 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const WINDOW_MS = 60_000;
+// Three-tier rate limit caps (requests per minute per IP).
+const LIMITS = {
+  api: { windowMs: 60_000, max: 60 },
+  public: { windowMs: 60_000, max: 30 },
+  private: { windowMs: 60_000, max: 120 },
+};
 
-// Per-route caps (requests per WINDOW_MS per IP).
-// Order matters for route matching: more specific patterns must come first.
-const ROUTE_LIMITS: {
-  key: string;
-  limit: number;
-  matcher: (p: string) => boolean;
-}[] = [
-  {
-    key: '/api/auth/webhook',
-    limit: 100,
-    matcher: (p) => p === '/api/auth/webhook',
-  },
-  { key: '/api/auth', limit: 20, matcher: (p) => p.startsWith('/api/auth') },
-  { key: '/login', limit: 10, matcher: (p) => p === '/login' },
-];
+function getLimit(pathname: string): { windowMs: number; max: number } {
+  if (pathname.startsWith('/api/')) return LIMITS.api;
+  if (pathname === '/login' || pathname === '/') return LIMITS.public;
+  return LIMITS.private;
+}
 
-// Module-level hit store: `${routeKey}:${ip}` → sorted array of request timestamps.
+// Module-level hit store: `${tier}:${ip}` → sorted array of request timestamps.
 // Reused across middleware invocations within a single worker instance.
 // Not shared across instances — see PR notes for the per-instance limitation.
 const hits = new Map<string, number[]>();
@@ -45,44 +40,47 @@ function getClientIp(request: NextRequest): string {
   return 'unknown';
 }
 
-function selectRoute(pathname: string): { key: string; limit: number } | null {
-  for (const route of ROUTE_LIMITS) {
-    if (route.matcher(pathname)) return { key: route.key, limit: route.limit };
-  }
-  return null;
+function tierKey(pathname: string): string {
+  if (pathname.startsWith('/api/')) return 'api';
+  if (pathname === '/login' || pathname === '/') return 'public';
+  return 'private';
 }
+
+// Max window across all tiers — used to evict buckets that are stale for any tier.
+const MAX_WINDOW_MS = Math.max(...Object.values(LIMITS).map((l) => l.windowMs));
 
 function maybeSweep(now: number): void {
   if (hits.size < SWEEP_THRESHOLD) return;
   for (const [bucket, timestamps] of hits) {
     const newest = timestamps.at(-1);
-    if (newest === undefined || newest < now - WINDOW_MS) hits.delete(bucket);
+    if (newest === undefined || newest < now - MAX_WINDOW_MS)
+      hits.delete(bucket);
   }
 }
 
 export function applyRateLimit(request: NextRequest): NextResponse | null {
   try {
     const { pathname } = request.nextUrl;
-    const route = selectRoute(pathname);
-    if (!route) return null;
+    const tier = tierKey(pathname);
+    const limit = getLimit(pathname);
 
     const ip = getClientIp(request);
-    const bucket = `${route.key}:${ip}`;
+    const bucket = `${tier}:${ip}`;
     const now = Date.now();
 
     maybeSweep(now);
 
     const timestamps = hits.get(bucket) ?? [];
     // Prune entries outside the current window.
-    const windowStart = now - WINDOW_MS;
+    const windowStart = now - limit.windowMs;
     const recent = timestamps.filter((t) => t >= windowStart);
 
-    if (recent.length >= route.limit) {
+    if (recent.length >= limit.max) {
       // Oldest timestamp in the current window determines when a slot next frees.
       const oldest = recent[0]!;
       const retryAfter = Math.max(
         1,
-        Math.ceil((oldest + WINDOW_MS - now) / 1000),
+        Math.ceil((oldest + limit.windowMs - now) / 1000),
       );
       return NextResponse.json(
         { error: 'Too many requests' },
@@ -90,7 +88,7 @@ export function applyRateLimit(request: NextRequest): NextResponse | null {
           status: 429,
           headers: {
             'Retry-After': String(retryAfter),
-            'X-RateLimit-Limit': String(route.limit),
+            'X-RateLimit-Limit': String(limit.max),
             'X-RateLimit-Remaining': '0',
           },
         },

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -27,6 +27,13 @@ const hits = new Map<string, number[]>();
 // abandoned IPs don't accumulate memory over the lifetime of the worker.
 const SWEEP_THRESHOLD = 5_000;
 
+// NOTE — Vercel deployment prerequisite: Vercel's infrastructure overwrites
+// x-forwarded-for before it reaches the middleware, preventing spoofing.
+// On non-Vercel proxies (staging tunnels, custom reverse proxies) a client can
+// set x-forwarded-for to an arbitrary IP and bypass per-IP limiting entirely.
+// If this middleware is ever deployed behind a non-Vercel proxy, add header-
+// trust validation (e.g. only trust the rightmost IP, or use a separate trusted
+// header set by the proxy) before relying on the rate-limit for security.
 function getClientIp(request: NextRequest): string {
   const forwarded = request.headers.get('x-forwarded-for');
   if (forwarded) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,7 @@ import type {
   PositionStatus,
   QuestionType,
 } from '@/prisma/client';
-import type { Prisma } from '@/prisma/client';
+import type { $Enums, Prisma } from '@/prisma/client';
 
 import type { REVIEWER_APPLICATION_STATUSES } from '@/lib/constants';
 
@@ -229,6 +229,15 @@ export type AdminUserListItem = Prisma.UserGetPayload<{
     };
   };
 }>;
+
+// Per-position application stats for admin/manager position cards.
+// Aggregate read-only shape — never exposes individual applicant identity.
+// Must only be passed to cards for positions the caller manages.
+export type PositionApplicationStats = {
+  positionId: string;
+  counts: Partial<Record<$Enums.ApplicationStatus, number>>;
+  total: number;
+};
 
 // Identity shape passed to nav components so sidebar and mobile nav agree
 // on what to display in the user menu.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,21 @@
 import { neonAuthMiddleware } from '@neondatabase/auth/next/server';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { applyRateLimit } from '@/lib/rate-limit';
+
 // Auth redirects are owned by layouts: app/(main)/(auth)/layout.tsx redirects
 // unauthenticated visitors to /login (prod) or /login/bypass (dev) via getCurrentUser().
 // Middleware only handles the Neon OAuth callback — the token exchange must run before
 // any page renders, but only fires when the verifier param is present.
-export default function middleware(request: NextRequest) {
+export function proxy(request: NextRequest): NextResponse {
+  // Rate limiting only applies outside development: in dev there is no proxy to set
+  // x-forwarded-for/x-real-ip, so every request maps to 'unknown' and all local
+  // traffic to a capped route would share one bucket.
+  if (process.env.NODE_ENV !== 'development') {
+    const limited = applyRateLimit(request);
+    if (limited) return limited;
+  }
+
   if (request.nextUrl.searchParams.has('neon_auth_session_verifier'))
     return neonAuthMiddleware({ loginUrl: '/login' })(request);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aplio",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aplio",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@neondatabase/auth": "0.1.0-beta.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aplio",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/data/applications.ts
+++ b/prisma/data/applications.ts
@@ -9,6 +9,7 @@ import {
   type ApplicationForReview,
   type MyApplicationListItem,
   type PositionApplicationListItem,
+  type PositionApplicationStats,
 } from '@/lib/types';
 
 const applicationSelect = {
@@ -326,4 +327,44 @@ export async function getReviewablePositions(user: {
     select: { id: true, title: true },
     orderBy: { title: 'asc' },
   });
+}
+
+// Returns non-draft/non-withdrawn application counts per status for a set of
+// position IDs, keyed by positionId. Returns cross-user aggregate data —
+// must be called with caller-managed position IDs only (admin = all positions;
+// manager = their assigned positions). Never call with arbitrary IDs from the client.
+export async function getPositionApplicationStats(
+  positionIds: string[],
+): Promise<Map<string, PositionApplicationStats>> {
+  if (positionIds.length === 0) return new Map();
+
+  const rows = await prisma.application.groupBy({
+    by: ['positionId', 'status'],
+    where: {
+      positionId: { in: positionIds },
+      deletedAt: null,
+      status: { notIn: ['draft', 'withdrawn'] },
+    },
+    _count: true,
+  });
+
+  const map = new Map<string, PositionApplicationStats>();
+
+  for (const row of rows) {
+    const existing = map.get(row.positionId) ?? {
+      positionId: row.positionId,
+      counts: {} as Partial<Record<$Enums.ApplicationStatus, number>>,
+      total: 0,
+    };
+    existing.counts[row.status] = row._count;
+    existing.total += row._count;
+    map.set(row.positionId, existing);
+  }
+
+  // Ensure every requested position has an entry (zero-count positions get an empty stats object).
+  for (const id of positionIds) {
+    if (!map.has(id)) map.set(id, { positionId: id, counts: {}, total: 0 });
+  }
+
+  return map;
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,7 +7,7 @@ import { applyRateLimit } from '@/lib/rate-limit';
 // unauthenticated visitors to /login (prod) or /login/bypass (dev) via getCurrentUser().
 // Middleware only handles the Neon OAuth callback — the token exchange must run before
 // any page renders, but only fires when the verifier param is present.
-export function proxy(request: NextRequest): NextResponse {
+export async function proxy(request: NextRequest): Promise<NextResponse> {
   // Rate limiting only applies outside development: in dev there is no proxy to set
   // x-forwarded-for/x-real-ip, so every request maps to 'unknown' and all local
   // traffic to a capped route would share one bucket.


### PR DESCRIPTION
## Release v1.2.1

### Changes
- #283 Update Privacy Policy and Terms of Service
- #284 Add LICENSE.md
- #252 Show Application Stats On Position Cards For Admins And Managers
- #269 Add Rate Limiting To Middleware
- #279 Update Nextjs Notes With Proxy Convention

### Testing plan
- [ ] Sign in as an admin or manager → navigate to Positions → each position card shows an application stats column (submitted, reviewing, etc.) → stats are visible and correct
- [ ] Sign in as a regular applicant → navigate to Positions → position cards show no stats column → stats are hidden for non-admin/non-manager users
- [ ] Navigate to /terms → Terms of Service renders fully, Section 7 shows proprietary language with no MIT license text
- [ ] Navigate to /privacy → Privacy Policy renders fully with all sections intact
- [ ] Open the sign-in page, navigate to /positions, and browse the app → no unexpected 429 errors under normal usage
